### PR TITLE
Update gmon to google-cloud-monitoring v2.x.x and above

### DIFF
--- a/tools/gmon/gmon/cli.py
+++ b/tools/gmon/gmon/cli.py
@@ -26,6 +26,7 @@ from gmon.clients.service_monitoring import ServiceMonitoringClient
 
 SAMPLE_METRIC_TYPE = "loadbalancing.googleapis.com/server/request_count"
 
+
 def parse_args(args):
     """Parse CLI arguments.
 
@@ -41,8 +42,8 @@ def parse_args(args):
     subparsers = parser.add_subparsers(title='Endpoints', dest='parser')
 
     # Accounts parser
-    accounts = subparsers.add_parser(
-        'accounts', help='Cloud Operations Account operations')
+    accounts = subparsers.add_parser('accounts',
+                                     help='Cloud Operations Account operations')
     accounts_sub = accounts.add_subparsers(dest='operation')
     accounts_get = accounts_sub.add_parser(
         'get', help='Get a Cloud Operations Account details')
@@ -105,7 +106,7 @@ def parse_args(args):
                                  help='Window to query (in seconds)',
                                  required=False,
                                  default=60)
-    metrics_inspect.add_argument('--filters', 
+    metrics_inspect.add_argument('--filters',
                                  '-f',
                                  nargs='+',
                                  help='Filter on nested fields.',
@@ -129,7 +130,7 @@ def parse_args(args):
                               help='Number of results to show.',
                               required=False,
                               default=None)
-    metrics_list.add_argument('--filters', 
+    metrics_list.add_argument('--filters',
                               '-f',
                               nargs='+',
                               help='Filter on nested fields.',
@@ -166,8 +167,7 @@ def parse_args(args):
     # Services
     sm_service = subparsers.add_parser(
         'services', help='Cloud Monitoring Service Monitoring services')
-    sm_service_sub = sm_service.add_subparsers(
-        dest='operation')
+    sm_service_sub = sm_service.add_subparsers(dest='operation')
     sm_service_get = sm_service_sub.add_parser(
         'get', help='Get a Cloud Monitoring Service Monitoring service')
     sm_service_create = sm_service_sub.add_parser(
@@ -180,29 +180,24 @@ def parse_args(args):
         'list', help='List a Cloud Monitoring Service Monitoring service')
 
     for p in [
-            sm_service_list, sm_service_get,
-            sm_service_create,
-            sm_service_update,
-            sm_service_delete
+            sm_service_list, sm_service_get, sm_service_create,
+            sm_service_update, sm_service_delete
     ]:
         p.add_argument('--project',
                        '-p',
                        help='Cloud Monitoring host project id.',
                        required=True)
-    for p in [
-            sm_service_get, sm_service_create,
-            sm_service_delete
-    ]:
+    for p in [sm_service_get, sm_service_create, sm_service_delete]:
         p.add_argument('service_id', help='Cloud Monitoring service id')
 
-    sm_service_create.add_argument(
-        '--config', help='Path to service config.', required=True)
+    sm_service_create.add_argument('--config',
+                                   help='Path to service config.',
+                                   required=True)
 
     # SLOs
     sm_slo = subparsers.add_parser(
         'slos', help='Cloud Monitoring Service Monitoring SLOs')
-    sm_slo_sub = sm_slo.add_subparsers(
-        dest='operation')
+    sm_slo_sub = sm_slo.add_subparsers(dest='operation')
     sm_slo_get = sm_slo_sub.add_parser(
         'get', help='Get a Cloud Monitoring Service Monitoring SLO')
     sm_slo_create = sm_slo_sub.add_parser(
@@ -215,9 +210,7 @@ def parse_args(args):
         'list', help='List Cloud Monitoring Service Monitoring SLOs')
 
     for p in [
-            sm_slo_list, sm_slo_get,
-            sm_slo_update, sm_slo_create,
-            sm_slo_delete
+            sm_slo_list, sm_slo_get, sm_slo_update, sm_slo_create, sm_slo_delete
     ]:
         p.add_argument('--project',
                        '-p',
@@ -225,10 +218,7 @@ def parse_args(args):
                        required=True)
         p.add_argument('service_id', help='Cloud Monitoring service id')
 
-    for p in [
-            sm_slo_get, sm_slo_update,
-            sm_slo_delete
-    ]:
+    for p in [sm_slo_get, sm_slo_update, sm_slo_delete]:
         p.add_argument('slo_id', help='SLO id.')
 
     sm_slo_create.add_argument('--config',
@@ -244,10 +234,12 @@ def parse_args(args):
     }
     return parsers, parser.parse_args(args)
 
+
 def main():
     """gmon CLI entrypoint."""
     parsers, args = parse_args(sys.argv[1:])
     cli(parsers, args)
+
 
 def cli(parsers, args):
     """Main CLI function.
