### PR TITLE
[Kafka2Avro example] Update to the latest versions of SBT, Beam, Scio and others

### DIFF
--- a/examples/dataflow-scala-kafka2avro/README.md
+++ b/examples/dataflow-scala-kafka2avro/README.md
@@ -94,7 +94,7 @@ CLASSPATH="target/pack/lib/*" java com.google.cloud.pso.kafka2avro.Object2Kafka 
 This is a streaming pipeline. It will keep running unless you cancel it. The
 default windowing policy is to group messages every 2 minutes, in a fixed
 window. To change the policy, please see 
-[the function `windowIn` in `Kafka2Avro.scala`](src/main/scala/com/google/cloud/pso/kafka2avro/Kafka2Avro.scala#L62-L72).
+[the function `windowIn` in `Kafka2Avro.scala`](src/main/scala/com/google/cloud/pso/kafka2avro/Kafka2Avro.scala#L60-L70).
 
 Once you have generated the JAR file using the `pack` command inside SBT, you
 can now launch the job in Dataflow to populate Kafka with some demo

--- a/examples/dataflow-scala-kafka2avro/build.sbt
+++ b/examples/dataflow-scala-kafka2avro/build.sbt
@@ -17,18 +17,19 @@
 import sbt._
 import Keys._
 
-val scioVersion = "0.7.0"
-val beamVersion = "2.9.0"
+val scioVersion = "0.8.0-beta2"
+val beamVersion = "2.16.0"
+val kafkaClientsVersion = "2.3.1"
 val scalaMacrosVersion = "2.1.1"
-val pureconfigVersion = "0.10.1"
-val avro4sVersion = "2.0.2"
-val slf4jVersion = "1.7.25"
+val pureconfigVersion = "0.12.1"
+val avro4sVersion = "3.0.4"
+val slf4jVersion = "1.7.29"
 
 lazy val commonSettings = Defaults.coreDefaultSettings ++ Seq(
   organization := "com.google.cloud.pso",
   // Semantic versioning http://semver.org/
-  version := "0.1.0-SNAPSHOT",
-  scalaVersion := "2.12.8",
+  version := "0.2.0-SNAPSHOT",
+  scalaVersion := "2.12.10",
   scalacOptions ++= Seq("-target:jvm-1.8",
                         "-deprecation",
                         "-feature",
@@ -57,6 +58,7 @@ lazy val root: Project = project
       "org.apache.beam" % "beam-runners-direct-java" % beamVersion,
       "org.apache.beam" % "beam-runners-google-cloud-dataflow-java" % beamVersion,
       "org.apache.beam" % "beam-sdks-java-io-kafka" % beamVersion,
+      "org.apache.kafka" % "kafka-clients" % kafkaClientsVersion,
       // Configuration library
       "com.github.pureconfig" %% "pureconfig" % pureconfigVersion,
       // Avro schema automation

--- a/examples/dataflow-scala-kafka2avro/project/build.properties
+++ b/examples/dataflow-scala-kafka2avro/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.4

--- a/examples/dataflow-scala-kafka2avro/project/plugins.sbt
+++ b/examples/dataflow-scala-kafka2avro/project/plugins.sbt
@@ -1,3 +1,2 @@
-addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
-addSbtPlugin("org.xerial.sbt" % "sbt-pack" % "0.11")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
+addSbtPlugin("org.xerial.sbt" % "sbt-pack" % "0.12")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")

--- a/examples/dataflow-scala-kafka2avro/src/main/scala/com/google/cloud/pso/kafka2avro/Kafka2Avro.scala
+++ b/examples/dataflow-scala-kafka2avro/src/main/scala/com/google/cloud/pso/kafka2avro/Kafka2Avro.scala
@@ -107,7 +107,7 @@ object Kafka2Avro {
 
     Logger.info("All bytes have been properly twisted. Congratulations.")
 
-    sc.close
+    sc.run
   }
 
   /** Read data from Kafka, and return the messages ignoring the keys. */

--- a/examples/dataflow-scala-kafka2avro/src/main/scala/com/google/cloud/pso/kafka2avro/Object2Kafka.scala
+++ b/examples/dataflow-scala-kafka2avro/src/main/scala/com/google/cloud/pso/kafka2avro/Object2Kafka.scala
@@ -78,7 +78,7 @@ object Object2Kafka {
 
     Logger.info("All done. Give me an E, give me a T, give me an L!")
 
-    sc.close
+    sc.run
   }
 
   /** Generate a SCollection of objects **/


### PR DESCRIPTION
I am the original author of this example, that was submitted initially some months ago.

I am planning to write a blog post to showcase how to read from Kafka using Dataflow with Scala, and I will be referencing to this example, so I am submitting a pull request to update it to the latest versions of Scio, Apache Beam, SBT and the rest of dependencies. I am also removing two SBT plugins that were not really used in the example.

Currently (before this PR), this example is using Apache 2.9.0, [which will be deprecated in Dataflow next week](https://cloud.google.com/dataflow/docs/support/sdk-version-support-status#apache-beam-2x-sdks).

With the update to Apache Beam 2.16.0, I also had to include a new dependency for `kafka-clients`. This has changed since Beam 2.9.0, that's why I need to include the dependency now.