### PR TITLE
Add out_path_prefix flag to gen_csv_from_images in cloud-vision-utils.

### DIFF
--- a/tools/cloud-vision-utils/cloud_vision_utils/dataset.py
+++ b/tools/cloud-vision-utils/cloud_vision_utils/dataset.py
@@ -36,6 +36,7 @@ def gen_csv_from_images(
     input_dir: str,
     output_file=constants.DEFAULT_CSV_FILENAME,
     add_label=False,
+    out_path_prefix='',
     dataset_type=constants.DEFAULT_DATASET_TYPE):
   """Generate AutoML dataset CSV from directory of images.
 
@@ -44,6 +45,8 @@ def gen_csv_from_images(
     output_file: Output CSV filename.
     add_label: Whether to include image label based on
       last directory on the image's filepath.
+    out_path_prefix: Output path prefix to prepend to each filename.
+      (e.g. gs://path/to/the/imagedir)
     dataset_type: AutoML dataset type (TRAIN, VALIDATE, TEST, UNSPECIFIED)
       to use for all the parsed images.
   """
@@ -54,8 +57,12 @@ def gen_csv_from_images(
     writer = csv.writer(f, delimiter=',')
     for topdir, _, files in gfile.walk(os.path.expanduser(input_dir)):
       for f in files:
+        if out_path_prefix:
+          filepath = os.path.join(out_path_prefix, f)
+        else:
+          filepath = os.path.join(topdir, f)
         label = get_label(topdir)
-        row = ([dataset_type, f, label] +
+        row = ([dataset_type, filepath, label] +
                ['']*constants.NUM_BOUNDING_BOX_FIELDS)
         writer.writerow(row)
 

--- a/tools/cloud-vision-utils/cloud_vision_utils/dataset_test.py
+++ b/tools/cloud-vision-utils/cloud_vision_utils/dataset_test.py
@@ -55,14 +55,14 @@ class GenCsvFromImagesTest(unittest.TestCase):
 
   def test_add_label_false(self):
     result = self._test_helper(add_label=False)
-    images = [row[1] for row in result]
-    self.assertCountEqual(images, self.test_images)
+    labels = [row[2] for row in result]
+    exp_labels = ['']*self.NUM_IMAGES
+    self.assertCountEqual(labels, exp_labels)
 
   def test_add_label_true(self):
     result = self._test_helper(add_label=True)
-    image_label_pairs = [(row[1], row[2]) for row in result]
-    self.assertCountEqual(
-        image_label_pairs, list(zip(self.test_images, self.test_labels)))
+    labels = [row[2] for row in result]
+    self.assertCountEqual(labels, self.test_labels)
 
   def test_input_dir_does_not_exist(self):
     test_dir = '/path/to/non/existent/dir'
@@ -75,6 +75,13 @@ class GenCsvFromImagesTest(unittest.TestCase):
     result = self._test_helper(dataset_type=dataset_type)
     dataset_types = [row[0] for row in result]
     self.assertCountEqual(dataset_types, [dataset_type]*self.NUM_IMAGES)
+
+  def test_out_path_prefix(self):
+    # Check that the out_path_prefix is present in output CSV
+    out_path_prefix = 'gs://path/to/images'
+    result = self._test_helper(out_path_prefix=out_path_prefix)
+    for row in result:
+      self.assertIn(out_path_prefix, row[1])
 
 
 class GenCsvFromAnnotationsTest(unittest.TestCase):


### PR DESCRIPTION
This changes adds support for the --out_path_prefix flag in cloud-vision-utils.dataset.gen_csv_from_images().

The flag allows the image file to be prepended with a custom path in the outputted AutoML dataset CSV, e.g.
image1.jpg -> gs://path/to/images/image1.jpg