### PR TITLE
Column family names not correctly extracted in helper script

### DIFF
--- a/examples/bigtable-change-key/scripts/copy_schema_to_new_table.sh
+++ b/examples/bigtable-change-key/scripts/copy_schema_to_new_table.sh
@@ -41,7 +41,7 @@ cbt createtable "$OUTPUT_TABLE"
 
 cbt ls "$INPUT_TABLE" | tail -n+3 | while read -r line
 do
-  FAMILY=$( echo "$line" | cut -d " " -f 1 )
+  FAMILY=$( echo "$line" | cut -f 1 )
   echo Adding column family "$FAMILY"
   cbt createfamily "$OUTPUT_TABLE" "$FAMILY"
 done


### PR DESCRIPTION
This is a minor fix in one helper script.

It tries to extract the column families names from an existing Bigtable table. It was not correctly splitting the output because it was using space. `cbt` now reports the output separated by tabs (default delimiter with `cut`).