### PR TITLE
Update docs, cross-project support, input standarization

### DIFF
--- a/tools/vm-migrator/Makefile
+++ b/tools/vm-migrator/Makefile
@@ -7,16 +7,19 @@ SOURCE_CSV=source.csv # actual default value
 INPUT_CSV=export.csv
 
 SOURCE_PROJECT=delivery-center-poc
-SOURCE_REGION=us-central1
-SOURCE_SUBNETWORK=default
-SOURCE_ZONE=us-central1-a
+SOURCE_REGION=europe-west3
+SOURCE_SUBNETWORK=test
+SOURCE_ZONE=europe-west3-c
 SOURCE_ZONE_2=
-SOURCE_ZONE_3=us-central1-b
+SOURCE_ZONE_3=
 
-# in this example source and target project are the same
-TARGET_PROJECT=
-TARGET_REGION=us-west1
-TARGET_SUBNETWORK=sub-01
+
+#TARGET_PROJECT=${SOURCE_PROJECT}
+# use the default target service account
+#TARGET_PROJECT_SA=$(gcloud projects describe ${TARGET_PROJECT} --format 'value(projectNumber)')-compute@developer.gserviceaccount.com
+#TARGET_PROJECT_SA_SCOPES=https://www.googleapis.com/auth/cloud-platform
+TARGET_REGION=europe-west4
+TARGET_SUBNETWORK=default
 
 # actual default values
 EXPORT_CSV=export.csv
@@ -63,7 +66,7 @@ migrate-subnet:
 		--source_zone_2=$(SOUCE_ZONE_2) --source_zone_3=$(SOURCE_ZONE_3) \
 		--target_project=$(TARGET_PROJECT) \
 		--target_project_sa=$(TARGET_PROJECT_SA) \
-		--target_project_sa_scopes=$(TARGET_PROJECT_SCOPES) \
+		--target_project_sa_scopes=$(TARGET_PROJECT_SA_SCOPES) \
 		--target_region=$(TARGET_REGION) \
 		--target_subnetwork=$(TARGET_SUBNETWORK) --source_csv=$(SOURCE_CSV) \
 		--filter_csv=$(FILTER_CSV) --input_csv=$(INPUT_CSV) \

--- a/tools/vm-migrator/Makefile
+++ b/tools/vm-migrator/Makefile
@@ -61,7 +61,10 @@ migrate-subnet:
 		--source_project=$(SOURCE_PROJECT) --source_region=$(SOURCE_REGION) \
 		--source_subnetwork=$(SOURCE_SUBNETWORK) --source_zone=$(SOURCE_ZONE) \
 		--source_zone_2=$(SOUCE_ZONE_2) --source_zone_3=$(SOURCE_ZONE_3) \
-		--target_project=$(TARGET_PROJECT) --target_region=$(TARGET_REGION) \
+		--target_project=$(TARGET_PROJECT) \
+		--target_project_sa=$(TARGET_PROJECT_SA) \
+		--target_project_sa_scopes=$(TARGET_PROJECT_SCOPES) \
+		--target_region=$(TARGET_REGION) \
 		--target_subnetwork=$(TARGET_SUBNETWORK) --source_csv=$(SOURCE_CSV) \
-		--export_csv=$(EXPORT_CSV) --filter_csv=$(FILTER_CSV) \
+		--filter_csv=$(FILTER_CSV) --input_csv=$(INPUT_CSV) \
 		--log_level=$(LOG_LEVEL)

--- a/tools/vm-migrator/Makefile
+++ b/tools/vm-migrator/Makefile
@@ -16,7 +16,7 @@ SOURCE_ZONE_3=
 
 #TARGET_PROJECT=${SOURCE_PROJECT}
 # use the default target service account
-#TARGET_PROJECT_SA=$(gcloud projects describe ${TARGET_PROJECT} --format 'value(projectNumber)')-compute@developer.gserviceaccount.com
+#TARGET_PROJECT_SA=
 #TARGET_PROJECT_SA_SCOPES=https://www.googleapis.com/auth/cloud-platform
 TARGET_REGION=europe-west4
 TARGET_SUBNETWORK=default

--- a/tools/vm-migrator/Makefile
+++ b/tools/vm-migrator/Makefile
@@ -2,40 +2,32 @@
 # without warranty or representation for any use or purpose.
 # Your use of it is subject to your agreement with Google.
 
-PROJECT=delivery-center-poc
 MACHINE_IMAGE_REGION=us-central1
-
+SOURCE_CSV=source.csv # actual default value
 INPUT_CSV=export.csv
 
