### PR TITLE
Fix Cloud Shell link in Fixity example

### DIFF
--- a/examples/gcs-fixity-function/docs/setup.md
+++ b/examples/gcs-fixity-function/docs/setup.md
@@ -1,7 +1,7 @@
 # Setup
 Clone this repository and run locally, or use Cloud Shell to walk through the steps:
 
-[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.png)](https://ssh.cloud.google.com/cloudshell/open?page=shell&cloudshell_git_repo=https://github.com/GoogleCloudPlatform/professional-services&cloudshell_tutorial=gcs-fixity-function%2Fdocs%2Fsetup.md)
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.png)](https://ssh.cloud.google.com/cloudshell/open?page=shell&cloudshell_git_repo=https://github.com/GoogleCloudPlatform/professional-services&cloudshell_tutorial=examples%2Fgcs-fixity-function%2Fdocs%2Fsetup.md)
 
 ## Prepare
 To setup this function, run through these instructions from the root of the repository or using Cloud Shell. 


### PR DESCRIPTION
The Cloud Shell link in the README for the Fixity example was broken. This PR resolves that.