### PR TITLE
[slo-generator] Fix unit testing

### DIFF
--- a/tools/slo-generator/.pylintrc
+++ b/tools/slo-generator/.pylintrc
@@ -1,15 +1,10 @@
 [MASTER]
 
-# A comma-separated list of package or module names from where C extensions may
-# be loaded. Extensions are loading into the active Python interpreter and may
-# run arbitrary code.
-extension-pkg-whitelist=
-
-# Add files or directories to the blacklist. They should be base names, not
+# Add files or directories to the deny list. They should be base names, not
 # paths.
 ignore=CVS
 
-# Add files or directories matching the regex patterns to the blacklist. The
+# Add files or directories matching the regex patterns to the deny list. The
 # regex matches against base names, not paths.
 ignore-patterns=
 
@@ -141,7 +136,8 @@ disable=print-statement,
         exception-escape,
         comprehension-escape,
         arguments-differ,
-        dangerous-default-value
+        dangerous-default-value,
+        logging-fstring-interpolation
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
@@ -191,7 +187,7 @@ never-returning-functions=sys.exit
 
 # Format style used to check logging format string. `old` means using %
 # formatting, while `new` is for `{}` formatting.
-logging-format-style=fstr
+logging-format-style=new
 
 # Logging modules to check that the string format arguments are in logging
 # function parameter format.

--- a/tools/slo-generator/setup.py
+++ b/tools/slo-generator/setup.py
@@ -48,10 +48,10 @@ setup(name='slo-generator',
       ],
       keywords='slo sli generator gcp',
       install_requires=[
-          'google-api-python-client', 'oauth2client', 'google-cloud-monitoring',
-          'google-cloud-pubsub', 'google-cloud-bigquery',
-          'prometheus-http-client', 'prometheus-client', 'pyyaml', 'opencensus',
-          'elasticsearch', 'pytz'
+          'google-api-python-client', 'oauth2client',
+          'google-cloud-monitoring', 'google-cloud-pubsub==1.7.0',
+          'google-cloud-bigquery', 'prometheus-http-client',
+          'prometheus-client', 'pyyaml', 'opencensus', 'elasticsearch', 'pytz'
       ],
       entry_points={
           'console_scripts': ['slo-generator=slo_generator.cli:main'],


### PR DESCRIPTION
This makes sure the unittests are passing by pinning a version on the `google-cloud-pubsub` package.
This also modified the .pylintrc file to allow new logging format as the `fstr` oiption was removed in 2.5 (see https://stackoverflow.com/a/59027338)