@@ -295,7 +287,7 @@ def cli(parsers, args):
 
         elif command in ['inspect']:
             response = method(metric_type, window=args.window, filters=filters)
-            filters  = {} # already using API filters
+            filters = {}  # already using API filters
 
         elif command in ['delete_unused']:
             response = method(pattern=args.regex, window=args.window)
@@ -335,6 +327,7 @@ def cli(parsers, args):
             method = getattr(client, command + '_slos')
             response = method(args.service_id)
         return fmt_response(response, limit, fields, filters)
+
 
 def parse_filters(filters=[]):
     """Function to parse `filters` CLI argument.
@@ -407,6 +400,7 @@ def fmt_response(response, limit, fields, filters={}):
             pprint.pprint(r, indent=1, width=80)
             responses.append(r)
     return responses
+
 
 def parse_fields(fields):
     """Parse `fields` CLI argument.

--- a/tools/gmon/setup.py
+++ b/tools/gmon/setup.py
@@ -29,7 +29,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(name='gmon',
-      version='1.1.1',
+      version='1.1.2',
       description='Cloud Monitoring API client (unofficial)',
       long_description=long_description,
       long_description_content_type='text/markdown',
@@ -52,8 +52,6 @@ setup(name='gmon',
           'google-cloud-monitoring', 'dotmap'
       ],
       entry_points={
-          'console_scripts': [
-              'gmon=gmon.cli:main',
-          ],
+          'console_scripts': ['gmon=gmon.cli:main',],
       },
       python_requires='>=3.4')

--- a/tools/gmon/tests/unit/test_cli.py
+++ b/tools/gmon/tests/unit/test_cli.py
@@ -18,18 +18,17 @@ import unittest
 
 from mock import patch
 from gmon.cli import parse_args, cli
-from test_stubs import (
-    mock_cm_list_metric_descriptors,
-    mock_cm_inspect_metric_descriptors,
-    mock_cm_list_services,
-    mock_cm_list_slos)
+from test_stubs import (mock_cm_list_metric_descriptors,
+                        mock_cm_inspect_metric_descriptors,
+                        mock_cm_list_services, mock_cm_list_slos)
 
 cwd = os.path.dirname(os.path.abspath(__file__))
 root = os.path.dirname(os.path.dirname(cwd))
 
 PROJECT_ID = 'fake_project_id'
 SERVICE_ID = 'kkKv9xDqTs6SgN6l6wqa-w'
-SSM_MOCK = "gmon.clients.service_monitoring.ServiceMonitoringServiceClient" # noqa: E501
+SSM_MOCK = "gmon.clients.service_monitoring.ServiceMonitoringServiceClient"  # noqa: E501
+
 
 # pylint: disable=E501
 class TestCLI(unittest.TestCase):
@@ -38,9 +37,8 @@ class TestCLI(unittest.TestCase):
         pass
 
     def test_parse_args_metrics_list(self):
-        parsers, args = parse_args([
-            'metrics', 'list', 'custom.', '-p', PROJECT_ID
-        ])
+        parsers, args = parse_args(
+            ['metrics', 'list', 'custom.', '-p', PROJECT_ID])
         self.assertEqual(args.parser, 'metrics')
         self.assertEqual(args.operation, 'list')
         self.assertEqual(args.project, PROJECT_ID)
@@ -53,31 +51,25 @@ class TestCLI(unittest.TestCase):
         self.assertEqual(args.parser, 'metrics')
         self.assertEqual(args.operation, 'inspect')
         self.assertEqual(args.project, PROJECT_ID)
