### PR TITLE
Update checkstyle version to fix security vunerability

### DIFF
--- a/examples/dataflow-streaming-benchmark/pom.xml
+++ b/examples/dataflow-streaming-benchmark/pom.xml
@@ -39,7 +39,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- Dependency properties -->
-    <checkstyle.version>8.11</checkstyle.version>
+    <checkstyle.version>8.18</checkstyle.version>
     <beam.version>2.6.0</beam.version>
     <hamcrest.version>1.3</hamcrest.version>
     <java.version>1.8</java.version>


### PR DESCRIPTION
Checkstyle prior to 8.18 loads external DTDs by default, which can potentially lead to denial of service attacks or the leaking of confidential information. This PR updates the checkstyle version to 8.18 to close this security gap.