### PR TITLE
alerting_burn_rate_threshold is float

### DIFF
--- a/tools/slo-generator/slo_generator/report.py
+++ b/tools/slo-generator/slo_generator/report.py
@@ -72,7 +72,7 @@ class SLOReport:
                           **step,
                           lambdas={
                               'slo_target': float,
-                              'alerting_burn_rate_threshold': int
+                              'alerting_burn_rate_threshold': float
                           })
 
         # Set other fields


### PR DESCRIPTION
Currently only the int part is taken leading to false alerts.