### PR TITLE
deleting tables after done recording benchmark results

### DIFF
--- a/examples/bq_file_load_benchmark/load_benchmark_tools/benchmark_load_table.py
+++ b/examples/bq_file_load_benchmark/load_benchmark_tools/benchmark_load_table.py
@@ -229,10 +229,11 @@ class BenchmarkLoadTable(object):
 
         except exceptions.BadRequest as e:
             logging.error(e.message)
-            self.bq_client.delete_table(self.benchmark_table_util.table_ref)
-            logging.info('Deleting table {0:s}'.format(
-                self.job_destination_table
-            ))
+            
+        self.bq_client.delete_table(self.benchmark_table_util.table_ref)
+        logging.info('Deleting table {0:s}'.format(
+            self.job_destination_table
+        ))
 
 
 


### PR DESCRIPTION
- constantly running the file loader benchmark results in lots of tables = unnecessary expense
- modifying the code to delete the tables once the results are recorded