### PR TITLE
Add reminder to submit bug to Eng Council

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,10 +9,12 @@ Please, go through these steps before you submit a PR.
     * Add a link to your contribution in the top-level [README](https://github.com/GoogleCloudPlatform/professional-services/blob/master/README.md) (alpha-order).
     * Add [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0) license headers with an up-to-date copyright date attributed to `Google LLC`.
     * Remove unnecessary LICENSE files. There's no need to include an additional license since all repository submissions are covered by the top-level Apache 2.0 [license](https://github.com/GoogleCloudPlatform/professional-services/blob/master/LICENSE).
+    * **For new tools/examples**, file your project with the PSO Engineering Council.
 
 3. **After** these steps, you're ready to open a pull request.
     * Give a descriptive title to your PR.
     * Provide a description of your changes.
+    * Include the Engineering Council bug ID with your pull request.
     * Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
 <br/>
 


### PR DESCRIPTION
This adds a mention to submit new tools to the PSO engineering council before they are submitted.