### PR TITLE
SLO Generator - Always cast threshold_bucket to int

### DIFF
--- a/tools/slo-generator/setup.py
+++ b/tools/slo-generator/setup.py
@@ -29,7 +29,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(name='slo-generator',
-      version='0.1.6',
+      version='0.1.7',
       description='SLO generator',
       long_description=long_description,
       long_description_content_type='text/markdown',

--- a/tools/slo-generator/slo_generator/backends/stackdriver.py
+++ b/tools/slo-generator/slo_generator/backends/stackdriver.py
@@ -140,7 +140,7 @@ class StackdriverBackend(MetricBackend):
         project_id = kwargs['project_id']
         measurement = kwargs['measurement']
         filter_valid = measurement['filter_valid']
-        threshold_bucket = measurement['threshold_bucket']
+        threshold_bucket = int(measurement['threshold_bucket'])
         good_below_threshold = measurement.get('good_below_threshold', True)
 
         # Query 'valid' events


### PR DESCRIPTION
 Terraform `jsonencode` function doesn't convert all fields in a nested JSON to there proper types, so we need to always cast strings to int to avoid issues when automating deployment of SLO generator. 