### PR TITLE
[dataflow-streaming-benchmark] Add some more env vars for launching the pipeline.

### DIFF
--- a/examples/dataflow-streaming-benchmark/README.md
+++ b/examples/dataflow-streaming-benchmark/README.md
@@ -78,9 +78,17 @@ Pub/Sub topic.
 PROJECT_ID=<project-id>
 BUCKET=<bucket>
 PIPELINE_FOLDER=gs://${BUCKET}/dataflow/pipelines/streaming-benchmark
+SCHEMA_LOCATION=gs://<path-to-schema-location-in-gcs>
+PUBSUB_TOPIC=projects/$PROJECT_ID/topics/<topic-id>
+
+# Set the desired QPS
+QPS=50000
 
 # Set the runner
 RUNNER=DataflowRunner
+
+# Compute engine zone
+ZONE=us-east1-d
 
 # Build the template
 mvn compile exec:java \
@@ -91,10 +99,10 @@ mvn compile exec:java \
     --stagingLocation=${PIPELINE_FOLDER}/staging \
     --tempLocation=${PIPELINE_FOLDER}/temp \
     --runner=${RUNNER} \
-    --zone=us-east1-d \
+    --zone=${ZONE} \
     --autoscalingAlgorithm=THROUGHPUT_BASED \
     --maxNumWorkers=5 \
-    --qps=50000 \
-    --schemaLocation=gs://<bucket>/<path>/<to>/game-event-schema \
-    --topic=projects/<project-id>/topics/<topic-id>"
+    --qps=${QPS} \
+    --schemaLocation=${SCHEMA_LOCATION} \
+    --topic=${PUBSUB_TOPIC}"
 ```


### PR DESCRIPTION
This just updates the README.md of one of the examples (dataflow-streaming-benchmark).

Some options were left unset in the `mvn` command line call, and it might be confusing for beginners.
