### PR TITLE
Adding CI checks for java formatting. Updating exclusion list.

### DIFF
--- a/cloudbuild/Dockerfile
+++ b/cloudbuild/Dockerfile
@@ -26,4 +26,9 @@ RUN make install
 
 RUN npm install gts
 
+# Install java + google-java-format jar
+RUN apt-get install -y default-jdk
+RUN wget https://github.com/google/google-java-format/releases/download/google-java-format-1.7/google-java-format-1.7-all-deps.jar --directory-prefix=/usr/share/java/
+
+
 ENTRYPOINT ["make"]

--- a/helpers/exclusion_list.txt
+++ b/helpers/exclusion_list.txt
@@ -12,7 +12,6 @@ tools/dataproc-edge-node
 tools/dns-sync
 tools/gce-google-keys-to-cmek
 tools/gce-quota-sync
-tools/gce-usage-log
 tools/gcp-arch-viz
 tools/gcs-bucket-mover
 tools/gsuite-exporter

--- a/helpers/format.sh
+++ b/helpers/format.sh
@@ -67,5 +67,16 @@ do
                 exit 1
             fi
         fi
+
+        echo "Formatting java files (if any)"
+
+        FILES_TO_FORMAT=$(find $FOLDER -type f -name "*.java")
+        if [[ ! -z "$FILES_TO_FORMAT" ]]
+        then
+            # format all java files in place
+            java -jar /usr/share/java/google-java-format-1.7-all-deps.jar -r $FILES_TO_FORMAT > /dev/null
+        else
+            echo "No java files found for $FOLDER - SKIP"
+        fi
     fi
 done


### PR DESCRIPTION
Adding lint check for java using google-java-format-1.7.

Removing tools/gce-usage-log from the exclusion list (only folder in tools and examples with correctly formatted java files).