### PR TITLE
Change call to get_bq_schema_string()

### DIFF
--- a/examples/dataflow-data-generator/data-generator-pipeline/data_generator_joinable_table.py
+++ b/examples/dataflow-data-generator/data-generator-pipeline/data_generator_joinable_table.py
@@ -144,7 +144,7 @@ def run(argv=None):
              # In this case we use the value passed in from the command line.
              data_args.output_bq_table,
              schema=None
-             if schema_inferred else data_gen.get_bq_schema_string(),
+             if schema_inferred else data_gen.get_bq_schema(),
              # Creates the table in BigQuery if it does not yet exist.
              create_disposition=beam.io.BigQueryDisposition.CREATE_IF_NEEDED,
              write_disposition=data_gen.write_disp,


### PR DESCRIPTION
To get_bq_schema() - that exists, the _string version does not. I've run this multiple times on Dataflow, it didn't run without changing this.

Fixes: https://github.com/GoogleCloudPlatform/professional-services/issues/595

Thanks
