### PR TITLE
set up directory for sql gravity

### DIFF
--- a/tools/sql-gravity/README.md
+++ b/tools/sql-gravity/README.md
@@ -1,0 +1,3 @@
+# BigQuery Sql Gravity
+
+This directory contains the tools built by BigQuery SQL Gravity. Projects details will be added as they start.


### PR DESCRIPTION
Set up the directory for bigquery sql gravity OSS projects

This summer, bigquery sql gravity team will welcome many OSS contributors to join and contribute to sql migration related tools. We'd like to set up a directory to host all the projects.