### PR TITLE
deps: add max version for google-cloud-* libraries

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -3,11 +3,10 @@ steps:
   name: gcr.io/$PROJECT_ID/make
   args: [test]
   waitFor: ['-']
-# Commented due to Unit test failures (Check https://github.com/GoogleCloudPlatform/professional-services/issues/532)
-# - id: tools/hive-bigquery
-#   name: google/cloud-sdk
-#   args: [gcloud, builds, submit, tools/hive-bigquery/, --config=tools/hive-bigquery/cloudbuild.yaml]
-#   waitFor: ['-']
+- id: tools/hive-bigquery
+  name: google/cloud-sdk
+  args: [gcloud, builds, submit, tools/hive-bigquery/, --config=tools/hive-bigquery/cloudbuild.yaml]
+  waitFor: ['-']
 - id: examples/cloud-composer-examples
   name: google/cloud-sdk
   args: [gcloud, builds, submit, examples/cloud-composer-examples/,

--- a/tools/hive-bigquery/setup.py
+++ b/tools/hive-bigquery/setup.py
@@ -28,15 +28,15 @@ here = pathlib.Path(__file__).parent
 requirements = [
     'pyhive[hive] >= 0.6.1',
     'pymysql >= 0.9.3',
-    'google-cloud-bigquery >= 1.9.0',
-    'google-cloud-storage >= 1.14.0',
-    'google-cloud-kms >= 1.0.0',
+    'google-cloud-bigquery >= 1.9.0, < 2.0.0dev',
+    'google-cloud-storage >= 1.14.0, < 2.0.0dev',
+    'google-cloud-kms >= 1.0.0, < 2.0.0dev',
     "setuptools >= 34.0.0",
 ]
 
 setup(
     name='cloud-pso-hive-bigquery',
-    version='0.0.1',
+    version='0.0.2',
     description='hive to bigquery',
     url='https://github.com/GoogleCloudPlatform/professional-services/tree/master/tools/hive-bigquery',
     classifiers=[


### PR DESCRIPTION
Version 2.0 includes breaking changes. The tool will require code
updates to work with the latest libraries. In the meantime, limit the
package versions to pre-2.0 versions.

* re-enable hive-bigquery tests

Towards #532