-# SOURCE_SUBNET=projects/pso-suchit/regions/us-west1/subnetworks/sub-01
-# SUBNET_NAME=sub-01 # The subnet to be deleted and moved
-# SOURCE_ZONE=us-west1-b
-# SOUCE_ZONE_2=us-west1-a
-# SOURCE_REGION=us-west1
-
-# TARGET_REGION=us-west1
-# TARGET_SUBNET=projects/pso-suchit/regions/us-west1/subnetworks/sub-02
-# TARGET_NETWORK=projects/pso-suchit/global/networks/vpc1
-# TARGET_ZONE=us-west1-c
-
-
-SOURCE_SUBNET=projects/delivery-center-poc/regions/us-central1/subnetworks/default
-SUBNET_NAME=default # The subnet to be deleted and moved
-SOURCE_ZONE=us-central1-a
-SOURCE_ZONE_3=us-central1-b
+SOURCE_PROJECT=delivery-center-poc
 SOURCE_REGION=us-central1
+SOURCE_SUBNETWORK=default
+SOURCE_ZONE=us-central1-a
+SOURCE_ZONE_2=
+SOURCE_ZONE_3=us-central1-b
 
+# in this example source and target project are the same
+TARGET_PROJECT=
 TARGET_REGION=us-west1
-TARGET_SUBNET=projects/delivery-center-poc/regions/us-west1/subnetworks/sub-01
-TARGET_NETWORK=projects/delivery-center-poc/global/networks/vpc1
+TARGET_SUBNETWORK=sub-01
 
+# actual default values
+EXPORT_CSV=export.csv
+FILTER_CSV=filter.csv
+LOG_LEVEL=INFO
 
 STEP=prepare_inventory 
 #  The steps can be any of prepare_inventory | filter_inventory | 
 #  shutdown_instances | create_machine_images | delete_instances | release_ip | 
 #  release_ip_for_subnet | 
 #  clone_subnet | create_instances | create_instances_without_ip
-
 
 clean-pyc:
 	find . -name '*.pyc' -exec rm --force {} +
@@ -64,6 +56,12 @@ lint:
 	find . -type f -name "*.py" | xargs pylint 
 
 migrate-subnet:
-	python3 -m migrator.subnet_region_migrator --step=$(STEP) --source_zone=$(SOURCE_ZONE) --source_zone_2=$(SOUCE_ZONE_2) --source_zone_3=$(SOURCE_ZONE_3) --source_subnet=$(SOURCE_SUBNET) --project=$(PROJECT) --input_csv=$(INPUT_CSV) --target_subnet=$(TARGET_SUBNET) --machine_image_region=$(MACHINE_IMAGE_REGION) --subnet_name=$(SUBNET_NAME) --source_region=$(SOURCE_REGION) --target_region=$(TARGET_REGION)
-
-#  make SOURCE_ZONE=us-west1-a SOURCE_SUBNET=projects/delivery-center-poc/regions/us-west1/subnetworks/sub-03 TARGET_SUBNET=projects/delivery-center-poc/regions/us-central1/subnetworks/sub-01 TARGET_ZONE=us-central1-a export-subnet
+	python3 -m migrator.subnet_region_migrator --step=$(STEP) \
+		--machine_image_region=$(MACHINE_IMAGE_REGION) \
+		--source_project=$(SOURCE_PROJECT) --source_region=$(SOURCE_REGION) \
+		--source_subnetwork=$(SOURCE_SUBNETWORK) --source_zone=$(SOURCE_ZONE) \
+		--source_zone_2=$(SOUCE_ZONE_2) --source_zone_3=$(SOURCE_ZONE_3) \
+		--target_project=$(TARGET_PROJECT) --target_region=$(TARGET_REGION) \
+		--target_subnetwork=$(TARGET_SUBNETWORK) --source_csv=$(SOURCE_CSV) \
+		--export_csv=$(EXPORT_CSV) --filter_csv=$(FILTER_CSV) \
+		--log_level=$(LOG_LEVEL)

--- a/tools/vm-migrator/Readme.md
+++ b/tools/vm-migrator/Readme.md
@@ -37,7 +37,7 @@ The `Makefile` has different variables which are passed to the subnet_region_mig
 | SOURCE_ZONE_2 | [Optional] The second zone in which the source subnet is present, this is used to fetch the inventory details |
 | SOURCE_ZONE_3 | [Optional] The third zone in which the source subnet is present, this is used to fetch the inventory details |
 | TARGET_PROJECT | [Optional] If different, the Project ID where the new subnet will exist |
-| TARGET_PROJECT_SA | [Optional] Required if the target project is different than the source project. Service Account on the VMs. |
+| TARGET_PROJECT_SA | [Optional] Required if the target project is different than the source project. Used as Service Account on the target VMs. |
 | TARGET_PROJECT_SA_SCOPES | [Optional] If the target project is different than the source project, scopes to assign to the Service Account on the VMs |
 | TARGET_REGION | [Optional] If different, the target region where machines will be migrated to |
 | TARGET_SUBNETWORK | [Optional] Leave this argument empty if using `clone_subnet`. Otherwise, if different to `SOURCE_SUBNETWORK`, specify an existing target subnetwork.  |
@@ -67,7 +67,7 @@ While we can move all the machines in a subnet to the destination subnet we have
 | delete_instances | This will delete the instances which are specifed in the `INPUT_CSV` file |
 | release_ip | This will release all the internal static ip addresses of the instances which are specifed in the `INPUT_CSV` file |
 | release_ip_for_subnet | This will release all the internal static ip addresses of the source subnet | 
