### PR TITLE
Limiting flake to logical checks

### DIFF
--- a/helpers/check_format.sh
+++ b/helpers/check_format.sh
@@ -45,7 +45,7 @@ validate_python() {
     # Initialize FILES_TO_LINT to empty string
     FILES_TO_LINT=""
 
-    (cd $FOLDER && flake8 --exclude=.git,__pycache__,.venv,venv --select=E9,F)
+    (cd $FOLDER && flake8 --exclude=.git,__pycache__,.venv,venv --select=E9,F,C)
     if [ $? -ne 0 ]
     then
        need_formatting $FOLDER
@@ -195,4 +195,3 @@ do
         echo "$FOLDER in exclusion list - SKIP  "
     fi
 done
-

--- a/helpers/check_format.sh
+++ b/helpers/check_format.sh
@@ -45,7 +45,7 @@ validate_python() {
     # Initialize FILES_TO_LINT to empty string
     FILES_TO_LINT=""
 
-    (cd $FOLDER && flake8 --exclude=.git,__pycache__,.venv,venv --ignore=E501,W5)
+    (cd $FOLDER && flake8 --exclude=.git,__pycache__,.venv,venv --select=E9,F)
     if [ $? -ne 0 ]
     then
        need_formatting $FOLDER


### PR DESCRIPTION
In this PR:

 Flake8 is limited to [logic checks](https://flake8.pycqa.org/en/latest/user/error-codes.html#error-violation-codes) as yapf is used to for formatting related checks

Closes #476 