### PR TITLE
fix some typo issues

### DIFF
--- a/examples/kubeflow-fairing-example/Fairing_XGBoost.ipynb
+++ b/examples/kubeflow-fairing-example/Fairing_XGBoost.ipynb
@@ -282,7 +282,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "class HousingServe(object):\n",
+    "class FraudServe(object):\n",
     "    \n",
     "    def __init__(self):\n",
     "        self.train_input = GCP_Bucket + \"train_fraud.csv\"\n",
@@ -319,7 +319,7 @@
    "source": [
     "## Train an XGBoost model in a notebook\n",
     "\n",
-    "Call `HousingServe().train()` to train your model, and then evaluate and save your trained model."
+    "Call `FraudServe().train()` to train your model, and then evaluate and save your trained model."
    ]
   },
   {
@@ -417,7 +417,7 @@
     }
    ],
    "source": [
-    "HousingServe().train()"
+    "FraudServe().train()"
    ]
   },
   {
@@ -462,7 +462,7 @@
    "source": [
     "### Train an XGBoost model remotely on Kubeflow\n",
     "\n",
-    "Import the `TrainJob` and `GKEBackend` classes. Kubeflow Fairing packages the `HousingServe` class, the training data, and the training job's software prerequisites as a Docker image. Then Kubeflow Fairing deploys and runs the training job on Kubeflow."
+    "Import the `TrainJob` and `GKEBackend` classes. Kubeflow Fairing packages the `FraudServe` class, the training data, and the training job's software prerequisites as a Docker image. Then Kubeflow Fairing deploys and runs the training job on Kubeflow."
    ]
   },
   {
@@ -655,7 +655,7 @@
     "from fairing import TrainJob\n",
     "from fairing.backends import GKEBackend\n",
     "\n",
-    "train_job = TrainJob(HousingServe, BASE_IMAGE, input_files=[\"requirements.txt\"],\n",
+    "train_job = TrainJob(FraudServe, BASE_IMAGE, input_files=[\"requirements.txt\"],\n",
     "                     docker_registry=DOCKER_REGISTRY, backend=GKEBackend())\n",
     "train_job.submit()"
    ]
@@ -666,7 +666,7 @@
    "source": [
     "### Train an XGBoost model remotely on Cloud ML Engine\n",
     "\n",
-    "Import the `TrainJob` and `GCPManagedBackend` classes. Kubeflow Fairing packages the `HousingServe` class, the training data, and the training job's software prerequisites as a Docker image. Then Kubeflow Fairing deploys and runs the training job on Cloud ML Engine."
+    "Import the `TrainJob` and `GCPManagedBackend` classes. Kubeflow Fairing packages the `FraudServe` class, the training data, and the training job's software prerequisites as a Docker image. Then Kubeflow Fairing deploys and runs the training job on Cloud ML Engine."
    ]
   },
   {
@@ -818,7 +818,7 @@
    "source": [
     "from fairing import TrainJob\n",
     "from fairing.backends import GCPManagedBackend\n",
-    "train_job = TrainJob(HousingServe, BASE_IMAGE, input_files=[\"requirements.txt\"],\n",
+    "train_job = TrainJob(FraudServe, BASE_IMAGE, input_files=[\"requirements.txt\"],\n",
     "                     docker_registry=DOCKER_REGISTRY, backend=GCPManagedBackend())\n",
     "train_job.submit()"
    ]
@@ -829,7 +829,7 @@
    "source": [
     "### Deploy the trained model to Kubeflow for predictions\n",
     "\n",
-    "Import the `PredictionEndpoint` and `KubeflowGKEBackend` classes. Kubeflow Fairing packages the `HousingServe` class, the trained model, and the prediction endpoint's software prerequisites as a Docker image. Then Kubeflow Fairing deploys and runs the prediction endpoint on Kubeflow."
+    "Import the `PredictionEndpoint` and `KubeflowGKEBackend` classes. Kubeflow Fairing packages the `FraudServe` class, the trained model, and the prediction endpoint's software prerequisites as a Docker image. Then Kubeflow Fairing deploys and runs the prediction endpoint on Kubeflow."
    ]
   },
   {
@@ -968,7 +968,7 @@
     "from fairing import PredictionEndpoint\n",
     "from fairing.backends import KubeflowGKEBackend\n",
     "# The trained_ames_model.joblib is exported during the above local training\n",
-    "endpoint = PredictionEndpoint(HousingServe, BASE_IMAGE, input_files=['trained_fraud_model.joblib', \"requirements.txt\"],\n",
+    "endpoint = PredictionEndpoint(FraudServe, BASE_IMAGE, input_files=['trained_fraud_model.joblib', \"requirements.txt\"],\n",
     "                              docker_registry=DOCKER_REGISTRY, backend=KubeflowGKEBackend())\n",
     "endpoint.create()"
    ]


### PR DESCRIPTION
This PR fix the typo in Fairing_XGBoost.ipynb.

The original dataset used is Ames Housing dataset, but changed to ulb_fraud_detection to comply with data license requirement. Forgot to change the class name accordingly.

The change essentially change the name `HousingServe` to `FraudServe`.