-| clone_subnet | This will delete and re create the subnet in the destination region with the same config as the source subnet, this is required when you want to drain the entire subnet and create it in the destination region |
+| clone_subnet | This will delete and re create the subnet in the destination region with the same config as the source subnet, this is required when you want to drain the entire subnet and create it in the destination region. Keep in mind that subnets can't be deleted from VPCs with auto subnet mode. |
 | set_machineimage_iampolicies | This will provide the target project service account with the right permissions to access the source project machine images |
 | create_instances | This will create the instances from the machine images in the destination region, it requires the destination subnet to be in place ( if you are cloning the subnet it will automatically be created  ) |
 | create_instances_without_ip | This is similar to the create_instances step jus that it will not preserve the source ips, this is useful in situation when you are moving some of the machine to the destination subenet which has a different CIDR range |
@@ -94,3 +94,68 @@ If you are planing to migrate machines to a different region and in the process 
 ## Rollback
 In order to rollback the changes please change the parameters of the source file and interchange the source and destination parameters.
 Please note that some steps like `crate_machine_image` would not be required to run as the machine images have already been created.
+
+## Examples
+
+There are certain common scenarios you might be interested in. All of them require you to fill the proper required parameters in the `Makefile`. Afterwards, you can execute the following recipes:
+
+### Moving VMs across projects
+
+This one requires a `TARGET_PROJECT`. By default, `TARGET_PROJECT_SA` points to the target project's compute engine service account.
+
+```
+# standard
+make STEP=prepare_inventory migrate-subnet
+make STEP=filter_inventory migrate-subnet
+make STEP=shutdown_instances migrate-subnet
+make STEP=create_machine_images migrate-subnet
+make STEP=delete_instances migrate-subnet
+# release VM static IPs
+make STEP=release_ip migrate-subnet
+# target service account requires access to the source machine images
+make STEP=set_machineimage_iampolicies migrate-subnet
+# create instances in the target project
+make STEP=create_instances_without_ip migrate-subnet
+```
+
+### Move VMs across regions (same subnet)
+
+This one requires the `TARGET_REGION` where the subnet will be moved to (and VMs will be recreated in). Indicating the `TARGET_SUBNETWORK` will create the same subnet in the new region with the new name.
+
+```
+# standard
+make STEP=prepare_inventory migrate-subnet
+make STEP=filter_inventory migrate-subnet
+make STEP=shutdown_instances migrate-subnet
+make STEP=create_machine_images migrate-subnet
+make STEP=delete_instances migrate-subnet
+# remove reserved static ips for this subnetwork
+make STEP=release_ip_for_subnet migrate-subnet
+# remove and recreate subnet in the same VPC but in the target region
+make STEP=clone_subnet migrate-subnet
+# recreate instances with the same IP in the recreated subnet
+make STEP=create_instances migrate-subnet
+```
+
+Notes:
+* This case is particularly interesting if VMs need to stay *in the same VPC*. Otherwise, the next example(move VMs to a different subnet is a better fit).
+* Specifying the `TARGET_SUBNETWORK` without specifying the `TARGET_REGION` is equivalent to renaming the subnet within the same region.
+
+### Move VMs to a different (already existing) subnet
+
+If you're just moving VMs across subnets, you need to specify the `TARGET_SUBNETWORK`, which must already exist. If your target subnet is in a different region, you need to specify the `TARGET_REGION` as well:
+
+```
+# standard
+make STEP=prepare_inventory migrate-subnet
+make STEP=filter_inventory migrate-subnet
+make STEP=shutdown_instances migrate-subnet
+make STEP=create_machine_images migrate-subnet
+make STEP=delete_instances migrate-subnet
+# release VM static IPs
+make STEP=release_ip migrate-subnet
+# create instances in the target subnet
+make STEP=create_instances_without_ip migrate-subnet
+```
+
+This recipe is fully compatible with moving across projects. In that case, please specify the `TARGET_PROJECT*` variables and execute `make STEP=set_machineimage_iampolicies migrate-subnet` before creating the instances as well.

--- a/tools/vm-migrator/Readme.md
+++ b/tools/vm-migrator/Readme.md
@@ -37,6 +37,8 @@ The `Makefile` has different variables which are passed to the subnet_region_mig
 | SOURCE_ZONE_2 | [Optional] The second zone in which the source subnet is present, this is used to fetch the inventory details |
 | SOURCE_ZONE_3 | [Optional] The third zone in which the source subnet is present, this is used to fetch the inventory details |
 | TARGET_PROJECT | [Optional] If different, the Project ID where the new subnet will exist |
