### PR TITLE
Cloud Composer CI/CD example

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The examples folder contains example solutions across a variety of Google Cloud 
 * [BigQuery Pipeline Utility](tools/bqpipeline)  - Python utility class for defining data pipelines in BigQuery.
 * [Bigtable Dataflow Cryptocurrencies Exchange RealTime Example](examples/cryptorealtime) - Apache Beam example that reads from the Crypto Exchanges WebSocket API as Google Cloud Dataflow pipeline and saves the feed in Google Cloud Bigtable. Real time visualization and query examples from GCP Bigtable running on Flask server are included.
 * [Cloud Composer Examples](examples/cloud-composer-examples) - Examples of using Cloud Composer, GCP's managed Apache Airflow service.
+* [Cloud Composer CI/CD](examples/cloud-composer-cicd) - Examples of using Cloud Build to deploy airflow DAGs to Cloud Composer.
 * [Cloud Function VM Delete Event Handler Example](examples/gcf-pubsub-vm-delete-event-handler) - Solution to automatically delete A records in Cloud DNS when a VM is deleted.  This solution implements a [Google Cloud Function][gcf] [Background Function][gcf-bg] triggered on `compute.instances.delete` events published through [Stackdriver Logs Export][logs-export].
 * [Cloud SQL Custom Metric](examples/cloud-sql-custom-metric) - An example of creating a Stackdriver custom metric monitoring Cloud SQL Private Services IP consumption.
 * [CloudML Bank Marketing](examples/cloudml-bank-marketing) - Notebook for creating a classification model for marketing using CloudML.

--- a/examples/cloud-composer-cicd/.gitignore
+++ b/examples/cloud-composer-cicd/.gitignore
@@ -1,0 +1,9 @@
+__pycache__
+logs/
+.direnv
+.envrc
+airflow.cfg
+airflow.db
+unittests.cfg
+tmp/
+deployed/

--- a/examples/cloud-composer-cicd/Dockerfile
+++ b/examples/cloud-composer-cicd/Dockerfile
@@ -1,0 +1,18 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+
+
+FROM python:3.7
+
+COPY requirements.txt ./
+RUN pip3 install --no-cache-dir -r requirements.txt
+ENV AIRFLOW_HOME=/workspace/airflow
+ENV AIRFLOW__CORE__LOAD_EXAMPLES=False

--- a/examples/cloud-composer-cicd/README.md
+++ b/examples/cloud-composer-cicd/README.md
@@ -1,0 +1,48 @@
+# Cloud Composer Examples
+
+This example demonstrates how to test Airflow DAGs using then deploy them to
+Cloud Composer using with Cloud Build.
+
+## Run build using Cloud Build
+
+The included cloudbuild.yaml file has the following flow:
+1. Build Airflow DAGs Builder: Builds a docker image with airflow dependencies included
+2. Validation Test: Check that the DAGs load correctly
+3. End to End Test: Backfill DAGs for a specific date with some variables set.
+4. Deploy DAGs: copy DAGs to a target Cloud Composer DAGs folder in GCS
+
+To enable this,
+* Create a Cloud Build trigger, and point it at this the `examples/cloud-composer-cicd/cloudbuild.yaml` file.
+* Set the substitution variable `_DEPLOY_DAGS_LOCATION` to the GCS path that your cloud composer environment is using for dags eg: `gs://my-composer-env-bucket/dags/`
+* Set the substitution variable `_DIRECTORY` to `examples/cloud-composer-cicd` (this allows the `cloudbuild.yaml` to be generalized for other project structures).
+
+Now you can trigger the build.
+
+## Running validation test locally
+
+The file `dag_integrity_test.py` will test the DAG integrity of the available airflow environment.
+To test the dags folder in this example locally, you can run:
+
+```
+pip install -r requirements.txt
+export AIRFLOW_HOME=`pwd`/tmp
+export AIRFLOW__CORE__LOAD_EXAMPLES=False
+export AIRFLOW__CORE__DAGS_FOLDER=`pwd`/dags
+airflow initdb
+python -m unittest tests/dag_integrity_test.py
+```
+
+## Running build locally with cloud build emulator
+
+Alternatively you can run these tests locally using the cloud build emulator. This requires docker to be running.
+
+```
+cloud-build-local --config=cloudbuild.yaml --dryrun=false \
+  --substitutions=_DEPLOY_DAGS_LOCATION=gs://my-composer-env-bucket/dags/,_DIRECTORY=examples/cloud-composer-cicd ../../
+```
+
+You can run the full build without deploying your DAGs by directing the DAGs to /tmp
+```
+cloud-build-local --config=cloudbuild.yaml --dryrun=false \
+  --substitutions=_DEPLOY_DAGS_LOCATION=/tmp,_DIRECTORY=examples/cloud-composer-cicd ../../
+```

