### PR TITLE
Update GSuite exporter version

### DIFF
--- a/tools/gsuite-exporter/setup.py
+++ b/tools/gsuite-exporter/setup.py
@@ -34,6 +34,7 @@ setup(
     version='0.0.3',
     description='GSuite Admin API Exporter',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     author='Google Inc.',
     author_email='ocervello@google.com',
     packages=find_packages(exclude=['contrib', 'docs', 'tests']),

--- a/tools/gsuite-exporter/setup.py
+++ b/tools/gsuite-exporter/setup.py
@@ -31,7 +31,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='gsuite-exporter',
-    version='0.0.2',
+    version='0.0.3',
     description='GSuite Admin API Exporter',
     long_description=long_description,
     author='Google Inc.',


### PR DESCRIPTION
Had forgotten to update the package version after #232. This is breaking the `terraform-google-gsuite-export` package in some cases (I've received an email from a customer), so need to be merged ASAP.

@AdrienWalkowiak if you can help expedite this, thanks :)