### PR TITLE
Three new features for the Asset Inventory tool.

### DIFF
--- a/tools/asset-inventory/MANIFEST.in
+++ b/tools/asset-inventory/MANIFEST.in
@@ -1,0 +1,1 @@
+include asset_inventory/*.json

--- a/tools/asset-inventory/asset_inventory/api_schema.py
+++ b/tools/asset-inventory/asset_inventory/api_schema.py
@@ -1,0 +1,358 @@
+#!/usr/bin/env python
+#
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+""" Generates BigQuery schema from API discovery documents.
+
+
+"""
+from asset_inventory import bigquery_schema
+import requests
+from collections import defaultdict
+from requests_futures.sessions import FuturesSession
+from google.cloud import bigquery
+
+
+# Map CAI asset types to the Google API they come from.
+# Used to download the API discovery document for each asset.
+ASSET_TYPE_PREFIX_TO_API = {
+    'google.cloud.kms': 'cloudkms',
+    'google.cloud.resourcemanager': 'cloudresourcemanager',
+    'google.compute': 'compute',
+    'google.appengine': 'appengine',
+    'google.cloud.billing': 'cloudbilling',
+    'google.cloud.storage': 'storage',
+    'google.cloud.dns': 'dns',
+    'google.spanner': 'spanner',
+    'google.cloud.bigquery': 'bigquery',
+    'google.iam': 'iam',
+    'google.pubsub': 'pubsub',
+    'google.cloud.dataproc': 'dataproc',
+    'google.cloud.sql': 'sqladmin',
+    'google.container': 'container'
+}
+
+
+class APISchemas(object):
+    """Convert a CAI asset type to a BigQuery table schema.
+
+    When the import_pipeline uses a group_by of ASSET_TYPE or ASSET_TYPE_VERSION
+    we'll use a BigQuery schema generated from API discovery documents. This
+    gives us all the type, names and description of every asset type property.
+    Will union all API versions into a single schema.
+    """
+
+    discovey_documents_map = None
+    schema_cache = {}
+
+    @classmethod
+    def _get_discovery_documents_map(cls):
+        """Download discovery documents.
+
+        Caches downloaded documents in the `discovey_documents_map` map.
+
+        Returns:
+            Dict of API names to their Discovery document.
+        """
+        if cls.discovey_documents_map:
+            return cls.discovey_documents_map
+
+        discovery_docs = requests.get(
+            'https://content.googleapis.com/discovery/v1/apis').json()
+
+        session = FuturesSession()
+        api_to_discovery_docs_requests = defaultdict(list)
+        for discovery_doc in discovery_docs['items']:
+            for api_name in ASSET_TYPE_PREFIX_TO_API.values():
+                if api_name == discovery_doc['name']:
+                    api_to_discovery_docs_requests[api_name].append(
+                        session.get(discovery_doc['discoveryRestUrl']))
+        cls.discovey_documents_map = {
+            api_name:
+                [f.result().json() for f in fl if f.result().status_code == 200]
+            for api_name, fl in api_to_discovery_docs_requests.items()
+        }
+        return cls.discovey_documents_map
+
+    @classmethod
+    def get_api_name_for_asset_type(cls, asset_type):
+        """Given an asset type, return it's api name."""
+        for prefix, api_name in ASSET_TYPE_PREFIX_TO_API.items():
+            if asset_type.startswith(prefix):
+                return api_name
+        raise Exception('no api for type name {}'.format(asset_type))
+
+    @classmethod
+    def _get_bigquery_type_for_property(cls, property_value):
+        """Map API type to a BigQuery type."""
+        bigquery_type = 'STRING'
+        property_type = property_value.get('type', None)
+        if '$ref' in property_value or property_type == 'object':
+            bigquery_type = 'RECORD'
+        elif property_type == 'array':
+            return cls._get_bigquery_type_for_property(property_value['items'])
+        if property_type in ('number', 'integer'):
+            bigquery_type = 'NUMERIC'
+        elif property_type == 'boolean':
+            bigquery_type = 'BOOL'
+        return bigquery_type
+
+    @classmethod
+    def _get_properties_map_from_value(cls, property_name, property_value,
+                                       resources, seen_resources):
+        """Return the properties of the nested type of a `RECORD` property."""
+        if 'properties' in property_value:
+            return property_value['properties']
+        property_resource_name = property_value.get('$ref', None)
+        if property_resource_name:
+            # not handling recursive fields.
+            if property_resource_name in seen_resources:
+                return None
+            seen_resources[property_resource_name] = True
+            return cls._get_properties_map_from_value(
+                property_resource_name, resources[property_resource_name],
+                resources, seen_resources)
+        if 'items' not in property_value:
+            # we can't safely process labels or additionalProperties fields so
+            # skip them
+            return None
+        return cls._get_properties_map_from_value(
+            property_name, property_value['items'], resources, seen_resources)
+
+    @classmethod
+    def _properties_map_to_field_list(cls, properties_map, resources,
+                                      seen_resources):
+        """Convert API resource properties to BigQuery schema."""
+        fields = []
+        for property_name, property_value in properties_map.items():
+            field = {'name': property_name}
+            property_type = property_value.get('type', None)
+            bigquery_type = cls._get_bigquery_type_for_property(property_value)
+            field['field_type'] = bigquery_type
+            if 'description' in property_value:
+                field['description'] = property_value['description'][:1024]
+            if property_type == 'array':
+                field['mode'] = 'REPEATED'
+            else:
+                field['mode'] = 'NULLABLE'
+            if bigquery_type == 'RECORD':
+                property_properties_map = cls._get_properties_map_from_value(
+                    property_name, property_value, resources, seen_resources)
+                if not property_properties_map:
+                    continue
+                fields_list = cls._properties_map_to_field_list(
+                    property_properties_map, resources, seen_resources)
+                if not fields_list:
+                    continue
+                field['fields'] = fields_list
+            fields.append(bigquery.SchemaField(**field))
+        return fields
+
+    @classmethod
+    def _translate_resource_to_schema(cls, resource_name, document):
+        """Expands the $ref properties of a reosurce definition."""
+        api_id = document['id']
+        resource_cache_key = api_id + resource_name
+        if resource_cache_key in cls.schema_cache:
+            return cls.schema_cache[resource_cache_key]
+        resources = document['schemas']
+        field_list = []
+        if resource_name in resources:
+            resource = resources[resource_name]
+            properties_map = resource['properties']
+            field_list = cls._properties_map_to_field_list(
+                properties_map, resources, {})
+        cls.schema_cache[resource_cache_key] = field_list
+        return field_list
+
+    @classmethod
+    def _get_field_by_name(cls, fields, field_name):
+        for i, field in enumerate(fields):
+            if field.name == field_name:
+                return i, field
+        return None, None
+
+    @classmethod
+    def _convert_to_asset_schema(cls,
+                                 schema,
+                                 include_resource=True,
+                                 include_iam_policy=True):
+        """Add the fields that the asset export adds to each resource.
+
+        Args:
+            schema: list of google.cloud.bigquery.SchemaField objects.
+            include_resource: to include resource schema.
+            include_iam_policy: to include iam policy schema.
+        Returns:
+            list of google.cloud.bigquery.SchemaField objects.
+        """
+        asset_schema = [{
+            'name': 'name',
+            'field_type': 'STRING',
+            'description': 'URL of the asset.',
+            'mode': 'REQUIRED'
+        }, {
+            'name': 'asset_type',
+            'field_type': 'STRING',
+            'description': 'Asset name.',
+            'mode': 'REQUIRED'
+        }]
+        if include_resource:
+            resource_schema = list(schema)
+            last_modified, _ = cls._get_field_by_name(resource_schema,
+                                                      'lastModifiedTime')
+            if not last_modified:
+                resource_schema.append({
+                    'name': 'lastModifiedTime',
+                    'field_type': 'STRING',
+                    'mode': 'NULLABLE',
+                    'description': 'Last time resource was changed.'
+                })
+            asset_schema.append({
+                'name': 'resource',
+                'field_type': 'RECORD',
+                'description': 'Resource properties.',
+                'fields': [{
+                    'name': 'version',
+                    'field_type': 'STRING',
+                    'description': 'Api version of resource.',
+                    'mode': 'REQUIRED'
+                }, {
+                    'name': 'discovery_document_uri',
+                    'field_type': 'STRING',
+                    'description': 'Discovery document uri.',
+                    'mode': 'REQUIRED'
+                }, {
+                    'name': 'parent',
+                    'field_type': 'STRING',
+                    'description': 'Parent resource.',
+                    'mode': 'NULLABLE'
+                }, {
+                    'name': 'discovery_name',
+                    'field_type': 'STRING',
+                    'description': 'Name in discovery document.',
+                    'mode': 'REQUIRED'
+                }, {
+                    'name': 'data',
+                    'field_type': 'RECORD',
+                    'description': 'Resource properties.',
+                    'mode': 'REQUIRED',
+                    'fields': resource_schema
+                }],
+                'mode': 'NULLABLE'
+            })
+        if include_iam_policy:
+            asset_schema.append({
+                'name': 'iam_policy',
+                'field_type': 'RECORD',
+                'description': 'IAM Policy',
+                'fields': [{
+                    'name': 'etag',
+                    'field_type': 'STRING',
+                    'description': 'Etag.',
+                    'mode': 'NULLABLE'
+                }, {
+                    'name': 'audit_configs',
+                    'field_type': 'RECORD',
+                    'description': 'Logging of each type of permission.',
+                    'mode': 'REPEATED',
+                    'fields': [{
+                        'name': 'service',
+                        'field_type': 'STRING',
+                        'description':
+                            'Service that will be enabled for audit logging.',
+                        'mode': 'NULLABLE'
+                    }, {
+                        'name': 'audit_log_configs',
+                        'field_type': 'RECORD',
+                        'description': 'Logging of each type of permission.',
+                        'mode': 'REPEATED',
+                        'fields': [{
+                            'name': 'log_type',
+                            'field_type': 'NUMERIC',
+                            'mode': 'NULLABLE',
+                            'description':
+                            ('1: Admin reads. Example: CloudIAM getIamPolicy',
+                             '2: Data writes. Example: CloudSQL Users create',
+                             '3: Data reads. Example: CloudSQL Users list')
+                        }]
+                    }]
+                }, {
+                    'name': 'bindings',
+                    'field_type': 'RECORD',
+                    'mode': 'REPEATED',
+                    'description': 'Bindings',
+                    'fields': [{
+                        'name': 'role',
+                        'field_type': 'STRING',
+                        'mode': 'NULLABLE',
+                        'description': 'Assigned role.'
+                    }, {
+                        'name': 'members',
+                        'field_type': 'STRING',
+                        'mode': 'REPEATED',
+                        'description': 'Principles assigned the role.'
+                    }]
+                }]
+            })
+
+        # convert dict structure into bigquery.SchemaField objects
+        def to_bigquery_schema(fields):
+            for field in fields:
+                if 'fields' in field:
+                    field['fields'] = to_bigquery_schema(fields['fields'])
+            return [bigquery.SchemaField(**field) for field in fields]
+
+        return to_bigquery_schema(asset_schema)
+
+    @classmethod
+    def bigquery_schema_for_asset_type(cls, asset_type, include_resource,
+                                       include_iam_policy):
+        """Returns the BigQuery schema for the asset type.
+
+        Args:
+            asset_type: CAI asset type.
+            include_resource: if resource schema should be included.
+            include_iam_policy: if IAM policy schema should be included.
+        """
+        cache_key = '{}.{}.{}'.format(asset_type, include_resource,
+                                      include_iam_policy)
+        if cache_key in cls.schema_cache:
+            return cls.schema_cache[cache_key]
+        api_name = cls.get_api_name_for_asset_type(asset_type)
+        discovery_documents_map = cls._get_discovery_documents_map()
+        discovery_documents = discovery_documents_map[api_name]
+        resource_name = resource_name_for_asset_type(
+            asset_type)
+        # merge all asset versions into a single schema.
+        schemas = [
+            cls._translate_resource_to_schema(resource_name, document)
+            for document in discovery_documents
+        ]
+        merged_schema = bigquery_schema.merge_schemas(schemas)
+        asset_type_schema = cls._convert_to_asset_schema(
+            merged_schema, include_resource, include_iam_policy)
+        cls.schema_cache[cache_key] = asset_type_schema
+        return asset_type_schema
+
+
+def resource_name_for_asset_type(asset_type):
+    """Return the resource name for the asset_type.
+
+    Args:
+        asset_type: the asset type like 'google.compute.Instance'
+    Returns:
+        a resource name like 'Instance'
+    """
+    return asset_type.split('.')[-1]

--- a/tools/asset-inventory/asset_inventory/bigquery_schema.py
+++ b/tools/asset-inventory/asset_inventory/bigquery_schema.py
@@ -19,8 +19,8 @@
 The entry points are:
 
     `translate_json_to_schema`- Returns a list of
-    `google.cloud.bigquery.SchemaField` objects that describe the provided
-    document
+    `google.cloud.bigquery.SchemaField` like dict objects that describe the
+    provided document
 
     `sanitize_property_value`- Modifies the supplied json object to conform to
     BigQuery standards such as nesting depth, column name format.
@@ -28,9 +28,14 @@ The entry points are:
     `merge_schemas` - Combines multiple BigQuery schmas and returns a new schema
     that is a union of both.
 
+    `get_field_by_name` - Returns a field with the supplied name from a list of
+    BigQuery field.
+
 This module helps import json documents into BigQuery.
+
 """
 
+import copy
 from numbers import Number
 import re
 
@@ -87,13 +92,13 @@ def _get_bigquery_type_for_property_value(property_value):
 def translate_json_to_schema(document):
     """Convert a json object to a BigQuery schema.
 
-    Traverses the json object collecting
-    `google.cloud.bigquery.SchemaField` objects for each value.
+    Traverses the json object collecting `google.cloud.bigquery.SchemaField`
+    like dict objects for each value.
 
     Args:
         document: A json object. It's not modified.
     Returns:
-        List of `google.cloud.bigquery.SchemaField` objects.
+        List of `google.cloud.bigquery.SchemaField` like dict objects.
 
     """
     schema = []
@@ -110,51 +115,51 @@ def translate_json_to_schema(document):
             field['mode'] = 'NULLABLE'
         if bigquery_type == 'RECORD':
             field['fields'] = translate_json_to_schema(property_value)
-        schema.append(bigquery.SchemaField(**field))
+        schema.append(field)
+    schema.reverse()
     return schema
 
 
-def _get_field_by_name(fields, field_name):
+def get_field_by_name(fields, field_name):
     for i, field in enumerate(fields):
-        if field.name == field_name:
+        # BigQuery column names are case insensitive.
+        if field['name'].lower() == field_name.lower():
             return i, field
     return None, None
 
 
 def _merge_fields(destination_field, source_field):
-    """Combines two SchemaField objects.
+    """Combines two SchemaField like dicts.
 
     The same field can exist in both the destination and source schemas when
     trying to combine schemas. To handle this we try to choose a more specific
     type if there is a conflict and merge any encosed fields.
 
     Args:
-        destination_field:  `google.cloud.bigquery.SchemaField` object.
-        source_field: `google.cloud.bigquery.SchemaField` object.
+        destination_field:  `google.cloud.bigquery.SchemaField` dict.
+        source_field: `google.cloud.bigquery.SchemaField` dict.
     Returns:
-        A `google.cloud.bigquery.SchemaField` object.
+        A `google.cloud.bigquery.SchemaField` dict.
     """
-    field = destination_field
+    field = copy.deepcopy(destination_field)
+    # apply description.
+    dd = destination_field.get('description', None)
+    sd = source_field.get('description', None)
+    if ((not dd and sd) or (sd and dd and len(dd) < len(sd))):
+        field['description'] = sd
+
     # use the more specific type if destination is just a STRING.
-    if (destination_field.field_type == 'STRING' and
-        source_field.field_type != 'STRING'):
-        # Modify SchemaField.type by copy.
-        field = bigquery.SchemaField(
-            name=field.name,
-            fields=field.fields,
-            field_type=source_field.field_type,
-            description=field.description,
-            mode=field.mode)
-    merged_fields = _merge_schema(destination_field.fields,
-                                  source_field.fields)
-    # Modify SchemaField.fields by copy.
-    if merged_fields != destination_field.fields:
-        field = bigquery.SchemaField(
-            name=field.name,
-            fields=merged_fields,
-            field_type=field.field_type,
-            description=field.description,
-            mode=field.mode)
+    dft = destination_field.get('field_type', None)
+    sft = source_field.get('field_type', None)
+    if (dft == 'STRING' and sft != 'STRING'):
+        field['field_type'] = sft
+
+    df = destination_field.get('fields', [])
+    sf = source_field.get('fields', [])
+    merged_fields = _merge_schema(df, sf)
+    # recursivly merge nested fields.
+    if merged_fields != df:
+        field['fields'] = merged_fields
     return field
 
 
@@ -171,11 +176,13 @@ def _merge_schema(destination_schema, source_schema):
         The modified destination_schema list.
 
     """
-
+    # short circuit if schemas are the same.
+    if destination_schema == source_schema:
+        return destination_schema
     destination_schema_list = list(destination_schema)
     for source_field in source_schema:
-        i, destination_field = _get_field_by_name(destination_schema_list,
-                                                  source_field.name)
+        i, destination_field = get_field_by_name(destination_schema_list,
+                                                 source_field['name'])
         # field with same name exists, merge them.
         if destination_field:
             destination_schema_list[i] = _merge_fields(destination_field,
@@ -211,9 +218,9 @@ def _convert_labels_dict_to_list(parent):
     object has arbitrary user supplied fields.
 
     Args:
-        parent: Json object.
+        parent: dict object.
     Returns:
-        The modified json object.
+        The modified dict object.
 
     """
     labels_dict = parent['labels']
@@ -259,7 +266,8 @@ def _sanitize_property(property_name, parent, depth):
         parent[new_property_name] = property_value
 
     # handle labels (condition #1).
-    if new_property_name == 'labels':
+    if (new_property_name == 'labels' and
+        isinstance(parent[new_property_name], dict)):
         _convert_labels_dict_to_list(parent)
 
     property_value = parent[new_property_name]
@@ -271,7 +279,9 @@ def _sanitize_property(property_name, parent, depth):
     parent[new_property_name] = sanitized
 
     # remove empty dicts or list of empty dicts (condition #3)
-    if not any(sanitized):
+    if ((isinstance(sanitized, list) or
+         isinstance(sanitized, dict))
+        and not any(sanitized)):
         # BigQuery doesn't deal well with empty records.
         # prune the value.
         parent.pop(new_property_name)

--- a/tools/asset-inventory/asset_inventory/cai_to_api.py
+++ b/tools/asset-inventory/asset_inventory/cai_to_api.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+#
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Convert CAI Assets to match API names.
+
+There are some Cloud Asset Inventory (CAI) properties which don't match the
+properties in the API discovery documents. This converts those CAI properties to
+match those in the API. The property mappings are supplied by
+the 'cai_to_api_mapping.json' configuration file which needs to be
+regenerated if new properties are added to assets that don't aren't mapped
+correctly.
+
+The entrypoint is the `CAIToAPI.cai_to_api_properties` method.
+
+"""
+
+impot json
+import os
+
+
+class CAIToAPI(object):
+    """Convert CAI properties names to API properties."""
+
+    _cai_to_api_dict = None
+
+    @classmethod
+    def _get_cai_to_api_properties(cls):
+        """Get the dict containing current mappings."""
+        # To regnerate the configs see:
+        # https://colab.corp.google.com/drive/183eM8uKO0V-HD2ldx7AMJ8H6UQnh3JHt
+        if cls._cai_to_api_dict is None:
+            with open(os.path.join(os.path.dirname(__file__),
+                                   'cai_to_api_properties.json')) as f:
+                cls._cai_to_api_dict = json.load(f)
+        return cls._cai_to_api_dict
+
+    @classmethod
+    def _apply_cai_to_api(cls, cai_properties, cai_to_api):
+        """Recursively map CAI to API properties.
+
+        Args:
+            cai_properties: dict of cai properties at current level of
+            recursion.
+            cai_to_api: dict of cai to api mappings for the current level of
+            recursion.
+        """
+        # `cai_properties is either a list of dicts or a dict.
+        # if a list, apply for each dict in the list.
+        if isinstance(cai_properties, list):
+            for item in cai_properties:
+                cls._apply_cai_to_api(item, cai_to_api)
+            return
+
+        # if a dict, recurse into each property that requires modification
+        for cai_property in cai_to_api:
+            if cai_property in cai_properties:
+                cls._apply_cai_to_api(cai_properties[cai_property],
+                                           cai_to_api[cai_property])
+
+        # and apply the necessary modifications.
+        if 'cai_to_api_names' in cai_to_api:
+            cai_to_api_names = cai_to_api['cai_to_api_names']
+            for cai_property, r_property  in cai_to_api_names.items():
+                if cai_property in cai_properties:
+                    cai_properties[r_property] = cai_properties.pop(
+                        cai_property)
+
+    @classmethod
+    def cai_to_api_properties(cls, resource_name, cai_properties):
+        """Convert properties in """
+        cai_to_api_properties = cls._get_cai_to_api_properties()
+        if resource_name in cai_to_api_properties:
+            cai_to_api = cai_to_api_properties[resource_name]
+            cls._apply_cai_to_api(cai_properties, cai_to_api)
+        return cai_properties

--- a/tools/asset-inventory/asset_inventory/cai_to_api.py
+++ b/tools/asset-inventory/asset_inventory/cai_to_api.py
@@ -27,7 +27,7 @@ The entrypoint is the `CAIToAPI.cai_to_api_properties` method.
 
 """
 
-impot json
+import json
 import os
 
 
@@ -68,7 +68,7 @@ class CAIToAPI(object):
         for cai_property in cai_to_api:
             if cai_property in cai_properties:
                 cls._apply_cai_to_api(cai_properties[cai_property],
-                                           cai_to_api[cai_property])
+                                      cai_to_api[cai_property])
 
         # and apply the necessary modifications.
         if 'cai_to_api_names' in cai_to_api:
@@ -80,7 +80,7 @@ class CAIToAPI(object):
 
     @classmethod
     def cai_to_api_properties(cls, resource_name, cai_properties):
-        """Convert properties in """
+        """Convert CAI properties that should match API properties."""
         cai_to_api_properties = cls._get_cai_to_api_properties()
         if resource_name in cai_to_api_properties:
             cai_to_api = cai_to_api_properties[resource_name]

--- a/tools/asset-inventory/asset_inventory/cai_to_api_properties.json
+++ b/tools/asset-inventory/asset_inventory/cai_to_api_properties.json
@@ -1,0 +1,441 @@
+{
+    "Autoscaler": {
+        "autoscalingPolicy": {
+            "cai_to_api_names": {
+                "customMetricUtilization": "customMetricUtilizations"
+            }
+        }
+    },
+    "BackendService": {
+        "backend": {
+            "cai_to_api_names": {
+                "resourceGroup": "group"
+            }
+        },
+        "cai_to_api_names": {
+            "backend": "backends",
+            "customRequestHeader": "customRequestHeaders",
+            "enableCdn": "enableCDN",
+            "healthCheck": "healthChecks",
+            "serviceProtocol": "protocol"
+        },
+        "securitySettings": {
+            "serverSettingsSelector": {
+                "cai_to_api_names": {
+                    "labelMatch": "labelMatches"
+                }
+            }
+        }
+    },
+    "Disk": {
+        "cai_to_api_names": {
+            "guestOsFeature": "guestOsFeatures",
+            "license": "licenses",
+            "licenseCode": "licenseCodes",
+            "replicaZone": "replicaZones",
+            "resourcePolicy": "resourcePolicies",
+            "user": "users"
+        }
+    },
+    "Firewall": {
+        "allowed": {
+            "cai_to_api_names": {
+                "ipProtocol": "IPProtocol",
+                "port": "ports"
+            }
+        },
+        "cai_to_api_names": {
+            "destinationRange": "destinationRanges",
+            "sourceRange": "sourceRanges",
+            "sourceServiceAccount": "sourceServiceAccounts",
+            "sourceTag": "sourceTags",
+            "targetServiceAccount": "targetServiceAccounts",
+            "targetTag": "targetTags"
+        },
+        "denied": {
+            "cai_to_api_names": {
+                "ipProtocol": "IPProtocol",
+                "port": "ports"
+            }
+        }
+    },
+    "ForwardingRule": {
+        "cai_to_api_names": {
+            "ipAddress": "IPAddress",
+            "ipProtocol": "IPProtocol"
+        }
+    },
+    "Image": {
+        "cai_to_api_names": {
+            "guestOsFeature": "guestOsFeatures",
+            "license": "licenses",
+            "licenseCode": "licenseCodes",
+            "storageLocation": "storageLocations"
+        }
+    },
+    "Instance": {
+        "cai_to_api_names": {
+            "disk": "disks",
+            "guestAccelerator": "guestAccelerators",
+            "networkInterface": "networkInterfaces",
+            "resourcePolicy": "resourcePolicies",
+            "serviceAccount": "serviceAccounts"
+        },
+        "disk": {
+            "cai_to_api_names": {
+                "guestOsFeature": "guestOsFeatures",
+                "license": "licenses"
+            },
+            "initializeParams": {
+                "cai_to_api_names": {
+                    "guestOsFeature": "guestOsFeatures",
+                    "replicaZone": "replicaZones"
+                }
+            }
+        },
+        "metadata": {
+            "cai_to_api_names": {
+                "item": "items"
+            }
+        },
+        "networkInterface": {
+            "accessConfig": {
+                "cai_to_api_names": {
+                    "externalIp": "natIP"
+                }
+            },
+            "cai_to_api_names": {
+                "accessConfig": "accessConfigs",
+                "aliasIpRange": "aliasIpRanges",
+                "ipAddress": "networkIP"
+            }
+        },
+        "scheduling": {
+            "cai_to_api_names": {
+                "nodeAffinity": "nodeAffinities"
+            },
+            "nodeAffinity": {
+                "cai_to_api_names": {
+                    "value": "values"
+                }
+            }
+        },
+        "serviceAccount": {
+            "cai_to_api_names": {
+                "scope": "scopes"
+            }
+        },
+        "tags": {
+            "cai_to_api_names": {
+                "tag": "items"
+            }
+        }
+    },
+    "InstanceGroup": {
+        "cai_to_api_names": {
+            "namedPort": "namedPorts"
+        }
+    },
+    "InstanceGroupManager": {
+        "cai_to_api_names": {
+            "autoHealingPolicy": "autoHealingPolicies",
+            "namedPort": "namedPorts",
+            "targetPool": "targetPools",
+            "version": "versions"
+        },
+        "distributionPolicy": {
+            "cai_to_api_names": {
+                "zone": "zones"
+            }
+        },
+        "statefulPolicy": {
+            "preservedResources": {
+                "cai_to_api_names": {
+                    "disk": "disks"
+                }
+            }
+        }
+    },
+    "InstanceTemplate": {
+        "properties": {
+            "cai_to_api_names": {
+                "disk": "disks",
+                "guestAccelerator": "guestAccelerators",
+                "networkInterface": "networkInterfaces",
+                "serviceAccount": "serviceAccounts"
+            },
+            "disk": {
+                "cai_to_api_names": {
+                    "guestOsFeature": "guestOsFeatures",
+                    "license": "licenses"
+                },
+                "initializeParams": {
+                    "cai_to_api_names": {
+                        "guestOsFeature": "guestOsFeatures",
+                        "replicaZone": "replicaZones"
+                    }
+                }
+            },
+            "metadata": {
+                "cai_to_api_names": {
+                    "item": "items"
+                }
+            },
+            "networkInterface": {
+                "accessConfig": {
+                    "cai_to_api_names": {
+                        "externalIp": "natIP"
+                    }
+                },
+                "cai_to_api_names": {
+                    "accessConfig": "accessConfigs",
+                    "aliasIpRange": "aliasIpRanges",
+                    "ipAddress": "networkIP"
+                }
+            },
+            "scheduling": {
+                "cai_to_api_names": {
+                    "nodeAffinity": "nodeAffinities"
+                },
+                "nodeAffinity": {
+                    "cai_to_api_names": {
+                        "value": "values"
+                    }
+                }
+            },
+            "serviceAccount": {
+                "cai_to_api_names": {
+                    "scope": "scopes"
+                }
+            },
+            "tags": {
+                "cai_to_api_names": {
+                    "tag": "items"
+                }
+            }
+        },
+        "sourceInstanceParams": {
+            "cai_to_api_names": {
+                "diskConfig": "diskConfigs"
+            }
+        }
+    },
+    "Network": {
+        "cai_to_api_names": {
+            "gatewayIpv4": "gatewayIPv4",
+            "ipv4Range": "IPv4Range",
+            "subnetwork": "subnetworks"
+        }
+    },
+    "Project": {
+        "cai_to_api_names": {
+            "enabledFeature": "enabledFeatures",
+            "quota": "quotas"
+        },
+        "commonInstanceMetadata": {
+            "cai_to_api_names": {
+                "item": "items"
+            }
+        }
+    },
+    "Route": {
+        "cai_to_api_names": {
+            "tag": "tags",
+            "warning": "warnings"
+        }
+    },
+    "Router": {
+        "bgp": {
+            "cai_to_api_names": {
+                "advertisedGroup": "advertisedGroups",
+                "advertisedIpRange": "advertisedIpRanges"
+            }
+        },
+        "bgpPeer": {
+            "cai_to_api_names": {
+                "advertisedGroup": "advertisedGroups",
+                "advertisedIpRange": "advertisedIpRanges"
+            }
+        },
+        "cai_to_api_names": {
+            "bgpPeer": "bgpPeers",
+            "interface": "interfaces",
+            "nat": "nats"
+        },
+        "nat": {
+            "cai_to_api_names": {
+                "natIp": "natIps",
+                "subnetwork": "subnetworks"
+            },
+            "subnetwork": {
+                "cai_to_api_names": {
+                    "secondaryIpRangeName": "secondaryIpRangeNames"
+                }
+            }
+        }
+    },
+    "Snapshot": {
+        "cai_to_api_names": {
+            "guestOsFeature": "guestOsFeatures",
+            "license": "licenses",
+            "licenseCode": "licenseCodes",
+            "storageLocation": "storageLocations"
+        }
+    },
+    "Subnetwork": {
+        "cai_to_api_names": {
+            "allowConflictingRoutes": "allowSubnetCidrRoutesOverlap",
+            "secondaryIpRange": "secondaryIpRanges"
+        }
+    },
+    "TargetHttpsProxy": {
+        "cai_to_api_names": {
+            "sslCertificate": "sslCertificates"
+        }
+    },
+    "TargetPool": {
+        "cai_to_api_names": {
+            "healthCheck": "healthChecks",
+            "instance": "instances"
+        }
+    },
+    "TargetSslProxy": {
+        "cai_to_api_names": {
+            "backendService": "service",
+            "sslCertificate": "sslCertificates"
+        }
+    },
+    "TargetTcpProxy": {
+        "cai_to_api_names": {
+            "backendService": "service"
+        }
+    },
+    "TargetVpnGateway": {
+        "cai_to_api_names": {
+            "forwardingRule": "forwardingRules",
+            "tunnel": "tunnels"
+        }
+    },
+    "UrlMap": {
+        "cai_to_api_names": {
+            "hostRule": "hostRules",
+            "pathMatcher": "pathMatchers",
+            "test": "tests"
+        },
+        "defaultRouteAction": {
+            "cai_to_api_names": {
+                "weightedBackendService": "weightedBackendServices"
+            },
+            "corsPolicy": {
+                "cai_to_api_names": {
+                    "allowHeader": "allowHeaders",
+                    "allowMethod": "allowMethods",
+                    "allowOrigin": "allowOrigins",
+                    "allowOriginRegex": "allowOriginRegexes",
+                    "exposeHeader": "exposeHeaders"
+                }
+            },
+            "retryPolicy": {
+                "cai_to_api_names": {
+                    "retryCondition": "retryConditions"
+                }
+            }
+        },
+        "hostRule": {
+            "cai_to_api_names": {
+                "host": "hosts"
+            }
+        },
+        "pathMatcher": {
+            "cai_to_api_names": {
+                "pathRule": "pathRules",
+                "routeRule": "routeRules"
+            },
+            "defaultRouteAction": {
+                "cai_to_api_names": {
+                    "weightedBackendService": "weightedBackendServices"
+                },
+                "corsPolicy": {
+                    "cai_to_api_names": {
+                        "allowHeader": "allowHeaders",
+                        "allowMethod": "allowMethods",
+                        "allowOrigin": "allowOrigins",
+                        "allowOriginRegex": "allowOriginRegexes",
+                        "exposeHeader": "exposeHeaders"
+                    }
+                },
+                "retryPolicy": {
+                    "cai_to_api_names": {
+                        "retryCondition": "retryConditions"
+                    }
+                }
+            },
+            "pathRule": {
+                "cai_to_api_names": {
+                    "backendService": "service",
+                    "path": "paths"
+                },
+                "routeAction": {
+                    "cai_to_api_names": {
+                        "weightedBackendService": "weightedBackendServices"
+                    },
+                    "corsPolicy": {
+                        "cai_to_api_names": {
+                            "allowHeader": "allowHeaders",
+                            "allowMethod": "allowMethods",
+                            "allowOrigin": "allowOrigins",
+                            "allowOriginRegex": "allowOriginRegexes",
+                            "exposeHeader": "exposeHeaders"
+                        }
+                    },
+                    "retryPolicy": {
+                        "cai_to_api_names": {
+                            "retryCondition": "retryConditions"
+                        }
+                    }
+                }
+            },
+            "routeRule": {
+                "cai_to_api_names": {
+                    "matchRule": "matchRules"
+                },
+                "matchRule": {
+                    "cai_to_api_names": {
+                        "headerMatch": "headerMatches",
+                        "metadataFilter": "metadataFilters",
+                        "queryParameterMatch": "queryParameterMatches"
+                    },
+                    "metadataFilter": {
+                        "cai_to_api_names": {
+                            "filterLabel": "filterLabels"
+                        }
+                    }
+                },
+                "routeAction": {
+                    "cai_to_api_names": {
+                        "weightedBackendService": "weightedBackendServices"
+                    },
+                    "corsPolicy": {
+                        "cai_to_api_names": {
+                            "allowHeader": "allowHeaders",
+                            "allowMethod": "allowMethods",
+                            "allowOrigin": "allowOrigins",
+                            "allowOriginRegex": "allowOriginRegexes",
+                            "exposeHeader": "exposeHeaders"
+                        }
+                    },
+                    "retryPolicy": {
+                        "cai_to_api_names": {
+                            "retryCondition": "retryConditions"
+                        }
+                    }
+                }
+            }
+        },
+        "test": {
+            "cai_to_api_names": {
+                "expectedBackendService": "service"
+            }
+        }
+    }
+}

--- a/tools/asset-inventory/asset_inventory/import_pipeline_metadata
+++ b/tools/asset-inventory/asset_inventory/import_pipeline_metadata
@@ -23,7 +23,7 @@
     "name": "group_by",
     "label": "How to group the assets in BigQuery.",
     "help_text": "Either 'ASSET_TYPE' or 'ASSET_TYPE_VERSION'.",
-    "regexes": ["^(ASSET_TYPE|ASSET_TYPE_VERSION)$"]
+    "regexes": ["^(ASSET_TYPE|ASSET_TYPE_VERSION|NONE)$"]
   },
   {
     "name": "write_disposition",

--- a/tools/asset-inventory/asset_inventory/main.py
+++ b/tools/asset-inventory/asset_inventory/main.py
@@ -51,8 +51,13 @@ def parse_args():
     parser.add_argument(
         '--group_by',
         default='ASSET_TYPE',
-        choices=['ASSET_TYPE', 'ASSET_TYPE_VERSION'],
-        help='How to group exported resources into Bigquery tables.')
+        choices=['ASSET_TYPE', 'ASSET_TYPE_VERSION', 'NONE'],
+        # pylint: disable=line-too-long
+        help=(
+            'How to group exported resources into Bigquery tables.\n',
+            '  ASSET_TYPE: A table for each asset type (like google.compute.Instance\n',
+            '  ASSET_TYPE_VERSION: A table for each asset type and api version (like google.compute.Instance.v1\n',
+            '  NONE: One one table holding assets in a single json column\n'))
 
     parser.add_argument(
         '--write_disposition',
@@ -110,10 +115,10 @@ def parse_args():
         '--template-job-runtime-environment-json',
         type=json_value,
         help=('When launching a template via --template-job-launch-location, '
-         'this is an optional json dict for '
-         'runtime environment for the dataflow template launch request. '
-         'See https://cloud.google.com/dataflow/docs/reference/rest/v1b3/RuntimeEnvironment. '
-         'For example : \'{"maxWorkers": 10}\''))
+              'this is an optional json dict for '
+              'runtime environment for the dataflow template launch request. '
+              'See https://cloud.google.com/dataflow/docs/reference/rest/v1b3/RuntimeEnvironment. '
+              'For example : \'{"maxWorkers": 10}\''))
 
     args, beam_args = parser.parse_known_args()
 

--- a/tools/asset-inventory/gae/config.yaml
+++ b/tools/asset-inventory/gae/config.yaml
@@ -45,7 +45,7 @@ import_template_region: us-central1
 # If running a template. This is the template location.
 import_template_location: gs://professional-services-tools-asset-inventory/latest/import_pipeline
 
-# How to group exported resources into Bigquery tables. Either ASSET_TYPE_VERSION or ASSET_TYPE
+# How to group exported resources into Bigquery tables. Either NONE, ASSET_TYPE_VERSION or ASSET_TYPE
 import_group_by: ASSET_TYPE
 
 # If tables should be ovewritten (WRITE_EMPTY) or appended (WRITE_APPEND) to.

--- a/tools/asset-inventory/setup.py
+++ b/tools/asset-inventory/setup.py
@@ -39,6 +39,8 @@ setup(
     packages=['asset_inventory'],
     setup_requires=['pytest-runner'],
     tests_require=['mock', 'pytest'],
+    include_package_data=True,
+    data_files=[('.', ['asset_inventory/cai_to_api_properties.json'])],
     install_requires=[
         'google-api-core',
         'google-apitools',
@@ -47,4 +49,5 @@ setup(
         'google-api-python-client',
         'googleapis-common-protos==1.5.3',
         'google-cloud-asset', 'google-cloud-bigquery==1.6.0',
+        'requests-futures'
     ])

--- a/tools/asset-inventory/tests/test_api_schema.py
+++ b/tools/asset-inventory/tests/test_api_schema.py
@@ -23,6 +23,9 @@ from asset_inventory.api_schema  import APISchema
 # pylint:disable=protected-access
 class TestApiSchema(unittest.TestCase):
 
+    def tearDown(self):
+        APISchema._discovey_documents_map = None
+
     def test_simple_properties(self):
         api_properties = {
             'property-1': {
@@ -158,7 +161,8 @@ class TestApiSchema(unittest.TestCase):
                 }
             }
         }
-        schema = APISchema._properties_map_to_field_list(resources['Object-1']['properties'],
-                                                         resources, {})
+        schema = APISchema._properties_map_to_field_list(
+            resources['Object-1']['properties'],
+            resources, {})
         schema.sort()
         self.assertEqual(schema, [])

--- a/tools/asset-inventory/tests/test_api_schema.py
+++ b/tools/asset-inventory/tests/test_api_schema.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python
+#
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#            http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test construction of a BigQuery schema from an API discovery document.."""
+
+import unittest
+from asset_inventory.api_schema  import APISchema
+
+
+# pylint:disable=protected-access
+class TestApiSchema(unittest.TestCase):
+
+    def test_simple_properties(self):
+        api_properties = {
+            'property-1': {
+                'type': 'string',
+                'description': 'description-1.'
+            },
+            'property-2': {
+                'type': 'integer',
+                'description': 'description-2.'
+            }
+
+        }
+        schema = APISchema._properties_map_to_field_list(api_properties, {},
+                                                             {})
+        schema.sort()
+        self.assertEqual(schema, [{'name': 'property-1',
+                                   'field_type': 'STRING',
+                                   'description': 'description-1.',
+                                   'mode': 'NULLABLE'},
+                                  {'name': 'property-2',
+                                   'field_type': 'NUMERIC',
+                                   'description': 'description-2.',
+                                   'mode': 'NULLABLE'
+                                  }])
+
+    def test_record_properties(self):
+        api_properties = {
+            'property-1': {
+                'type': 'object',
+                '$ref': 'NestedObject',
+                'description': 'description-1.'
+            },
+        }
+        resources = {
+            'NestedObject': {
+                'properties': {
+                    'property-2': {
+                        'type': 'string',
+                        'description': 'description-2.'
+                    }
+                }
+            }
+        }
+        schema = APISchema._properties_map_to_field_list(api_properties,
+                                                         resources, {})
+        schema.sort()
+        self.assertEqual(schema, [{'name': 'property-1',
+                                   'field_type': 'RECORD',
+                                   'mode': 'NULLABLE',
+                                   'description': 'description-1.',
+                                   'fields': [{
+                                       'name': 'property-2',
+                                       'field_type': 'STRING',
+                                       'description': 'description-2.',
+                                       'mode': 'NULLABLE'
+                                   }]
+                                  }])
+
+    def test_repeated_properties(self):
+        api_properties = {
+            'property-1': {
+                'type': 'array',
+                'items': {
+                    '$ref': 'NestedObject',
+                },
+                'description': 'description-1.'
+            },
+        }
+        resources = {
+            'NestedObject': {
+                'properties': {
+                    'property-2': {
+                        'type': 'string',
+                        'description': 'description-2.'
+                    }
+                }
+            }
+        }
+        schema = APISchema._properties_map_to_field_list(api_properties,
+                                                         resources, {})
+        schema.sort()
+        self.assertEqual(schema, [{'name': 'property-1',
+                                   'field_type': 'RECORD',
+                                   'mode': 'REPEATED',
+                                   'description': 'description-1.',
+                                   'fields': [{
+                                       'name': 'property-2',
+                                       'field_type': 'STRING',
+                                       'description': 'description-2.',
+                                       'mode': 'NULLABLE'
+                                   }]
+                                  }])
+
+    def test_for_for_asset_type(self):
+        APISchema._discovey_documents_map = {
+            'compute': [{
+                'id': 'compute.v1',
+                'schemas': {
+                    'Instance': {
+                        'properties': {
+                            'property-1': {
+                                'type': 'string',
+                                'description': 'description-1.'
+                            }
+                        }
+                    }
+                }
+            }]}
+
+        schema = APISchema.bigquery_schema_for_asset_type(
+            'google.compute.Instance',
+            True, True)
+        print schema
+        print len(schema)
+        self.assertEqual(len(schema), 4)
+
+    def test_recursive_properties(self):
+        resources = {
+            'Object-1': {
+                'properties': {
+                    'property-1': {
+                        'type': 'object',
+                        '$ref': 'Object-2',
+                    }
+                }
+            },
+            'Object-2': {
+                'properties': {
+                    'property-2': {
+                        'type': 'object',
+                        '$ref': 'Object-1',
+                    }
+                }
+            }
+        }
+        schema = APISchema._properties_map_to_field_list(resources['Object-1']['properties'],
+                                                         resources, {})
+        schema.sort()
+        self.assertEqual(schema, [])

--- a/tools/asset-inventory/tests/test_bigquery_schema.py
+++ b/tools/asset-inventory/tests/test_bigquery_schema.py
@@ -26,67 +26,51 @@ class TestBigQuerySchema(unittest.TestCase):
         document = {'record_field': {'string_field': 'string_value'}}
         schema = bigquery_schema.translate_json_to_schema(
             document)
-        self.assertEqual(len(schema), 1)
-        record_field = schema[0]
-        self.assertEqual(record_field.name, 'record_field')
-        self.assertEqual(record_field.field_type, 'RECORD')
-        self.assertEqual(record_field.mode, 'NULLABLE')
-        self.assertEqual(len(record_field.fields), 1)
-        string_field = record_field.fields[0]
-        self.assertEqual(string_field.name, 'string_field')
-        self.assertEqual(string_field.field_type, 'STRING')
-        self.assertEqual(string_field.mode, 'NULLABLE')
+        self.assertEqual(schema, [{'name': 'record_field',
+                                   'field_type': 'RECORD',
+                                   'mode': 'NULLABLE',
+                                   'fields': [
+                                       {'name': 'string_field',
+                                        'field_type': 'STRING',
+                                        'mode': 'NULLABLE'
+                                       }]}])
 
     def test_array(self):
         document = {'array_field': [{'string_field': 'string_value'}]}
         schema = bigquery_schema.translate_json_to_schema(
             document)
-        self.assertEqual(len(schema), 1)
-        array_field = schema[0]
-        self.assertEqual(array_field.name, 'array_field')
-        self.assertEqual(array_field.field_type, 'RECORD')
-        self.assertEqual(array_field.mode, 'REPEATED')
-        self.assertEqual(len(array_field.fields), 1)
-        string_field = array_field.fields[0]
-        self.assertEqual(string_field.name, 'string_field')
-        self.assertEqual(string_field.field_type, 'STRING')
-        self.assertEqual(string_field.mode, 'NULLABLE')
+        self.assertEqual(schema, [{'name': 'array_field',
+                                   'field_type': 'RECORD',
+                                   'mode': 'REPEATED',
+                                   'fields': [
+                                       {'name': 'string_field',
+                                        'field_type': 'STRING',
+                                        'mode': 'NULLABLE'
+                                       }]}])
 
     def test_numeric(self):
         document = {'integer_field': 111, 'float_field': 22.0}
         schema = bigquery_schema.translate_json_to_schema(
             document)
-        self.assertEqual(len(schema), 2)
-        _, integer_field = bigquery_schema._get_field_by_name(
-            schema,
-            'integer_field')
-        self.assertEqual(integer_field.name, 'integer_field')
-        self.assertEqual(integer_field.field_type, 'NUMERIC')
-        self.assertEqual(integer_field.mode, 'NULLABLE')
-        _, float_field = bigquery_schema._get_field_by_name(
-            schema,
-            'float_field')
-        self.assertEqual(float_field.name, 'float_field')
-        self.assertEqual(float_field.field_type, 'NUMERIC')
-        self.assertEqual(float_field.mode, 'NULLABLE')
+        self.assertEqual(schema, [{'name': 'integer_field',
+                                   'field_type': 'NUMERIC',
+                                   'mode': 'NULLABLE'},
+                                  {'name': 'float_field',
+                                   'field_type': 'NUMERIC',
+                                   'mode': 'NULLABLE'},
+                                 ])
 
     def test_bool(self):
         document = {'bool_array_field': [True, False], 'bool_field': False}
         schema = bigquery_schema.translate_json_to_schema(
             document)
-        self.assertEqual(len(schema), 2)
-        _, bool_array_field = bigquery_schema._get_field_by_name(
-            schema,
-            'bool_array_field')
-        self.assertEqual(bool_array_field.name, 'bool_array_field')
-        self.assertEqual(bool_array_field.field_type, 'BOOL')
-        self.assertEqual(bool_array_field.mode, 'REPEATED')
-        _, bool_field = bigquery_schema._get_field_by_name(
-            schema,
-            'bool_field')
-        self.assertEqual(bool_field.name, 'bool_field')
-        self.assertEqual(bool_field.field_type, 'BOOL')
-        self.assertEqual(bool_field.mode, 'NULLABLE')
+        self.assertEqual(schema, [{'name': 'bool_array_field',
+                                   'field_type': 'BOOL',
+                                   'mode': 'REPEATED'},
+                                  {'name': 'bool_field',
+                                   'field_type': 'BOOL',
+                                   'mode': 'NULLABLE'}
+                                 ])
 
     def test_merge_schemas_basic(self):
         schemas = [
@@ -99,54 +83,61 @@ class TestBigQuerySchema(unittest.TestCase):
             })
         ]
         merged_schema = bigquery_schema.merge_schemas(schemas)
-        self.assertEqual(len(merged_schema), 2)
-        _, field1 = bigquery_schema._get_field_by_name(
-            merged_schema, 'field1')
-        self.assertEqual(field1.field_type, 'STRING')
-        _, field2 = bigquery_schema._get_field_by_name(
-            merged_schema, 'field2')
-        self.assertEqual(field2.field_type, 'NUMERIC')
+        self.assertEqual(merged_schema,
+                         [{'name': 'field1',
+                           'field_type': 'STRING',
+                           'mode': 'NULLABLE'},
+                          {'name': 'field2',
+                           'field_type': 'NUMERIC',
+                           'mode': 'NULLABLE'},
+                         ])
 
     def test_merge_array_schemas_records(self):
-        schema = bigquery_schema.translate_json_to_schema(
-            [{'field1': 'value1'}, {'field2': 'value1'}])
-        self.assertEqual(len(schema), 2)
-        fields_found = [False, False]
-        for field in schema:
-            if field.name == 'field1':
-                fields_found[0] = True
-            if field.name == 'field2':
-                fields_found[1] = True
-            assert field.field_type == 'STRING'
-        self.assertTrue(fields_found[0] and fields_found[1])
+        schemas = [
+            bigquery_schema.translate_json_to_schema(
+                {'field1': [{'nested1': 'value1'}]}),
+            bigquery_schema.translate_json_to_schema(
+                {'field1': [{'nested2': 'value1'}]})
+        ]
+        merged_schema = bigquery_schema.merge_schemas(schemas)
+        self.assertEqual(merged_schema,
+                         [{'name': 'field1',
+                           'field_type': 'RECORD',
+                           'mode': 'REPEATED',
+                           'fields': [
+                               {'name': 'nested1',
+                                'field_type': 'STRING',
+                                'mode': 'NULLABLE'},
+                               {'name': 'nested2',
+                                'field_type': 'STRING',
+                                'mode': 'NULLABLE'}]}])
 
     def test_merge_schemas_records(self):
         schemas = [
             bigquery_schema.translate_json_to_schema({
-                'record_field': {
+                'recordField': {
                     'field1': 'string'
                 }
             }),
             bigquery_schema.translate_json_to_schema({
-                'record_field': {
+                'recordfield': {
                     'field1': 'string',
                     'field2': [2]
                 }
             })
         ]
         merged_schema = bigquery_schema.merge_schemas(schemas)
-        self.assertEqual(len(merged_schema), 1)
-        record_field = merged_schema[0]
-        self.assertEqual(record_field.field_type, 'RECORD')
-        self.assertEqual(len(record_field.fields), 2)
-        _, field1 = bigquery_schema._get_field_by_name(
-            record_field.fields, 'field1')
-        self.assertEqual(field1.field_type, 'STRING')
-        self.assertEqual(field1.mode, 'NULLABLE')
-        _, field2 = bigquery_schema._get_field_by_name(
-            record_field.fields, 'field2')
-        self.assertEqual(field2.field_type, 'NUMERIC')
-        self.assertEqual(field2.mode, 'REPEATED')
+        self.assertEqual(merged_schema,
+                         [{'name': 'recordField',
+                           'field_type': 'RECORD',
+                           'mode': 'NULLABLE',
+                           'fields': [
+                               {'name': 'field1',
+                                'field_type': 'STRING',
+                                'mode': 'NULLABLE'},
+                               {'name': 'field2',
+                                'field_type': 'NUMERIC',
+                                'mode': 'REPEATED'}]}])
 
     def test_sanitize_property_value(self):
         doc = {

--- a/tools/asset-inventory/tests/test_cai_to_resource_mapping.py
+++ b/tools/asset-inventory/tests/test_cai_to_resource_mapping.py
@@ -1,0 +1,92 @@
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#            http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test Cloud Asset Inventory export."""
+
+import argparse
+import logging
+import unittest
+
+from asset_inventory.cai_to_api import CAIToAPI
+import mock
+
+
+class TestCAIToAPIMapping(unittest.TestCase):
+    """
+    Tests the appliccation of CAI property mappings.
+
+    given a mapping like this:
+
+    "Instance": {
+        "cai_to_api_names": {
+            "disk": "disks",
+            "guestAccelerator": "guestAccelerators",
+            "networkInterface": "networkInterfaces",
+            "resourcePolicy": "resourcePolicies",
+            "serviceAccount": "serviceAccounts"
+        },
+        "disk": {
+            "cai_to_api_names": {
+                "guestOsFeature": "guestOsFeatures",
+                "license": "licenses"
+            }
+        }
+    }
+
+    and a json of:
+
+    {'disk': [{'license': 'value1',
+               'guestOsFeature': 'value2',
+               'unchanged': 'value3'}],
+     'unchanged': 'value4'}
+
+    the output should be:
+
+    {'disks': [{'licenses': 'value1',
+               'guestOsFeatures': 'value2',
+               'unchanged': 'value3'}],
+     'unchanged': 'value4'}
+    """
+
+    def test_instance_mapping(self):
+        cai_properties = {'disk': [{'license': 'value1',
+                                    'guestOsFeature': 'value2',
+                                    'unchanged': 'value3'}],
+                          'unchanged': 'value4'}
+
+        CAIToAPI.cai_to_api_properties(
+            'Instance', cai_properties)
+        self.assertEqual(cai_properties,
+                         {'disks': [{'licenses': 'value1',
+                                     'guestOsFeatures': 'value2',
+                                     'unchanged': 'value3'}],
+                          'unchanged': 'value4'})
+
+    def test_disk_mapping(self):
+        cai_properties = {'disk': {'license': 'value1',
+                                   'guestOsFeature': 'value2',
+                                   'unchanged': 'value3'},
+                          'networkInterface': {'accessConfig':
+                                               {'externalIp': 'value5'}},
+                          'unchanged': 'value4'}
+
+        CAIToAPI.cai_to_api_properties(
+            'Instance', cai_properties)
+        self.assertEqual(cai_properties,
+                         {'disks': {'licenses': 'value1',
+                                    'guestOsFeatures': 'value2',
+                                    'unchanged': 'value3'},
+                          'networkInterfaces': {'accessConfigs':
+                                                {'natIP': 'value5'}},
+                          'unchanged': 'value4'})

--- a/tools/asset-inventory/tests/test_cai_to_resource_mapping.py
+++ b/tools/asset-inventory/tests/test_cai_to_resource_mapping.py
@@ -14,12 +14,9 @@
 
 """Test Cloud Asset Inventory export."""
 
-import argparse
-import logging
 import unittest
 
 from asset_inventory.cai_to_api import CAIToAPI
-import mock
 
 
 class TestCAIToAPIMapping(unittest.TestCase):


### PR DESCRIPTION
Jake, since you did such a great job of reviewing my last commit I hope you can take a look at these additions I wish to make to the asset inventory tool.
Thanks!

- Some compute engine assets have fields in the CAI export that don't match the
  fields in the API resource object. This is due to differences in the API
  backend which Google hopes to correct in the future. Until that happens this
  change maps those fields to the same name they have in the API document.

- Because BigQuery sanitation might truncate some values, keep a column with the
  json description of the resource in each asset type table. There are also some
  use cases were querying across all resource types is useful, so also includes
  a table called 'resources' which includes every asset type in the export as
  json. Also add the 'NONE' group_by type to support users who don't want the
  asset type tables generated at all and only use the json exports

- Generate a complete asset schema from API discovery documents. Previously the
  asset schema was incrementally build from the exported json. The asset table
  would only have a column if the export contained a value for that property.
  This made it difficult to write queries that were usable across
  projects/organizations. We now generate a complete asset schema from the API
  documentation and will augment it with the values in the export if they every
  include fields not included in the API document. "