--- a/examples/cloud-composer-cicd/README.md
+++ b/examples/cloud-composer-cicd/README.md
@@ -12,7 +12,7 @@ The included cloudbuild.yaml file has the following flow:
 4. Deploy DAGs: copy DAGs to a target Cloud Composer DAGs folder in GCS
 
 To enable this,
-* Create a Cloud Build trigger, and point it at this the `examples/cloud-composer-cicd/cloudbuild.yaml` file.
+* Create a Cloud Build trigger, and point it at the `examples/cloud-composer-cicd/cloudbuild.yaml` file.
 * Set the substitution variable `_DEPLOY_DAGS_LOCATION` to the GCS path that your cloud composer environment is using for dags eg: `gs://my-composer-env-bucket/dags/`
 * Set the substitution variable `_DIRECTORY` to `examples/cloud-composer-cicd` (this allows the `cloudbuild.yaml` to be generalized for other project structures).
 

--- a/examples/cloud-composer-cicd/cloudbuild.yaml
+++ b/examples/cloud-composer-cicd/cloudbuild.yaml
@@ -1,0 +1,81 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  id: Pull docker cache
+  entrypoint: 'bash'
+  args:
+  - '-c'
+  - |
+   docker pull gcr.io/$PROJECT_ID/airflow-dags-builder:latest || exit 0
+- name: gcr.io/cloud-builders/docker
+  id: Build Airflow DAGs Builder
+  args: [
+      'build',
+      '-t', 'gcr.io/$PROJECT_ID/airflow-dags-builder',
+      '--cache-from', 'gcr.io/$PROJECT_ID/airflow-dags-builder:latest',
+      './'
+    ]
+  dir: ${_DIRECTORY}
+- name: 'gcr.io/$PROJECT_ID/airflow-dags-builder'
+  id: Validation Test
+  # Validate the integrity of the DAG files.
+  entrypoint: python
+  env:
+  - AIRFLOW__CORE__DAGS_FOLDER=/workspace/${_DIRECTORY}/dags
+  args:
+  - -m
+  - unittest
+  - tests/dag_integrity_test.py
+  dir: ${_DIRECTORY}
+- name: 'gcr.io/$PROJECT_ID/airflow-dags-builder'
+  # Actually run some DAGs with test data, this type of test is less common and requires
+  # more setup, creating test data sets, ensuring your task IO is configured
+  # via airflow Variables, etc.
+  # To succeed, these need to complete before the cloudbuild timeout.
+  id: End to End Test
+  entrypoint: bash
+  env:
+  - AIRFLOW__CORE__DAGS_FOLDER=/workspace/${_DIRECTORY}/dags
+  dir: ${_DIRECTORY}
+  # dir: examples/cloud-composer-cicd
+  args:
+  - -c
+  - |
+    pwd
+    ls -l
+    # Init an empty airflow metadata db
+    airflow initdb
+    # Initialise variables to configure airflow DAGs
+    airflow variables -s input gs://test-input-bucket/
+    airflow variables -s output gs://test-output-bucket/
+    # Run a backfill of our DAG for a specific date, add more dags here if required.
+    airflow backfill echo_and_wait --start_date=2020-01-03 --end_date=2020-01-03
+    ret=$?
+    # Cat the task logs so we can see when there was any error
+    find /workspace/airflow/logs/ -type f -name *.log | sort | xargs cat
+    # Fail if the backfill failed.
+    exit $ret
+- name: gcr.io/cloud-builders/gsutil
+  # Deploy the DAGs to your composer environment DAGs GCS folder
+  id: Deploy DAGs
+  args:
+  - -m
+  - rsync
+  - -r
+  - -c
+  - -x
+  - .*\.pyc|airflow_monitoring.py
+  - /workspace/${_DIRECTORY}/dags/
+  - ${_DEPLOY_DAGS_LOCATION}
+  dir: ${_DIRECTORY}
+images: ['gcr.io/$PROJECT_ID/airflow-dags-builder:latest']

