### PR TITLE
Unblock Qwiklab blocked by exceeding vCPUs quota.

### DIFF
--- a/examples/cloud-composer-examples/composer_http_post_example/ephemeral_dataproc_spark_dag.py
+++ b/examples/cloud-composer-examples/composer_http_post_example/ephemeral_dataproc_spark_dag.py
@@ -90,7 +90,6 @@ with DAG('average-speed',
         # in YYYYMMDD format. See docs https://airflow.apache.org/code.html?highlight=macros#macros
         cluster_name='ephemeral-spark-cluster-{{ ds_nodash }}',
         num_workers=2,
-        num_preemptible_workers=2,
         zone=Variable.get('gce_zone')
     )
 


### PR DESCRIPTION
Decrease dataproc cluster size by removing preembitble workers in cloud composer http post example.