### PR TITLE
Job doesn't need catch-up. Correct typo in dag.

### DIFF
--- a/tools/cuds-prioritized-attribution/composer/cud_correction_dag.py
+++ b/tools/cuds-prioritized-attribution/composer/cud_correction_dag.py
@@ -70,6 +70,7 @@ def format_commitment_table(templates_dict: Dict[str, Union[str, bool]], **kwarg
 
 with models.DAG('cud_correction_dag',
                 schedule_interval=datetime.timedelta(days=1),
+                catchup=False,
                 default_args=DEFAULT_DAG_ARGS,
                 params={
                     'billing_export_table_name': os.environ.get('billing_export_table_name'),

--- a/tools/cuds-prioritized-attribution/composer/dependencies/helper_function.py
+++ b/tools/cuds-prioritized-attribution/composer/dependencies/helper_function.py
@@ -111,7 +111,7 @@ def local_to_gcs(bucket_name: str, object_name: str, input_file: str) -> None:
         blob.upload_from_file(file_obj)
 
 
-def convert_to_schema(schema: List[Dict[str, str]) -> List[bigquery.SchemaField]:
+def convert_to_schema(schema: List[Dict[str, str]]) -> List[bigquery.SchemaField]:
     """Read the schema as a JSON and reformats as an array.
 
     Args:


### PR DESCRIPTION
- The job processes all data at once and doesn't need airflow's Catchup
processing to run on each missed scheduled interval, just running with the
latest date is good.

- Correct typo in type deceleration of convert_to_schema.
