### PR TITLE
bigquery-query-plan-exporter: export jobs from all users

### DIFF
--- a/tools/bigquery-query-plan-exporter/bqutil/bqexplain.py
+++ b/tools/bigquery-query-plan-exporter/bqutil/bqexplain.py
@@ -37,7 +37,8 @@ class BQQueryPlanExporter(object):
         c = self.get_client()
         dt0 = datetime.utcnow() - timedelta(start_days_ago)
         dt1 = datetime.utcnow() - timedelta(end_days_ago)
-        return [job._properties for job in c.list_jobs(min_creation_time=dt0,
+        return [job._properties for job in c.list_jobs(all_users = True,
+                                                       min_creation_time=dt0,
                                                        max_creation_time=dt1)
                 if hasattr(job, 'query_plan')]
 


### PR DESCRIPTION
Returns jobs from all users which can be filtered later on. At the moment, only the job of the service account running the tool will be returned.

This PR might close https://github.com/GoogleCloudPlatform/professional-services/issues/279 if returning all jobs is enough and no user filtering is necessary at the API call level.