--- a/examples/cloud-composer-cicd/dags/echo_and_wait.py
+++ b/examples/cloud-composer-cicd/dags/echo_and_wait.py
@@ -1,0 +1,48 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+"""
+This DAG is trivial, it has a sequence of two tasks that simply wait 10 seconds each.
+"""
+
+from datetime import timedelta
+from airflow.models import DAG
+from airflow.operators.bash_operator import BashOperator
+
+import airflow
+
+VERSION = 1
+DEFAULT_ARGS = {
+    'owner': 'airflow',
+    'start_date': airflow.utils.dates.days_ago(7)
+}
+
+with DAG(dag_id='echo_and_wait',
+         default_args=DEFAULT_ARGS,
+         schedule_interval='@daily',
+         dagrun_timeout=timedelta(minutes=60)) as dag:
+    TASK1 = BashOperator(task_id='echo_and_wait1',
+                         bash_command=f"""
+            echo DAG echo_and_wait1 version = {VERSION}
+            echo start;
+            sleep 10;
+            echo stop;
+        """)
+    TASK2 = BashOperator(task_id='echo_and_wait2',
+                         bash_command=f"""
+            echo DAG echo_and_wait2 version = {VERSION}
+            echo start;
+            sleep 10;
+            echo stop;
+        """)
+    TASK1.set_downstream(TASK2)
+
+if __name__ == "__main__":
+    dag.cli()

--- a/examples/cloud-composer-cicd/requirements.txt
+++ b/examples/cloud-composer-cicd/requirements.txt
@@ -1,0 +1,5 @@
+# These are used by the docker image that validates the DAG syntax,
+# they are already included in Cloud Composer by default.
+# If you any other dependencies here, you must also ensure separately cloud composer has them.
+werkzeug==0.15.4 # needed for airflow 1.10.3
+apache-airflow[gcp]==1.10.3

--- a/examples/cloud-composer-cicd/tests/dag_integrity_test.py
+++ b/examples/cloud-composer-cicd/tests/dag_integrity_test.py
@@ -1,0 +1,38 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+"""
+DAG Integrity Tests
+"""
+
+import unittest
+from airflow.models import DagBag
+
+
+class TestDags(unittest.TestCase):
+    """DAG Test Case"""
+
+    LOAD_THRESHOLD_SECONDS = 2
+
+    def setUp(self):
+        self.dagbag = DagBag()
+
+    def test_dags_syntax(self):
+        """Assert DAG bag load correctly"""
+        for key in self.dagbag.dags:
+            print(key)
+        self.assertFalse(
+            len(self.dagbag.import_errors),
+            f"DAG import errors. Errors: {self.dagbag.import_errors}")
+
+
+if __name__ == '__main__':
+    SUITE = unittest.TestLoader().loadTestsFromTestCase(TestDags)
+    unittest.TextTestRunner(verbosity=2).run(SUITE)


### PR DESCRIPTION
Example that uses Cloud build to test airflow DAGs and deploy them to Cloud Composer.

When deploying cloud composer environments, people often ask, "How do I test my DAGs".
The answer is CI/CD

* DAG integrity / validation tests (check it load correctly).
* DAG execution tests (run the complete dag)

Then deploy.

I've prepared an example of this using cloud build.

PSO Eng Bug Id = 147466944