+| TARGET_PROJECT_SA | [Optional] Required if the target project is different than the source project. Service Account on the VMs. |
+| TARGET_PROJECT_SA_SCOPES | [Optional] If the target project is different than the source project, scopes to assign to the Service Account on the VMs |
 | TARGET_REGION | [Optional] If different, the target region where machines will be migrated to |
 | TARGET_SUBNETWORK | [Optional] Leave this argument empty if using `clone_subnet`. Otherwise, if different to `SOURCE_SUBNETWORK`, specify an existing target subnetwork.  |
 | SOURCE_CSV | [Optional] (by default `source.csv`) The filename used by `prepare_inventory` |
@@ -66,6 +68,7 @@ While we can move all the machines in a subnet to the destination subnet we have
 | release_ip | This will release all the internal static ip addresses of the instances which are specifed in the `INPUT_CSV` file |
 | release_ip_for_subnet | This will release all the internal static ip addresses of the source subnet | 
 | clone_subnet | This will delete and re create the subnet in the destination region with the same config as the source subnet, this is required when you want to drain the entire subnet and create it in the destination region |
+| set_machineimage_iampolicies | This will provide the target project service account with the right permissions to access the source project machine images |
 | create_instances | This will create the instances from the machine images in the destination region, it requires the destination subnet to be in place ( if you are cloning the subnet it will automatically be created  ) |
 | create_instances_without_ip | This is similar to the create_instances step jus that it will not preserve the source ips, this is useful in situation when you are moving some of the machine to the destination subenet which has a different CIDR range |
 
@@ -74,7 +77,6 @@ While we can move all the machines in a subnet to the destination subnet we have
 Run ```make STEP=<step name> migrate-subnet```
 
 Once your setup is complete and prerequisites are met, you need to ensure the latest code is pulled from repository
-
 
 ## Zone Mapping
 

--- a/tools/vm-migrator/Readme.md
+++ b/tools/vm-migrator/Readme.md
@@ -97,7 +97,7 @@ Please note that some steps like `crate_machine_image` would not be required to 
 
 ## Examples
 
-There are certain common scenarios you might be interested in. All of them require you to fill the proper required parameters in the `Makefile`. Afterwards, you can execute the following recipes:
+There are certain common scenarios you might be interested in. All of them require you to fill the proper required parameters in the `Makefile` and the proper zone mapping in `zone_mapping.py`. Afterwards, you can execute the following recipes:
 
 ### Moving VMs across projects
 
@@ -118,7 +118,7 @@ make STEP=set_machineimage_iampolicies migrate-subnet
 make STEP=create_instances_without_ip migrate-subnet
 ```
 
-### Move VMs across regions (same subnet)
+### Move VMs across regions (recreate subnet)
 
 This one requires the `TARGET_REGION` where the subnet will be moved to (and VMs will be recreated in). Indicating the `TARGET_SUBNETWORK` will create the same subnet in the new region with the new name.
 
@@ -141,7 +141,7 @@ Notes:
 * This case is particularly interesting if VMs need to stay *in the same VPC*. Otherwise, the next example(move VMs to a different subnet is a better fit).
 * Specifying the `TARGET_SUBNETWORK` without specifying the `TARGET_REGION` is equivalent to renaming the subnet within the same region.
 
-### Move VMs to a different (already existing) subnet
+### Move VMs to a different (already existing target) subnet
 
 If you're just moving VMs across subnets, you need to specify the `TARGET_SUBNETWORK`, which must already exist. If your target subnet is in a different region, you need to specify the `TARGET_REGION` as well:
 
@@ -158,4 +158,4 @@ make STEP=release_ip migrate-subnet
 make STEP=create_instances_without_ip migrate-subnet
 ```
 
-This recipe is fully compatible with moving across projects. In that case, please specify the `TARGET_PROJECT*` variables and execute `make STEP=set_machineimage_iampolicies migrate-subnet` before creating the instances as well.
+This recipe is fully compatible with moving across projects. In this case, please specify the `TARGET_PROJECT*` variables additionally and execute `make STEP=set_machineimage_iampolicies migrate-subnet` before creating the instances as well.

--- a/tools/vm-migrator/migrator/instance.py
+++ b/tools/vm-migrator/migrator/instance.py
@@ -252,7 +252,8 @@ def upgrade_machine_type(machine_type, destination_zone):
 
 
 def create_instance(compute, project, zone, network, subnet, name,
-                    alias_ip_ranges, node_group, disk_names, ip, machine_type):
+                    alias_ip_ranges, node_group, disk_names, ip, machine_type,
+                    image_project):
     """
     Create Instance method create a new GCP VM from the machine image.
     """
@@ -344,7 +345,7 @@ def create_instance(compute, project, zone, network, subnet, name,
                                       zone=zone,
                                       body=config,
                                       sourceMachineImage='projects/' +
-                                      project + '/global/machineImages/' +
+                                      image_project + '/global/machineImages/' +
                                       name).execute()
 
 