-        self.assertEqual(
-            getattr(args, 'metric-type'),
-            'custom.googleapis.com/fake')
+        self.assertEqual(getattr(args, 'metric-type'),
+                         'custom.googleapis.com/fake')
 
     def test_parse_args_services_list(self):
-        parsers, args = parse_args([
-            'services', 'list', '-p', PROJECT_ID
-        ])
+        parsers, args = parse_args(['services', 'list', '-p', PROJECT_ID])
         self.assertEqual(args.parser, 'services')
         self.assertEqual(args.operation, 'list')
         self.assertEqual(args.project, PROJECT_ID)
 
     def test_parse_args_slos_list(self):
-        parsers, args = parse_args([
-            'slos', 'list', '-p', PROJECT_ID, SERVICE_ID
-        ])
+        parsers, args = parse_args(
+            ['slos', 'list', '-p', PROJECT_ID, SERVICE_ID])
         self.assertEqual(args.parser, 'slos')
         self.assertEqual(args.operation, 'list')
         self.assertEqual(args.project, PROJECT_ID)
         self.assertEqual(args.service_id, SERVICE_ID)
 
     def test_parse_args_accounts_get(self):
-        parsers, args = parse_args([
-            'accounts', 'get', '-p', PROJECT_ID
-        ])
+        parsers, args = parse_args(['accounts', 'get', '-p', PROJECT_ID])
         self.assertEqual(args.parser, 'accounts')
         self.assertEqual(args.operation, 'get')
         self.assertEqual(args.project, PROJECT_ID)
@@ -91,9 +83,8 @@ class TestCLI(unittest.TestCase):
     @patch('google.api_core.grpc_helpers.create_channel',
            return_value=mock_cm_list_metric_descriptors())
     def test_cli_metrics_list(self, mock):
-        parsers, args = parse_args([
-            'metrics', 'list', 'custom.googleapis.com/fake', '-p', PROJECT_ID
-        ])
+        parsers, args = parse_args(
+            ['metrics', 'list', 'custom.googleapis.com/fake', '-p', PROJECT_ID])
         response = cli(parsers, args)
         logging.info(response)
 
@@ -104,8 +95,10 @@ class TestCLI(unittest.TestCase):
             'metrics', 'inspect', 'custom.googleapis.com/invoice/paid/amount',
             '-p', PROJECT_ID
         ])
-        mlabel_keys = ['type', 'name', 'metricKind', 'valueType', 'description',
-                       'displayName', 'event_type']
+        mlabel_keys = [
+            'type', 'name', 'metricKind', 'valueType', 'description',
+            'displayName', 'event_type'
+        ]
         rlabel_keys = ['instance_id', 'project_id', 'zone']
 
         responses = cli(parsers, args)
@@ -128,9 +121,7 @@ class TestCLI(unittest.TestCase):
     @patch('google.api_core.grpc_helpers.create_channel',
            return_value=mock_cm_list_services())
     def test_cli_services_list(self, *mocks):
-        parsers, args = parse_args([
-            'services', 'list', '-p', PROJECT_ID
-        ])
+        parsers, args = parse_args(['services', 'list', '-p', PROJECT_ID])
         responses = cli(parsers, args)
         response = responses[0]
         display_name = response['displayName']
@@ -142,9 +133,8 @@ class TestCLI(unittest.TestCase):
     @patch('google.api_core.grpc_helpers.create_channel',
            return_value=mock_cm_list_slos())
     def test_cli_slos_list(self, *mocks):
-        parsers, args = parse_args([
-            'slos', 'list', '-p', PROJECT_ID, SERVICE_ID
-        ])
+        parsers, args = parse_args(
+            ['slos', 'list', '-p', PROJECT_ID, SERVICE_ID])
         responses = cli(parsers, args)
         response = responses[0]
         display_name = response['displayName']

--- a/tools/gmon/tests/unit/test_stubs.py
+++ b/tools/gmon/tests/unit/test_stubs.py
@@ -20,8 +20,7 @@ import re
 import yaml
 
 from google.api import metric_pb2
-from google.cloud.monitoring_v3.proto import (
-    metric_service_pb2, service_service_pb2)
+from google.cloud.monitoring_v3 import types
 
 TEST_DIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -76,6 +75,7 @@ def mock_grpc_response(response, proto_method):
     """
     return proto_method(**response)
 
+
 def mock_grpc_stub(data):
     """Fakes gRPC response channel for the proto_method passed.
 
