### PR TITLE
Translate additionalProperties API properties into arrays.

### DIFF
--- a/tools/asset-inventory/asset_inventory/api_schema.py
+++ b/tools/asset-inventory/asset_inventory/api_schema.py
@@ -177,9 +177,59 @@ class APISchema(object):
             return cls._get_properties_map_field_list(
                 property_name, property_value['items'],
                 resources, seen_resources)
-        # we can't safely process labels or additionalProperties fields so
-        # skip them
+        # convert additionalProperties fields to a dict
+        # of name value pairs for a more regular schema.
+        if 'additionalProperties' in property_value:
+            fields = [{'name': 'name',
+                       'field_type': 'STRING',
+                       'description': 'additionalProperties name',
+                       'mode': 'NULLABLE'}]
+            fields.append(
+                cls._property_to_field(
+                    'value',
+                    property_value['additionalProperties'],
+                    resources, seen_resources))
+            return fields
+        # unknown property type.
         return None
+
+    @classmethod
+    def _property_to_field(cls, property_name, property_value,
+                           resources, seen_resources):
+        """Convert api property to BigQuery field.
+
+        Args:
+            property_name: name of API property
+            property_value: value of the API property.
+            resources: dict of all other resources that might be referenced by
+            the API schema through reference types ($ref values).
+            seen_resources: dict of types we have processed to prevent endless
+        Returns:
+            BigQuery field or None if the field should be skipped.
+        """
+        field = {'name': property_name}
+        property_type = property_value.get('type', None)
+        bigquery_type = cls._get_bigquery_type_for_property(
+            property_value, resources)
+        field['field_type'] = bigquery_type
+        if 'description' in property_value:
+            field['description'] = property_value['description'][:1024]
+
+        # array fields are BigQuery repeated fields, and convert
+        # additionalProperties to repeated lists of key value pairs.
+        if (property_type == 'array' or
+            'additionalProperties' in property_value):
+            field['mode'] = 'REPEATED'
+        else:
+            field['mode'] = 'NULLABLE'
+
+        if bigquery_type == 'RECORD':
+            fields_list = cls._get_properties_map_field_list(
+                property_name, property_value, resources, seen_resources)
+            if not fields_list:
+                return None
+            field['fields'] = fields_list
+        return field
 
     @classmethod
     def _properties_map_to_field_list(cls, properties_map, resources,
@@ -198,24 +248,10 @@ class APISchema(object):
         """
         fields = []
         for property_name, property_value in properties_map.items():
-            field = {'name': property_name}
-            property_type = property_value.get('type', None)
-            bigquery_type = cls._get_bigquery_type_for_property(
-                property_value, resources)
-            field['field_type'] = bigquery_type
-            if 'description' in property_value:
-                field['description'] = property_value['description'][:1024]
-            if property_type == 'array':
-                field['mode'] = 'REPEATED'
-            else:
-                field['mode'] = 'NULLABLE'
-            if bigquery_type == 'RECORD':
-                fields_list = cls._get_properties_map_field_list(
-                    property_name, property_value, resources, seen_resources)
-                if not fields_list:
-                    continue
-                field['fields'] = fields_list
-            fields.append(field)
+            field = cls._property_to_field(property_name, property_value,
+                                           resources, seen_resources)
+            if field is not None:
+                fields.append(field)
         return fields
 
     @classmethod

--- a/tools/asset-inventory/asset_inventory/bigquery_schema.py
+++ b/tools/asset-inventory/asset_inventory/bigquery_schema.py
@@ -293,6 +293,7 @@ def _sanitize_property(property_name, parent, depth, num_properties):
         # prune the value.
         parent.pop(new_property_name)
 
+
 def remove_duplicates(properties):
     """Ensure no two property in properties share the same name.
 
@@ -441,7 +442,13 @@ def enforce_schema_data_types(resource, schema):
         if field_name in resource:
             resource_value = resource[field_name]
             if field.get('mode', 'NULLABLE') == 'REPEATED':
-                if not isinstance(resource_value, list):
+                # satisfy array condition by converting dict into
+                # repeated name value records.
+                if (field['field_type'] == 'RECORD' and
+                    isinstance(resource_value, dict)):
+                    resource_value = [{'name': key, 'value': val}
+                                      for (key, val) in resource_value.items()]
+                elif not isinstance(resource_value, list):
                     resource_value = [resource_value]
                 new_array = []
                 for value in resource_value:

--- a/tools/asset-inventory/setup.py
+++ b/tools/asset-inventory/setup.py
@@ -16,7 +16,7 @@ from setuptools import setup
 
 setup(
     name='asset-inventory',
-    version='1.0.0',
+    version='2.0.0',
     description=
     'Generate Cloud Asset Inventory exports and Import To BigQuery.',
     # pylint: disable=line-too-long

--- a/tools/asset-inventory/tests/test_api_schema.py
+++ b/tools/asset-inventory/tests/test_api_schema.py
@@ -270,3 +270,76 @@ class TestApiSchema(unittest.TestCase):
             discovery_doc)
         schema.sort()
         self.assertEqual(schema, [])
+
+    def test_string_additional_properties(self):
+        api_properties = {
+            'property-1': {
+                'type': 'object',
+                'additionalProperties': {
+                    'type': 'string',
+                    'description': 'description-1.'
+                },
+                'description': 'description-1'
+            },
+        }
+        resources = {}
+        schema = APISchema._properties_map_to_field_list(api_properties,
+                                                         resources, {})
+        schema.sort()
+        self.assertEqual(
+            schema,
+            [{'name': 'property-1',
+              'field_type': 'RECORD',
+              'description': 'description-1',
+              'mode': 'REPEATED',
+              'fields': [{'name': 'name',
+                          'field_type': 'STRING',
+                          'description': 'additionalProperties name',
+                          'mode': 'NULLABLE'},
+                         {'name': 'value',
+                          'field_type': 'STRING',
+                          'description': 'description-1.',
+                          'mode': 'NULLABLE'}]}])
+
+    def test_nested_additional_properties(self):
+        api_properties = {
+            'property-1': {
+                'type': 'object',
+                'additionalProperties': {
+                    '$ref': 'NestedObject',
+                    'description': 'description-1.'
+                },
+                'description': 'description-1'
+            },
+        }
+        resources = {
+            'NestedObject': {
+                'properties': {
+                    'property-2': {
+                        'type': 'string',
+                        'description': 'description-2.'
+                    }
+                }
+            }
+        }
+        schema = APISchema._properties_map_to_field_list(api_properties,
+                                                         resources, {})
+        schema.sort()
+        self.assertEqual(
+            schema,
+            [{'name': 'property-1',
+              'field_type': 'RECORD',
+              'description': 'description-1',
+              'mode': 'REPEATED',
+              'fields': [{'name': 'name',
+                          'field_type': 'STRING',
+                          'description': 'additionalProperties name',
+                          'mode': 'NULLABLE'},
+                         {'name': 'value',
+                          'field_type': 'RECORD',
+                          'description': 'description-1.',
+                          'mode': 'NULLABLE',
+                          'fields': [{'name': 'property-2',
+                                      'field_type': 'STRING',
+                                      'description': 'description-2.',
+                                      'mode': 'NULLABLE'}]}]}])

--- a/tools/asset-inventory/tests/test_bigquery_schema.py
+++ b/tools/asset-inventory/tests/test_bigquery_schema.py
@@ -255,6 +255,51 @@ class TestBigQuerySchema(unittest.TestCase):
         self.assertEqual(bigquery_schema.enforce_schema_data_types(
             {'property_7': [{'property_1': 'invalid'}, 33]}, schema), {})
 
+    def test_addtional_properties_repeated_string(self):
+        schema = [
+            {'name': 'property_1',
+             'field_type': 'RECORD',
+             'description': 'description-1',
+             'mode': 'REPEATED',
+             'fields': [{'name': 'name',
+                         'field_type': 'STRING',
+                         'description': 'additionalProperties name',
+                         'mode': 'NULLABLE'},
+                        {'name': 'value',
+                         'field_type': 'STRING',
+                         'description': 'description-1.',
+                         'mode': 'NULLABLE'}]}]
+        self.assertEqual(
+            bigquery_schema.enforce_schema_data_types(
+                {'property_1': {'key1': 'a', 'key2': 'b'}}, schema),
+            {'property_1': [{'name': 'key1', 'value': 'a'},
+                            {'name': 'key2', 'value': 'b'}]})
+
+    def test_addtional_properties_repeated_record(self):
+        schema = [
+            {'name': 'property_1',
+             'field_type': 'RECORD',
+             'description': 'description-1',
+             'mode': 'REPEATED',
+             'fields': [{'name': 'name',
+                         'field_type': 'STRING',
+                         'description': 'additionalProperties name',
+                         'mode': 'NULLABLE'},
+                        {'name': 'value',
+                         'field_type': 'RECORD',
+                         'description': 'description-1.',
+                         'mode': 'NULLABLE',
+                         'fields': [{'name': 'property_2',
+                                     'field_type': 'STRING',
+                                     'description': 'description-2.',
+                                     'mode': 'NULLABLE'}]}]}]
+        self.assertEqual(
+            bigquery_schema.enforce_schema_data_types(
+                {'property_1': {'key1': {'property_2': 'a'},
+                                'key2': {'property_2': 'b'}}}, schema),
+            {'property_1': [{'name': 'key1', 'value': {'property_2': 'a'}},
+                            {'name': 'key2', 'value': {'property_2': 'b'}}]})
+
     def test_remove_duplicate_property(self):
         doc = {
             'ipAddress': 'value',


### PR DESCRIPTION
This changes the BigQuery schema and is not backwards compatible with prior
imports. Subsequent WRITE_APPEND import runs will fail with conflicting schema
errors. Users can archive existing datasets and start new ones if old data is
important.

Previously additionalProperties API properties were RECORD fields. As these are
user defined unstructured data they would just keep adding to the BigQuery table
schema as more and more user defined fields were added over time. This change
converts any additionalProperties API property into an array of name value pairs
where the value is the type of the additionalProperties property. This should
greatly reduce the number of columns in BigQuery tables taken up by user defined
labels or app engine version names.

This is another fix for Issue #533 