@@ -374,8 +375,9 @@ def create(project,
            alias_ip_ranges,
            node_group,
            disk_names,
-           ip=None,
-           machine_type=None,
+           ip,
+           machine_type,
+           image_project,
            wait=True):
     """
     Main function to create the instance.
@@ -388,7 +390,7 @@ def create(project,
 
         create_instance(compute, project, target_zone, network, subnet,
                         instance_name, alias_ip_ranges, node_group, disk_names,
-                        ip, machine_type)
+                        ip, machine_type, image_project)
         if wait:
             wait_for_instance(compute, project, target_zone, instance_name)
         logging.info(

--- a/tools/vm-migrator/migrator/instance.py
+++ b/tools/vm-migrator/migrator/instance.py
@@ -383,6 +383,8 @@ def create(project,
            ip,
            machine_type,
            image_project,
+           target_service_account,
+           target_scopes,
            wait=True):
     """
     Main function to create the instance.
@@ -395,7 +397,8 @@ def create(project,
 
         create_instance(compute, project, target_zone, network, subnet,
                         instance_name, alias_ip_ranges, node_group, disk_names,
-                        ip, machine_type, image_project)
+                        ip, machine_type, image_project,
+                        target_service_account, target_scopes)
         if wait:
             wait_for_instance(compute, project, target_zone, instance_name)
         logging.info(

--- a/tools/vm-migrator/migrator/instance.py
+++ b/tools/vm-migrator/migrator/instance.py
@@ -23,7 +23,8 @@ import logging
 from . import node_group_mapping
 from . import machine_type_mapping
 from . import machine_image
-from .exceptions import InvalidFormatException, GCPOperationException, NotFoundException
+from .exceptions import InvalidFormatException, GCPOperationException, \
+                        NotFoundException
 from ratemate import RateLimit
 
 RATE_LIMIT = RateLimit(max_count=2000, per=100)

--- a/tools/vm-migrator/migrator/machine_image.py
+++ b/tools/vm-migrator/migrator/machine_image.py
@@ -92,3 +92,23 @@ def create(project, target_region, source_instance, name, wait=True):
     except Exception as exc:
         logging.error(exc)
         raise exc
+
+def set_iam_policy(source_project, name, target_service_account):
+    compute = get_compute()
+    body = {
+        "bindings": [
+            {
+                "role": "roles/compute.admin",
+                "members": [
+                    "serviceAccount:{}".format(target_service_account),
+                ],
+            },
+        ],
+        "version": 3
+    }
+    self_link = 'projects/{}/global/machineImages/{}'.format(source_project, name)
+    logging.info('Setting IAM policy for machine image %s', self_link)
+    compute.machineImages().setIamPolicy(project=source_project,
+                                         resource=name,
+                                         body=body).execute()
+    return self_link

--- a/tools/vm-migrator/migrator/machine_image.py
+++ b/tools/vm-migrator/migrator/machine_image.py
@@ -46,7 +46,7 @@ def get(project, name):
                                              machineImage=name).execute()
         if result['selfLink']:
             return result
-    except:
+    except Exception:
         return None
 
 
@@ -93,6 +93,7 @@ def create(project, target_region, source_instance, name, wait=True):
         logging.error(exc)
         raise exc
 
+
 def set_iam_policy(source_project, name, target_service_account):
     compute = get_compute()
     body = {
@@ -106,7 +107,8 @@ def set_iam_policy(source_project, name, target_service_account):
         ],
         "version": 3
     }
