### PR TITLE
[slo-generator] Fix Prometheus window replacement to allow full expressions

### DIFF
--- a/tools/slo-generator/slo_generator/backends/prometheus.py
+++ b/tools/slo-generator/slo_generator/backends/prometheus.py
@@ -84,16 +84,16 @@ class PrometheusBackend:
         filter_valid = conf['measurement'].get('filter_valid')
 
         # Replace window by its value in the error budget policy step
-        expr_good = filter_good.replace('[window]', f'[{window}s]')
+        expr_good = filter_good.replace('[window', f'[{window}s')
         res_good = self.query(expr_good)
         good_count = PrometheusBackend.count(res_good)
 
         if filter_bad:
-            expr_bad = filter_bad.replace('[window]', f'[{window}s]')
+            expr_bad = filter_bad.replace('[window', f'[{window}s')
             res_bad = self.query(expr_bad, timestamp)
             bad_count = PrometheusBackend.count(res_bad)
         elif filter_valid:
-            expr_valid = filter_valid.replace('[window]', f'[{window}s]')
+            expr_valid = filter_valid.replace('[window', f'[{window}s')
             res_valid = self.query(expr_valid, timestamp)
             bad_count = PrometheusBackend.count(res_valid) - good_count
         else:

--- a/tools/slo-generator/slo_generator/backends/prometheus.py
+++ b/tools/slo-generator/slo_generator/backends/prometheus.py
@@ -53,7 +53,7 @@ class PrometheusBackend:
         conf = slo_config['backend']
         measurement = conf['measurement']
         expr = measurement['expression']
-        expression = expr.replace("[window]", f"[{window}s]")
+        expression = expr.replace("[window", f"[{window}s")
         data = self.query(expression, timestamp)
         LOGGER.debug(
             f"Expression: {expression} | Result: {pprint.pformat(data)}")


### PR DESCRIPTION
Currently we cannot specify expressions that use `[window:resolution]` in Prometheus. This PR fixes that.