### PR TITLE
Add direct runner to pipeline

### DIFF
--- a/examples/bigtable-change-key/pom.xml
+++ b/examples/bigtable-change-key/pom.xml
@@ -234,7 +234,6 @@
             <groupId>org.apache.beam</groupId>
             <artifactId>beam-runners-direct-java</artifactId>
             <version>${beam.version}</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
This adds the Beam DirectRunner for runtime too. Currently, it is only used for testing.

I am the author of this example, and I am preparing a blog post explaining how to use this example. In that post, we are using the DirectRunner, so users don't need a Google Cloud project just to run a small example. In the original code, the DirectRunner was not included for runtime, only for test.