@@ -94,72 +94,68 @@ def mock_grpc_stub(data):
     channel = ChannelStub(responses=responses)
     return channel
 
+
 def mock_cm_list_metric_descriptors():
     metric_descriptor = load_fixture('metric_descriptor_proto.json')
-    data = [
-        {
-            'response': {
-                'next_page_token': '',
-                'metric_descriptors': [metric_descriptor]
-            },
-            'proto_method': metric_service_pb2.ListMetricDescriptorsResponse
-        }
-    ]
+    data = [{
+        'response': {
+            'next_page_token': '',
+            'metric_descriptors': [metric_descriptor]
+        },
+        'proto_method': types.ListMetricDescriptorsResponse
+    }]
     return mock_grpc_stub(data)
+
 
 def mock_cm_get_metric_descriptors():
     metric_descriptor = load_fixture('metric_descriptor_proto.json')
-    data = [
-        {
-            'response': metric_descriptor,
-            'proto_method': metric_pb2.MetricDescriptor
-        }
-    ]
+    data = [{
+        'response': metric_descriptor,
+        'proto_method': metric_pb2.MetricDescriptor
+    }]
     return mock_grpc_stub(data)
+
 
 def mock_cm_inspect_metric_descriptors():
     metric_descriptor = load_fixture('metric_descriptor_proto.json')
     timeseries = load_fixture('time_series_proto.json')
-    data = [
-        {
-            'response': {
-                'next_page_token': '',
-                'time_series': [timeseries]
-            },
-            'proto_method': metric_service_pb2.ListTimeSeriesResponse
+    data = [{
+        'response': {
+            'next_page_token': '',
+            'time_series': [timeseries]
         },
-        {
-            'response': metric_descriptor,
-            'proto_method': metric_pb2.MetricDescriptor
-        }
-    ]
+        'proto_method': types.ListTimeSeriesResponse
+    }, {
+        'response': metric_descriptor,
+        'proto_method': metric_pb2.MetricDescriptor
+    }]
     return mock_grpc_stub(data)
+
 
 def mock_cm_list_services():
     service = load_fixture('ssm_service_proto.json')
-    data = [
-        {
-            'response': {
-                'next_page_token': '',
-                'services': [service]
-            },
-            'proto_method': service_service_pb2.ListServicesResponse
-        }
-    ]
+    data = [{
+        'response': {
+            'next_page_token': '',
+            'services': [service]
+        },
+        'proto_method': types.ListServicesResponse
+    }]
     return mock_grpc_stub(data)
+
 
 def mock_cm_list_slos():
     slo = load_fixture('ssm_slo_proto.json')
-    data = [
-        {
-            'response': {
-                'next_page_token': '',
-                'service_level_objectives': [slo]
-            },
-            'proto_method': service_service_pb2.ListServiceLevelObjectivesResponse # noqa: E501
-        }
-    ]
+    data = [{
+        'response': {
+            'next_page_token': '',
+            'service_level_objectives': [slo]
+        },
+        'proto_method':
+            types.ListServiceLevelObjectivesResponse  # noqa: E501
+    }]
     return mock_grpc_stub(data)
+
 
 class dotdict(dict):
     """dot.notation access to dictionary attributes"""
@@ -182,6 +178,7 @@ def dotize(data):
         if isinstance(v, dict):
             data[k] = dotdict(v)
     return data
+
 
 def parse_config(path, ctx=os.environ):
     """Load a yaml / json configuration file and resolve environment variables
@@ -223,6 +220,7 @@ def parse_config(path, ctx=os.environ):
         content = replace_env_vars(content, ctx)
         data = yaml.safe_load(content)
     return data
+
 
 def load_fixture(filename, **ctx):
     """Load a fixture from the test/fixtures/ directory and replace context


### PR DESCRIPTION
Library stopped working because of the 1.x --> 2.x upgrade of the google-cloud-monitoring library, which breaks things. This bugfix version updates `gmon` to use the new interface offered in `google-cloud-monitoring`, and fixes the issues encountered when using the library.