-    self_link = 'projects/{}/global/machineImages/{}'.format(source_project, name)
+    self_link = 'projects/{}/global/machineImages/{}'.format(source_project,
+                                                             name)
     logging.info('Setting IAM policy for machine image %s', self_link)
     compute.machineImages().setIamPolicy(project=source_project,
                                          resource=name,

--- a/tools/vm-migrator/migrator/project.py
+++ b/tools/vm-migrator/migrator/project.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+# Copyright 2021 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License..
+"""
+This file is used to create instance from a machine image.
+"""
+
+import logging
+import googleapiclient.discovery
+
+
+def get_cloudresourcemanager():
+    cloudresourcemanager = googleapiclient.discovery.build('cloudresourcemanager',
+                                                           'v1',
+                                                           cache_discovery=False)
+    logging.getLogger('googleapiclient.discovery_cache').setLevel(
+        logging.ERROR)
+    return cloudresourcemanager
+
+def get_number(project_id):
+    project = get_cloudresourcemanager().projects().get(projectId=project_id) \
+                                                                     .execute()
+    return project['projectNumber'] if 'projectNumber' in project else None

--- a/tools/vm-migrator/migrator/project.py
+++ b/tools/vm-migrator/migrator/project.py
@@ -21,12 +21,12 @@ import googleapiclient.discovery
 
 
 def get_cloudresourcemanager():
-    cloudresourcemanager = googleapiclient.discovery.build('cloudresourcemanager',
-                                                           'v1',
-                                                           cache_discovery=False)
+    crm = googleapiclient.discovery.build('cloudresourcemanager', 'v1',
+                                          cache_discovery=False)
     logging.getLogger('googleapiclient.discovery_cache').setLevel(
         logging.ERROR)
-    return cloudresourcemanager
+    return crm
+
 
 def get_number(project_id):
     project = get_cloudresourcemanager().projects().get(projectId=project_id) \

--- a/tools/vm-migrator/migrator/subnet.py
+++ b/tools/vm-migrator/migrator/subnet.py
@@ -207,8 +207,8 @@ def wait_for_operation(compute, project, region, operation):
 
         time.sleep(5)
 
-def duplicate(project, source_subnet, source_subnet_region,
-              destination_project, destination_region):
+def duplicate(project, source_subnet_region, source_subnet,
+              destination_project, destination_region, destination_subnet):
     compute = get_compute()
     subnet_request = compute.subnetworks().get(project=project,
                                                region=source_subnet_region,
@@ -224,6 +224,8 @@ def duplicate(project, source_subnet, source_subnet_region,
 
     logging.info('re creating subnet %s in region %s', source_subnet,
                  destination_region)
+    del config["selfLink"]
+    config["name"] = destination_subnet
     insert_operation = compute.subnetworks().insert(project=destination_project,
                                                     region=destination_region,
                                                     body=config).execute()

--- a/tools/vm-migrator/migrator/subnet.py
+++ b/tools/vm-migrator/migrator/subnet.py
@@ -206,9 +206,8 @@ def wait_for_operation(compute, project, region, operation):
 
         time.sleep(5)
 
-
 def duplicate(project, source_subnet, source_subnet_region,
-              destination_region):
+              destination_project, destination_region):
     compute = get_compute()
     subnet_request = compute.subnetworks().get(project=project,
                                                region=source_subnet_region,
@@ -224,10 +223,10 @@ def duplicate(project, source_subnet, source_subnet_region,
 
     logging.info('re creating subnet %s in region %s', source_subnet,
                  destination_region)
-    insert_operation = compute.subnetworks().insert(project=project,
+    insert_operation = compute.subnetworks().insert(project=destination_project,
                                                     region=destination_region,
                                                     body=config).execute()
-    wait_for_operation(compute, project, destination_region,
+    wait_for_operation(compute, destination_project, destination_region,
                        insert_operation['name'])
     logging.info('new subnet added successfully')
 

--- a/tools/vm-migrator/migrator/subnet.py
+++ b/tools/vm-migrator/migrator/subnet.py
@@ -16,11 +16,12 @@
 This file deals with operations on subnets.
 """
 import time
+import re
 import logging
 import googleapiclient.discovery
 from googleapiclient.errors import HttpError
 from csv import DictWriter
-from .exceptions import GCPOperationException
+from .exceptions import GCPOperationException, InvalidFormatException
 from . import instance
 from . import disk
 from . import fields
@@ -230,10 +231,18 @@ def duplicate(project, source_subnet, source_subnet_region,
                        insert_operation['name'])
     logging.info('new subnet added successfully')
 
-def get_network(project, region, subnet):
-    result = get_compute().subnetworks().get(project=project,
-                                             region=region,
-                                             subnetwork=subnet).execute()
+def get_network(subnet_selflink):
+    if subnet_selflink.startswith('projects'):
+        subnet_selflink = '/' + subnet_selflink
+    response = re.search(r'\/projects\/(.*?)\/regions\/(.*?)\/subnetworks\/(.*?)$',
+                         subnet_selflink)
+    if len(response.groups()) != 3:
+        raise InvalidFormatException('Invalid SelfLink Format')
+
+    'projects/{project}/regions/{region}/subnetworks/{resourceId}'
+    result = get_compute().subnetworks().get(project=response.group(1),
+                                             region=response.group(2),
+                                             subnetwork=response.group(3)).execute()
     return result['network'] if 'network' in result else None
 
 

--- a/tools/vm-migrator/migrator/subnet.py
+++ b/tools/vm-migrator/migrator/subnet.py
@@ -144,6 +144,12 @@ def export_instances(project, zone, zone_2, zone_3, subnet, file_name):
                 csv['node_group'] = instance.get_node_group(instances)
 
             mydict.append(csv)
+        else:
+            logging.debug(
+                'Ignoring VM {} in subnet {} (looking for subnet {})'.format(
+                    instances['name'],
+                    instances['networkInterfaces'][0]['subnetwork'], subnet))
+
         with open(file_name, 'w') as csvfile:
 
             writer = DictWriter(csvfile, fieldnames=headers)

--- a/tools/vm-migrator/migrator/subnet.py
+++ b/tools/vm-migrator/migrator/subnet.py
@@ -111,6 +111,9 @@ def export_instances(project, zone, zone_2, zone_3, subnet, file_name):
                 'subnet': instances['networkInterfaces'][0]['subnetwork']
             }
 
+            logging.debug('Instance {} is in the right network'.format(
+                instances['name']))
+
             for i, disks in enumerate(instances['disks']):
                 if i < 9:
                     csv['device_name_' + str(i + 1)] = disks['deviceName']

--- a/tools/vm-migrator/migrator/subnet.py
+++ b/tools/vm-migrator/migrator/subnet.py
@@ -207,6 +207,7 @@ def wait_for_operation(compute, project, region, operation):
 
         time.sleep(5)
 
+
 def duplicate(project, source_subnet_region, source_subnet,
               destination_project, destination_region, destination_subnet):
     compute = get_compute()
@@ -226,25 +227,29 @@ def duplicate(project, source_subnet_region, source_subnet,
                  destination_region)
     del config["selfLink"]
     config["name"] = destination_subnet
-    insert_operation = compute.subnetworks().insert(project=destination_project,
-                                                    region=destination_region,
-                                                    body=config).execute()
+    insert_operation = \
+        compute.subnetworks() .insert(project=destination_project,
+                                      region=destination_region,
+                                      body=config).execute()
     wait_for_operation(compute, destination_project, destination_region,
                        insert_operation['name'])
     logging.info('new subnet added successfully')
 
+
 def get_network(subnet_selflink):
     if subnet_selflink.startswith('projects'):
         subnet_selflink = '/' + subnet_selflink
-    response = re.search(r'\/projects\/(.*?)\/regions\/(.*?)\/subnetworks\/(.*?)$',
-                         subnet_selflink)
+    response = \
+        re.search(r'\/projects\/(.*?)\/regions\/(.*?)\/subnetworks\/(.*?)$',
+                  subnet_selflink)
     if len(response.groups()) != 3:
         raise InvalidFormatException('Invalid SelfLink Format')
 
     'projects/{project}/regions/{region}/subnetworks/{resourceId}'
-    result = get_compute().subnetworks().get(project=response.group(1),
-                                             region=response.group(2),
-                                             subnetwork=response.group(3)).execute()
+    result = \
+        get_compute().subnetworks().get(project=response.group(1),
+                                        region=response.group(2),
+                                        subnetwork=response.group(3)).execute()
     return result['network'] if 'network' in result else None
 
 

--- a/tools/vm-migrator/migrator/subnet.py
+++ b/tools/vm-migrator/migrator/subnet.py
@@ -230,6 +230,12 @@ def duplicate(project, source_subnet, source_subnet_region,
                        insert_operation['name'])
     logging.info('new subnet added successfully')
 
+def get_network(project, region, subnet):
+    result = get_compute().subnetworks().get(project=project,
+                                             region=region,
+                                             subnetwork=subnet).execute()
+    return result['network'] if 'network' in result else None
+
 
 def list_subnets(compute, project, region):
     result = compute.subnetworks().list(project=project,

--- a/tools/vm-migrator/migrator/subnet_region_migrator.py
+++ b/tools/vm-migrator/migrator/subnet_region_migrator.py
@@ -66,6 +66,7 @@ def bulk_image_create(project, machine_image_region, file_name='export.csv'):
                         'machine image creation generated an exception: %s',
                         exc)
 
+
 def bulk_delete_instances(file_name):
     with open(file_name, 'r') as read_obj:
         csv_dict_reader = DictReader(read_obj)
@@ -205,7 +206,6 @@ def set_machineimage_iampolicies(file_name, source_project,
                 max_workers=100) as executor:
             # Start the load operations and mark each future with its URL
             for row in csv_dict_reader:
-                parsed_link = instance.parse_self_link(row['self_link'])
                 machineimage_future.append(
                     executor.submit(machine_image.set_iam_policy,
                                     source_project, row['name'],
@@ -222,6 +222,7 @@ def set_machineimage_iampolicies(file_name, source_project,
                 except Exception as exc:
                     logging.error(
                         'machine iam policy generated an exception: %s', exc)
+
 
 def bulk_create_instances(file_name, target_project, target_service_account,
                           target_scopes, target_subnet, source_project,
@@ -378,11 +379,11 @@ def release_ips_from_file(file_name):
 
 # main function
 def main(step, machine_image_region,
-        source_project, source_region, source_subnetwork,
-        source_zone, source_zone_2, source_zone_3,
-        target_project, target_service_account, target_scopes,
-        target_region, target_subnetwork,
-        source_csv, filter_csv, input_csv, log_level):
+         source_project, source_region, source_subnetwork,
+         source_zone, source_zone_2, source_zone_3,
+         target_project, target_service_account, target_scopes,
+         target_region, target_subnetwork,
+         source_csv, filter_csv, input_csv, log_level):
     """
     The main method to trigger the VM migration.
     """
@@ -394,8 +395,9 @@ def main(step, machine_image_region,
         target_subnetwork = source_subnetwork
     if source_project != target_project:
         if not target_service_account:
-            target_service_account = "{}-compute@developer.gserviceaccount.com"\
-                                      .format(project.get_number(target_project))
+            target_service_account = \
+                "{}-compute@developer.gserviceaccount.com".format(
+                    project.get_number(target_project))
         if target_scopes:
             target_scopes = target_scopes.split(',')
         else:
@@ -423,11 +425,13 @@ def main(step, machine_image_region,
     if step == 'prepare_inventory':
         logging.info('Preparing the inventory to be exported')
         subnet.export_instances(source_project, source_zone, source_zone_2,
-                                source_zone_3, source_subnet_selflink, source_csv)
+                                source_zone_3, source_subnet_selflink,
+                                source_csv)
     if step == 'filter_inventory':
         logging.info('Preparing the inventory to be exported')
         subnet.export_instances(source_project, source_zone, source_zone_2,
-                                source_zone_3, source_subnet_selflink, source_csv)
+                                source_zone_3, source_subnet_selflink,
+                                source_csv)
         logging.info('filtering out the inventory')
         overwrite_file = filter_records(source_csv, filter_csv, input_csv)
         if overwrite_file:
@@ -549,8 +553,8 @@ if __name__ == '__main__':
                         help='Target project ID')
     parser.add_argument('--target_project_sa',
                         help='Target service account in target project')
-    parser.add_argument('--target_project_sa_scopes',
-                        help='Target service account scopes in the target project')
+    parser.add_argument('--target_project_sa_scopes', help='Target service '
+                        'account scopes in the target project')
     parser.add_argument('--target_region',
                         help='Target region')
     parser.add_argument('--target_subnetwork',
@@ -569,9 +573,9 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     main(args.step, args.machine_image_region,
-        args.source_project, args.source_region, args.source_subnetwork,
-        args.source_zone, args.source_zone_2, args.source_zone_3,
-        args.target_project, args.target_project_sa,
-        args.target_project_sa_scopes, args.target_region,
-        args.target_subnetwork,
-        args.source_csv, args.filter_csv, args.input_csv, args.log_level)
+         args.source_project, args.source_region, args.source_subnetwork,
+         args.source_zone, args.source_zone_2, args.source_zone_3,
+         args.target_project, args.target_project_sa,
+         args.target_project_sa_scopes, args.target_region,
+         args.target_subnetwork,
+         args.source_csv, args.filter_csv, args.input_csv, args.log_level)

--- a/tools/vm-migrator/migrator/subnet_region_migrator.py
+++ b/tools/vm-migrator/migrator/subnet_region_migrator.py
@@ -436,7 +436,7 @@ def main(step, machine_image_region,
             csv_dict_reader = DictReader(read_obj)
             count = len(list(csv_dict_reader))
         shutdown_response = query_yes_no(
-            'Are you sure you want to shutdown the (%s)'
+            'Are you sure you want to shutdown the (%s) '
             'instances present in the inventory ?' % count,
             default='no')
         if shutdown_response:
@@ -460,7 +460,7 @@ def main(step, machine_image_region,
         with open(input_csv, 'r') as read_obj:
             csv_dict_reader = DictReader(read_obj)
             count = len(list(csv_dict_reader))
-        response = query_yes_no('Are you sure you want to delete the (%s)'
+        response = query_yes_no('Are you sure you want to delete the (%s) '
                                 'instances present in the inventory ?' % count,
                                 default='no')
         if response:
@@ -474,7 +474,7 @@ def main(step, machine_image_region,
     if step == 'clone_subnet':
         logging.info('Cloning Subnet')
         subnet.duplicate(source_project, source_region, source_subnetwork,
-                         target_project, target_region)
+                         target_project, target_region, target_subnetwork)
         logging.info('Subnet sucessfully cloned in the provided region')
 
     if step == 'set_machineimage_iampolicies':
@@ -502,13 +502,14 @@ def main(step, machine_image_region,
 
     if step == 'release_ip_for_subnet':
         logging.info('Releasing all the Ips present in the subnet')
-        subnet.release_ip(source_project, source_region, source_subnetwork)
-        logging.info('ips present in %s released subcessfully', input_csv)
+        subnet.release_ip(source_project, source_region,
+                          source_subnet_selflink)
+        logging.info('All the IPs of the Subnet released sucessfully')
 
     if step == 'release_ip':
         logging.info('Releasing the ips present in the export')
         release_ips_from_file(input_csv)
-        logging.info('All the IPs of the Subnet released sucessfully')
+        logging.info('ips present in %s released subcessfully', input_csv)
 
 
 if __name__ == '__main__':

--- a/tools/vm-migrator/migrator/subnet_region_migrator.py
+++ b/tools/vm-migrator/migrator/subnet_region_migrator.py
@@ -28,6 +28,7 @@ from . import disk
 from . import subnet
 from . import zone_mapping
 from . import fields
+from . import project
 from csv import DictReader
 from csv import DictWriter
 
@@ -392,6 +393,9 @@ def main(step, machine_image_region,
     if not target_subnetwork:
         target_subnetwork = source_subnetwork
     if source_project != target_project:
+        if not target_service_account:
+            target_service_account = "{}-compute@developer.gserviceaccount.com"\
+                                      .format(project.get_number(target_project))
         if target_scopes:
             target_scopes = target_scopes.split(',')
         else:


### PR DESCRIPTION
This PR contains:
* Support for cross-project migration
* Updated docs:
    * Example section at the bottom that indicates options and limitations
* Standarization of input variables with sensible defaults allow to implicitly use individual or combined types of migrations:
    * Cross-project migration
    * Cross-subnet migration
    * Cross-region migration
    * Subnet move