### PR TITLE
Prepare package for PyPI publishing

### DIFF
--- a/tools/gsuite-exporter/setup.py
+++ b/tools/gsuite-exporter/setup.py
@@ -34,6 +34,7 @@ setup(
     version='0.0.2',
     description='GSuite Admin API Exporter',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     author='Google Inc.',
     author_email='ocervello@google.com',
     packages=find_packages(exclude=['contrib', 'docs', 'tests']),


### PR DESCRIPTION
This PR adds the `long_description_content_type` need for a valid upload to PyPI