### PR TITLE
Ansible module for installation of Anthos on Bare Metal

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ The tools folder contains ready-made utilities which can simpilfy Google Cloud P
 * [Agile Machine Learning API](tools/agile-machine-learning-api) - A web application which provides the ability to train and deploy ML models on Google Cloud Machine Learning Engine, and visualize the predicted results using LIME through simple post request.
 * [Apache Beam Client Throttling](tools/apachebeam-throttling) - A library that can be used to limit the number of requests from an Apache Beam pipeline to an external service. It buffers requests to not overload the external service and activates client-side throttling when the service starts rejecting requests due to out of quota errors.
 * [AssetInventory](tools/asset-inventory) - Import Cloud Asset Inventory resourcs into BigQuery.
+* [AnthosBMAnsibleModule](tools/anthosbm-ansible-module) - Ansible module for installation of Anthos on Bare Metal
 * [BigQuery Discount Per-Project Attribution](tools/kunskap) - A tool that automates the generation of a BigQuery table that uses existing exported billing data, by attributing both CUD and SUD charges on a per-project basis.
 * [BigQuery Query Plan Exporter](tools/bigquery-query-plan-exporter) - Command line utility for exporting BigQuery query plans in a given date range.
 * [BigQuery Query Plan Visualizer](tools/bq-visualizer) - A web application which provides the ability to visualise the execution stages of BigQuery query plans to aid in the optimization of queries.

--- a/tools/anthosbm-ansible-module/README.md
+++ b/tools/anthosbm-ansible-module/README.md
@@ -1,0 +1,841 @@
+- [1. Introduction](#1-introduction)
+- [2. Anthos on Bare Metal Ansible Module](#2-anthos-on-bare-metal-ansible-module)
+  - [2.1 Ansible Configuration file](#21-ansible-configuration-file)
+  - [2.2 Execute Playbook](#22-execute-playbook)
+- [3. Prerequisites for Anthos on Bare Metal](#3-prerequisites-for-anthos-on-bare-metal)
+  - [3.1 Google Cloud Account](#31-google-cloud-account)
+  - [3.2 OS Prerequisites](#32-os-prerequisites)
+  - [3.3 Workstation Docker prerequisite](#33-workstation-docker-prerequisite)
+  - [3.4 Workstation gcloud SDK prerequisite](#34-workstation-gcloud-sdk-prerequisite)
+  - [3.5 Workstation Kubectl prerequisite](#35-workstation-kubectl-prerequisite)
+  - [3.6 Workstation bmctl prerequisite](#36-workstation-bmctl-prerequisite)
+- [4. Google Cloud Configuration](#4-google-cloud-configuration)
+- [5. Anthos Cluster Role](#5-anthos-cluster-role)
+  - [5.1 Inventory File](#51-inventory-file)
+  - [5.2 Variable File](#52-variable-file)
+  - [5.3 Admin Cluster](#53-admin-cluster)
+    - [5.3.1 Admin Cluster Inventory File](#531-admin-cluster-inventory-file)
+    - [5.3.2 Admin Cluster Variables](#532-admin-cluster-variables)
+    - [5.3.3 Create Admin Cluster](#533-create-admin-cluster)
+  - [5.4 Create User Cluster](#54-create-user-cluster)
+    - [5.4.1 User Cluster Inventory File](#541-user-cluster-inventory-file)
+    - [5.4.2 User Cluster Variables](#542-user-cluster-variables)
+    - [5.4.3 Create User Cluster](#543-create-user-cluster)
+  - [5.5 Create Hybrid Cluster](#55-create-hybrid-cluster)
+    - [5.5.1 Hybrid Cluster Inventory File](#551-hybrid-cluster-inventory-file)
+    - [5.5.2 Hybrid Cluster Variables](#552-hybrid-cluster-variables)
+    - [5.5.3 Create Hybrid Cluster](#553-create-hybrid-cluster)
+  - [5.6 Create Standalone Cluster](#56-create-standalone-cluster)
+    - [5.6.1 Standalone Cluster Inventory File](#561-standalone-cluster-inventory-file)
+    - [5.6.2 Standalone Cluster Variables](#562-standalone-cluster-variables)
+    - [5.6.3 Create Standalone Cluster](#563-create-standalone-cluster)
+- [6. Connect Gateway Configuration](#6-connect-gateway-configuration)
+  - [6.1 Configure Connect Gateway](#61-configure-connect-gateway)
+  - [6.2 Validate Connect Gateway](#62-validate-connect-gateway)
+
+
+## 1. Introduction
+
+Anthos on bare metal allows you to run Kubernetes clusters on your own hardware infrastructure and also allows you to monitor your cluster from Google Cloud Console.  Read more on Anthos on bare metal  [here](https://cloud.google.com/anthos/gke/docs/bare-metal/1.7/concepts/about-bare-metal).
+
+This guide explains the steps required for creating Anthos clusters on bare metal on Ubuntu hosts and also explains steps to try it on Google Compute Engine (GCE) VMs. 
+
+
+## 2. Anthos on Bare Metal Ansible Module
+
+This module can be used for installation of Anthos on Bare Metal nodes for all kind of clusters (admin, user, hybrid and standalone).
+
+
+### 2.1 Ansible Configuration file
+
+The ansible.cfg configuration file is placed in the &lt;REPOSITORY\_ROOT>/ansible directory. This configures the inventory location and disables host checking.
+
+
+```
+[defaults]
+inventory = ./inventory/hosts.yml
+host_key_checking = False
+```
+
+
+
+### 2.2 Execute Playbook
+
+Install Ansible on Workstation and run the below command to create the Anthos cluster.
+
+
+```
+sudo apt install ansible
+
+cd <REPOSITORY_ROOT>/ansible
+
+ansible-playbook anthos.yml
+```
+
+
+
+## 3. Prerequisites for Anthos on Bare Metal
+
+The complete list of prerequisites is available [here](https://cloud.google.com/anthos/clusters/docs/bare-metal/1.7/installing/install-prereq).
+
+Other than cluster nodes, you need a workstation machine that is used for running Anthos installation commands. It can be a GCE VM, or an on-premise VM or an on-premise physical server.  Following are the main prerequisites for a workstation:
+
+
+
+*   Operating system is the same supported Linux distribution running on the cluster node machines.
+*   More than 50 GB of free disk space.
+*   L3 connectivity to all cluster node machines.
+*   Access to all cluster node machines through SSH via private keys with passwordless root access. Access can be either direct or through sudo.
+*   Access to the control plane VIP.
+
+
+### 3.1 Google Cloud Account
+
+You need a user account or a service account that has a Project Owner/Editor role creating the required Google Cloud resources.  Alternatively You can add the following IAM roles to the user account (or service account):
+
+
+
+*   Service Account Admin
+*   Service Account Key Admin
+*   Project IAM Admin
+*   Compute Viewer
+*   Service Usage Admin
+
+```
+gcloud auth login
+gcloud auth application-default login
+```
+
+
+
+
+### 3.2 OS Prerequisites
+
+The Ubuntu OS prerequisites for all the cluster nodes including Workstation can be accomplished through**ubuntu-prereq/rhel-prereq** Ansible role. The execution of this role is controlled by the below variable in vars/anthos\_vars.yml file
+
+
+*vars/anthos_vars.yml*
+
+```
+# Possible values: ubuntu | rhel
+# Use rhel for CentOS as well
+os_type: "ubuntu"
+```
+
+
+The role execution is done from the playbook (anthos.yml).
+
+
+*anthos.yml*
+
+```
+- hosts: all
+  remote_user: "{{ login_user }}"
+  gather_facts: "no"
+  vars_files:
+    - vars/anthos_vars.yml
+  roles:
+    - role: ubuntu-prereq
+      become: yes
+      become_method: sudo
+      when: os_type == "ubuntu"
+    - role: rhel-prereq
+      become: yes
+      become_method: sudo
+      when: os_type == "rhel"
+```
+
+
+### 3.3 Workstation Docker prerequisite
+
+The workstation should have Docker installed and the non-root user that is used for Anthos installation should have access to the Docker. This can be achieved through the ws-docker role.
+
+
+*anthos.yml*
+
+```
+- hosts: workstation
+  remote_user: "{{ login_user }}"
+  gather_facts: "no"
+  vars_files:
+    - vars/anthos_vars.yml
+  roles:
+    - role: ws-docker
+      become: yes
+      become_method: sudo
+      when: ws_docker == "yes"
+```
+
+The role execution can be controlled by the below variable.
+
+
+*vars/anthos_vars.yml*
+
+```
+# Leave it blank if you would like to skip the docker installation and configuration
+ws_docker: "yes"
+```
+
+
+
+### 3.4 Workstation gcloud SDK prerequisite
+
+The Workstation should have gcloud SDK installed. You can do this using the**gcloud-sdk** Ansible role.
+
+
+*anthos.yml*
+
+```
+    - role: gcloud-sdk
+      become: yes
+      become_method: sudo
+      when: gcloud_sdk == "yes"
+```
+
+
+The role execution can be controlled by the below variable.
+
+
+*vars/anthos_vars.yml*
+
+```
+# Leave it blank if you would like to skip the gcloud SDK installation
+gcloud_sdk: "yes"
+```
+
+
+
+### 3.5 Workstation Kubectl prerequisite
+
+The Workstation should have the kubectl tool installed. This can be done through**kubectl-tool** Ansible role.
+
+
+*anthos.yml*
+
+```
+    - role: kubectl-tool
+      become: yes
+      become_method: sudo
+      when: kubectl_tool == "yes"
+```
+
+
+The role execution can be controlled by the below variable.
+
+
+*vars/anthos_vars.yml*
+
+```
+# Leave it blank if you would like to skip the kubectl installation
+kubectl_tool: "yes"
+```
+
+
+
+### 3.6 Workstation bmctl prerequisite
+
+The Workstation should have the bmctl tool installed. This can be done through**bmctl-tool** Ansible role.
+
+
+*anthos.yml*
+
+```
+    - role: bmctl-tool
+      become: yes
+      become_method: sudo
+      when: bmctl_tool == "yes"
+```
+
+
+The role execution can be controlled by the below variable.
+
+
+*vars/anthos_vars.yml*
+
+```
+# Leave it blank if you would like to skip the bmctl installation
+bmctl_tool: "yes"
+```
+
+
+The bmctl download location and version is configured through below variables.
+
+
+*vars/anthos_vars.yml*
+
+```
+bmctl_download_url: gs://anthos-baremetal-release/bmctl/1.6.2/linux-amd64/bmctl
+```
+
+
+
+## 4. Google Cloud Configuration
+
+The Google Cloud configuration can be done from a Cloud Shell or a GCE VM Instance. If the configuration is done from the Workstation, then you should login with a Google account. You can find the required details [here](https://cloud.google.com/anthos/clusters/docs/bare-metal/1.7/installing/install-prereq#logging_into_gcloud). 
+
+You can configure the Google Cloud as well as create required Service Accounts using**service-accounts** Ansible role.
+
+
+*anthos.yml*
+
+```
+    - role: service-accounts
+      when: service_accounts == "yes"
+```
+
+
+In case you have already created the Service Account and would like to skip this step, you can do so through the below variable.
+
+
+*vars/anthos_vars.yml*
+ 
+ ```
+ # Leave it blank if you would like to skip the bmctl installation
+service_accounts: "yes"
+```
+
+
+The location for downloaded key files for Service Accounts and the names of Service Accounts are configured through below variables.
+
+
+*vars/anthos_vars.yml*
+
+```
+# The Service Account Key files are stored in this location. The role that creates cluster searches this location for the key files.
+gcp_sa_key_dir: /home/anthos/gcp_keys
+# Below are the names of the Service Accounts created for the Anthos cluster
+local_gcr_sa_name: anthos-gcr-svc-account
+local_connect_agent_sa_name: connect-agent-svc-account
+local_connect_register_sa_name: connect-register-svc-account
+local_cloud_operations_sa_name: cloud-ops-svc-account
+```
+
+
+**Note:** The below bmctl command can also enable Google Cloud APIs and create the required service accounts. However, the Ansible role provides better control especially when you would like to use the same Service Accounts for different clusters.
+
+
+```
+bmctl create config -c [CLUSTER_NAME]
+    --enable-apis \
+    --create-service-accounts
+```
+
+
+
+## 5. Anthos Cluster Role
+
+The Anthos cluster can be created using the**anthos** Ansible role.
+
+
+*anthos.yml*
+
+```
+    - role: anthos
+```
+
+
+The**anthos** Ansible role uses a number of variables in addition to the Service Accounts variables. It also uses the Inventory host file.
+
+
+### 5.1 Inventory File
+
+The IP address or the DNS names of cluster nodes including Workstation should be set in the Ansible inventory. The**cp\_nodes** contains the list of Control Plane Nodes and**worker\_nodes** contains the list of Worker Nodes.
+
+
+*inventory/hosts.yml*
+
+```
+all:
+  hosts:
+  children:
+    workstation:
+      hosts:
+        10.200.0.7:
+    cp_nodes:
+      hosts:
+        10.200.0.2:
+        10.200.0.3:
+        10.200.0.4:
+    worker_nodes:
+      hosts:
+        10.200.0.5:
+        10.200.0.6:
+```
+
+
+
+### 5.2 Variable File
+
+The variable file is placed in the**vars** directory under the root of the code repository. The purpose of each variable explained below.
+
+
+*vars/anthos_vars.yml*
+
+```
+# Login user, group and home for Cluster nodes
+login_user: anthos
+login_user_group: anthos
+login_user_home: /home/anthos
+# Possible values: ubuntu | rhel 
+# Use rhel for CentOS as well
+os_type: "ubuntu"
+# Set value to "yes" to apply the respective role
+ws_docker: "yes"
+gcloud_sdk: "yes"
+kubectl_tool: "yes"
+bmctl_tool: "yes"
+service_accounts: "yes"
+# Link to download bmctl from. It also contains the version
+bmctl_download_url: gs://anthos-baremetal-release/bmctl/1.7.0/linux-amd64/bmctl
+# Directory used by bmctl tool for creating the cluster
+bmctl_workspace_dir: bmctl-workspace
+# Directory where Service Account keys are placed
+gcp_sa_key_dir: /home/anthos/gcp_keys
+# Names of the Service Accounts
+local_gcr_sa_name: anthos-gcr-svc-account
+local_connect_agent_sa_name: connect-agent-svc-account
+local_connect_register_sa_name: connect-register-svc-account
+local_cloud_operations_sa_name: cloud-ops-svc-account
+# The SSH key file for logging into Anthos nodes
+ssh_private_key_path: /home/anthos/.ssh/id_rsa
+# Project ID for the Google Cloud Project
+project_id: [PROJECT_ID]
+# Google Cloud region
+location: [REGION]
+# Name of the Cluster
+cluster_name: [CLUSTER_NAME]
+# Type of cluster deployment. Possible values are: standalone | hybrid | admin | user
+cluster_type: hybrid
+# Number of maximum Pods that can run on a node
+max_pod_per_node: 250
+# Container runtime for the cluster. Possible values are: docker and containerd
+container_runtime: docker
+# enable/disable application logging for cluster workloads. use 'true' to enable
+app_logs: false
+# Kubernetes POD CIDR.Change it if the default one overlaps with the Cluster Nodes CIDR.
+pod_cidr: 192.168.0.0/16
+# Kubernetes Services CIDR.Change it if the default one overlaps with the Cluster Nodes CIDR.
+service_cidr: 10.96.0.0/12
+# Anthos Cluster Control Plane VIP. This should be in the Cluster Node subnet and should not be part of lb_address_pool.
+cp_vip: 10.200.0.47
+# Anthos Ingress VIP. This should be in the Cluster Node subnet and should be part of lb_address_pool.
+ingress_vip: 10.200.0.48
+# Address pool for Cluster Load Balancer
+lb_address_pool: 
+- 10.200.0.48/28
+# For a 'user' cluster, place the admin cluster kubeconfig file on workstation machine and set admin_kubeconfig_path to the absolute path of this file
+admin_kubeconfig_path: [ADMIN_CLUSTER_KUBECONFIG]
+cgw_members: 
+- [email id of IAM user or service account]
+```
+
+
+
+### 5.3 Admin Cluster
+
+You can read about the admin cluster installation [here](https://cloud.google.com/anthos/clusters/docs/bare-metal/1.7/installing/creating-clusters/admin-cluster-creation).
+
+
+#### 5.3.1 Admin Cluster Inventory File
+
+The admin cluster consists of Control Plane nodes only. Therefore, the inventory file for an admin cluster would look like this.
+
+
+*inventory/hosts.yml*
+
+```
+all:
+  hosts:
+  children:
+    workstation:
+      hosts:
+        10.200.0.7:
+    cp_nodes:
+      hosts:
+        10.200.0.2:
+```
+
+
+The _cp\_nodes_ list should contain an odd number of hosts (such as 1, 3 or 5). The installation ignores _worker\_nodes_ list if it is present in the inventory file.
+
+
+#### 5.3.2 Admin Cluster Variables
+
+You need to set the _cluster\_type_ and _cluster\_name_ variables in the variable file.  Below is a sample variable file for the admin cluster using Ubuntu nodes. Replace the values enclosed in square brackets ([]) with actual values relevant to your GCP project and the cluster.
+
+
+*vars/anthos_vars.yml*
+
+```
+login_user: anthos
+login_user_group: anthos
+login_user_home: /home/anthos
+os_type: "ubuntu"
+ws_docker: "yes"
+gcloud_sdk: "yes"
+kubectl_tool: "yes"
+bmctl_tool: "yes"
+service_accounts: "yes"
+bmctl_download_url: gs://anthos-baremetal-release/bmctl/1.7.0/linux-amd64/bmctl
+bmctl_workspace_dir: bmctl-workspace
+gcp_sa_key_dir: /home/anthos/gcp_keys
+local_gcr_sa_name: anthos-gcr-svc-account
+local_connect_agent_sa_name: connect-agent-svc-account
+local_connect_register_sa_name: connect-register-svc-account
+local_cloud_operations_sa_name: cloud-ops-svc-account
+ssh_private_key_path: /home/anthos/.ssh/id_rsa
+project_id: [PROJECT_ID]
+location: [REGION]
+cluster_name: [CLUSTER_NAME]
+cluster_type: admin
+max_pod_per_node: 250
+container_runtime: docker
+app_logs: false
+pod_cidr: 192.168.0.0/16
+service_cidr: 10.96.0.0/12
+cp_vip: 10.200.0.47
+cgw_members: 
+- [email id of IAM user or service account]
+```
+
+Below variables are not used for the admin cluster. You can either ignore them or remove them from the variable file.
+
+```
+ingress_vip: 10.200.0.48
+lb_address_pool: 
+- 10.200.0.48/28
+admin_kubeconfig_path: 
+```
+
+#### 5.3.3 Create Admin Cluster
+
+Run below command from workstation node (ansible should be installed on the workstation node)  to create the cluster.
+
+
+```
+cd <REPOSITORY_ROOT>/ansible
+ansible-playbook anthos.yml
+```
+
+
+
+### 5.4 Create User Cluster
+
+You can read about the user cluster installation [here](https://cloud.google.com/anthos/clusters/docs/bare-metal/1.7/installing/creating-clusters/user-cluster-creation).
+
+
+#### 5.4.1 User Cluster Inventory File
+
+The user cluster consists of Control Plane nodes as well as worker nodes. Therefore, the inventory file for a user cluster would look like this.
+
+
+*inventory/hosts.yml*
+
+```
+all:
+  hosts:
+  children:
+    workstation:
+      hosts:
+        10.200.0.7:
+    cp_nodes:
+      hosts:
+        10.200.0.3:
+    worker_nodes:
+      hosts:
+        10.200.0.5:
+        10.200.0.6:
+```
+
+
+#### 5.4.2 User Cluster Variables
+
+You need to set the _cluster\_type_ and _cluster\_name_ variables in the variable file.  Below is a sample variable file for the user cluster using Ubuntu nodes. Replace the values enclosed in square brackets ([]) with the actual values relevant to your GCP project and the cluster.
+
+Set *admin_kubeconfig_path* variable to the full path of the admin cluster kubeconfig file.
+
+
+*vars/anthos_vars.yml*
+
+```
+login_user: anthos
+login_user_group: anthos
+login_user_home: /home/anthos
+os_type: "ubuntu"
+ws_docker: "yes"
+gcloud_sdk: "yes"
+kubectl_tool: "yes"
+bmctl_tool: "yes"
+service_accounts: "no"
+bmctl_download_url: gs://anthos-baremetal-release/bmctl/1.7.0/linux-amd64/bmctl
+bmctl_workspace_dir: bmctl-workspace
+gcp_sa_key_dir: /home/anthos/gcp_keys
+local_gcr_sa_name: anthos-gcr-svc-account
+local_connect_agent_sa_name: connect-agent-svc-account
+local_connect_register_sa_name: connect-register-svc-account
+local_cloud_operations_sa_name: cloud-ops-svc-account
+ssh_private_key_path: /home/anthos/.ssh/id_rsa
+project_id: [PROJECT_ID]
+location: [REGION]
+cluster_name: [CLUSTER_NAME]
+cluster_type: user
+max_pod_per_node: 250
+container_runtime: docker
+app_logs: false
+pod_cidr: 192.168.0.0/16
+service_cidr: 10.96.0.0/12
+cp_vip: 10.200.0.46
+ingress_vip: 10.200.0.48
+lb_address_pool: 
+- 10.200.0.48/28
+admin_kubeconfig_path: /home/anthos/bmctl-workspace/admin-abm/admin-abm-kubeconfig
+cgw_members: 
+- [email id of IAM user or service account]
+```
+
+
+
+#### 5.4.3 Create User Cluster
+
+Run below command from workstation node (ansible should be installed on the workstation node) to create the cluster.
+
+
+```
+cd <REPOSITORY_ROOT>/ansible
+ansible-playbook anthos.yml
+```
+
+
+
+### 5.5 Create Hybrid Cluster
+
+You can read about the hybrid cluster installation [here](https://cloud.google.com/anthos/clusters/docs/bare-metal/1.7/installing/creating-clusters/hybrid-cluster-creation).
+
+
+#### 5.5.1 Hybrid Cluster Inventory File
+
+The hybrid cluster consists of Control Plane nodes as well as worker nodes. Therefore, the inventory file for a hybrid cluster would look like this.
+
+
+*inventory/hosts.yml*
+
+```
+all:
+  hosts:
+  children:
+    workstation:
+      hosts:
+        10.200.0.7:
+    cp_nodes:
+      hosts:
+        10.200.0.2:
+        10.200.0.3:
+        10.200.0.4:
+    worker_nodes:
+      hosts:
+        10.200.0.5:
+        10.200.0.6:
+```
+
+
+
+#### 5.5.2 Hybrid Cluster Variables
+
+You need to set the _cluster\_type_ and _cluster\_name_ variables in the variable file.  Below is a sample variable file for the hybrid cluster using Ubuntu nodes. Replace the values enclosed in square brackets ([]) with actual values relevant to your GCP project and the cluster.
+
+
+
+*vars/anthos_vars.yml*
+
+```
+login_user: anthos
+login_user_group: anthos
+login_user_home: /home/anthos
+os_type: "ubuntu"
+ws_docker: "yes"
+gcloud_sdk: "yes"
+kubectl_tool: "yes"
+bmctl_tool: "yes"
+service_accounts: "yes"
+bmctl_download_url: gs://anthos-baremetal-release/bmctl/1.7.0/linux-amd64/bmctl
+bmctl_workspace_dir: bmctl-workspace
+gcp_sa_key_dir: /home/anthos/gcp_keys
+local_gcr_sa_name: anthos-gcr-svc-account
+local_connect_agent_sa_name: connect-agent-svc-account
+local_connect_register_sa_name: connect-register-svc-account
+local_cloud_operations_sa_name: cloud-ops-svc-account
+ssh_private_key_path: /home/anthos/.ssh/id_rsa
+project_id: [PROJECT_ID]
+location: [REGION]
+cluster_name: [CLUSTER_NAME]
+cluster_type: hybrid
+max_pod_per_node: 250
+container_runtime: docker
+app_logs: false
+pod_cidr: 192.168.0.0/16
+service_cidr: 10.96.0.0/12
+cp_vip: 10.200.0.47
+ingress_vip: 10.200.0.48
+lb_address_pool: 
+- 10.200.0.48/28
+admin_kubeconfig_path: 
+cgw_members: 
+- [email id of IAM user or service account]
+```
+
+The variables *admin_kubeconfig_path* is not used by the hybrid cluster.
+
+
+#### 5.5.3 Create Hybrid Cluster
+
+Run below command from workstation node (ansible should be installed on the workstation node) to create the cluster.
+
+
+```
+cd <REPOSITORY_ROOT>/ansible
+ansible-playbook anthos.yml
+```
+
+
+
+### 5.6 Create Standalone Cluster
+
+You can read about the standalone cluster installation [here](https://cloud.google.com/anthos/clusters/docs/bare-metal/1.7/installing/creating-clusters/standalone-cluster-creation).
+
+
+#### 5.6.1 Standalone Cluster Inventory File
+
+The standalone cluster consists of Control Plane nodes as well as worker nodes. Therefore, the inventory file for a standalone cluster would look like this.
+
+
+*inventory/hosts.yml*
+
+```
+all:
+  hosts:
+  children:
+    workstation:
+      hosts:
+        10.200.0.7:
+    cp_nodes:
+      hosts:
+        10.200.0.2:
+        10.200.0.3:
+        10.200.0.4:
+    worker_nodes:
+      hosts:
+        10.200.0.5:
+        10.200.0.6:
+```
+
+
+
+#### 5.6.2 Standalone Cluster Variables
+
+You need to set the _cluster\_type_ and _cluster\_name_ variables in the variable file.  Below is a sample variable file for the standalone cluster using Ubuntu nodes. Replace the values enclosed in square brackets ([]) with actual values relevant to your GCP project and the cluster.
+
+
+
+*vars/anthos_vars.yml*
+
+```
+login_user: anthos
+login_user_group: anthos
+login_user_home: /home/anthos
+os_type: "ubuntu"
+ws_docker: "yes"
+gcloud_sdk: "yes"
+kubectl_tool: "yes"
+bmctl_tool: "yes"
+service_accounts: "yes"
+bmctl_download_url: gs://anthos-baremetal-release/bmctl/1.7.0/linux-amd64/bmctl
+bmctl_workspace_dir: bmctl-workspace
+gcp_sa_key_dir: /home/anthos/gcp_keys
+local_gcr_sa_name: anthos-gcr-svc-account
+local_connect_agent_sa_name: connect-agent-svc-account
+local_connect_register_sa_name: connect-register-svc-account
+local_cloud_operations_sa_name: cloud-ops-svc-account
+ssh_private_key_path: /home/anthos/.ssh/id_rsa
+project_id: [PROJECT_ID]
+location: [REGION]
+cluster_name: [CLUSTER_NAME]
+cluster_type: standalone
+max_pod_per_node: 250
+container_runtime: docker
+app_logs: false
+pod_cidr: 192.168.0.0/16
+service_cidr: 10.96.0.0/12
+cp_vip: 10.200.0.47
+ingress_vip: 10.200.0.48
+lb_address_pool: 
+- 10.200.0.48/28
+admin_kubeconfig_path: 
+cgw_members: 
+- [email id of IAM user or service account]
+```
+
+The variables *admin_kubeconfig_path* is not used by the hybrid cluster.
+
+
+#### 5.6.3 Create Standalone Cluster
+
+Run below command from workstation node (ansible should be installed on the workstation node) to create the cluster.
+
+
+```
+cd <REPOSITORY_ROOT>/ansible
+ansible-playbook anthos.yml
+```
+
+
+
+## 6. Connect Gateway Configuration
+
+You can use Connect Gateway for connecting to the registered clusters and run commands to monitor the workload. You can read more about Connect Gateway [here](https://cloud.google.com/anthos/multicluster-management/gateway).
+
+
+### 6.1 Configure Connect Gateway
+
+You can configure the Connect Gateway with**connect-gateway** Ansible role. 
+
+
+*anthos.yml*
+
+```
+    - role: connect-gateway
+```
+
+
+This role requires the below variable that contains a list of users and/or service accounts that can connect to the cluster through Connect Gateway.
+
+
+*vars/anthos_vars.yml*
+
+```
+cgw_members: 
+- user:[USER_EMAIL_ID]
+- serviceAccount:[SERVICE_ACCOUNT_EMAIL_ID]
+```
+
+
+
+### 6.2 Validate Connect Gateway
+
+Open Cloud Shell from the GCP console after logging in using your Google account.
+
+
+```
+gcloud alpha container hub memberships get-credentials [CLUTER_NAME] --project [PROJECT_ID]
+```
+
+
+where `[CLUSTER_NAME]` is the name of the Anthos cluster and `[PROJECT_ID]` is the Google Cloud Project ID.
+
+Run the below command to verify that you can connect successfully to the Cluster API. 
+
+**NOTE:** your email ID should be added to the CGW configuration.
+
+
+```
+Kubectl get pods -A
+```

--- a/tools/anthosbm-ansible-module/ansible.cfg
+++ b/tools/anthosbm-ansible-module/ansible.cfg
@@ -1,0 +1,18 @@
+# Copyright 2021 Google LLC
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[defaults]
+inventory = ./inventory/hosts.yml
+host_key_checking = False
+#command_warnings = False

--- a/tools/anthosbm-ansible-module/anthos.yml
+++ b/tools/anthosbm-ansible-module/anthos.yml
@@ -1,0 +1,58 @@
+# Copyright 2021 Google LLC
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+# Playbook to create Anthos Cluster
+- hosts: all
+  remote_user: "{{ login_user }}"
+  gather_facts: "no"
+  vars_files:
+    - vars/anthos_vars.yml
+  roles:
+    - role: ubuntu-prereq
+      become: yes
+      become_method: sudo
+      when: os_type == "ubuntu"
+    - role: rhel-prereq
+      become: yes
+      become_method: sudo
+      when: os_type == "rhel"
+
+- hosts: workstation
+  remote_user: "{{ login_user }}"
+  gather_facts: "no"
+  vars_files:
+    - vars/anthos_vars.yml
+  roles:
+    - role: ws-docker
+      become: yes
+      become_method: sudo
+      when: ws_docker == "yes"
+    - role: gcloud-sdk
+      become: yes
+      become_method: sudo
+      when: gcloud_sdk == "yes"
+    - role: kubectl-tool
+      become: yes
+      become_method: sudo
+      when: kubectl_tool == "yes"
+    - role: bmctl-tool
+      become: yes
+      become_method: sudo
+      when: bmctl_tool == "yes"
+    - role: service-accounts
+      when: service_accounts == "yes"
+    - role: anthos
+    - role: connect-gateway
+    

--- a/tools/anthosbm-ansible-module/inventory/hosts.yml
+++ b/tools/anthosbm-ansible-module/inventory/hosts.yml
@@ -1,3 +1,17 @@
+# Copyright 2021 Google LLC
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 all:
   hosts:
   children:

--- a/tools/anthosbm-ansible-module/inventory/hosts.yml
+++ b/tools/anthosbm-ansible-module/inventory/hosts.yml
@@ -1,0 +1,15 @@
+all:
+  hosts:
+  children:
+    workstation:
+      hosts:
+        10.200.0.7:
+    cp_nodes:
+      hosts:
+        10.200.0.2:
+        10.200.0.3:
+        10.200.0.4:
+    worker_nodes:
+      hosts:
+        10.200.0.5:
+        10.200.0.6:

--- a/tools/anthosbm-ansible-module/roles/anthos/files/cloud-console-reader.yaml
+++ b/tools/anthosbm-ansible-module/roles/anthos/files/cloud-console-reader.yaml
@@ -1,0 +1,11 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cloud-console-reader
+rules:
+- apiGroups: [""]
+  resources: ["nodes", "persistentvolumes"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["storage.k8s.io"]
+  resources: ["storageclasses"]
+  verbs: ["get", "list", "watch"]

--- a/tools/anthosbm-ansible-module/roles/anthos/files/cloud-console-reader.yaml
+++ b/tools/anthosbm-ansible-module/roles/anthos/files/cloud-console-reader.yaml
@@ -1,3 +1,17 @@
+# Copyright 2021 Google LLC
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/tools/anthosbm-ansible-module/roles/anthos/tasks/main.yml
+++ b/tools/anthosbm-ansible-module/roles/anthos/tasks/main.yml
@@ -1,0 +1,107 @@
+# Copyright 2021 Google LLC
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Reset ssh connection to allow group changes
+  meta: reset_connection
+  
+- name: Delete bmctl workspace cluster directory if exists
+  ansible.builtin.file:
+    path: "{{ login_user_home }}/{{ bmctl_workspace_dir }}/{{ cluster_name }}"
+    state: absent
+    
+- name: Create bmctl workspace cluster directory
+  ansible.builtin.file:
+    path: "{{ login_user_home }}/{{ bmctl_workspace_dir }}/{{ cluster_name }}"
+    state: directory
+    owner: "{{ login_user }}"
+    group: "{{ login_user_group }}"
+
+- name: Create Cluster Config file
+  ansible.builtin.template:
+    src: cluster.yaml.j2
+    dest: "{{ login_user_home }}/{{ bmctl_workspace_dir }}/{{ cluster_name }}/{{ cluster_name}}.yaml"
+    owner: "{{ login_user }}"
+    group: "{{ login_user_group }}"
+
+- name: Check Config
+  shell:
+    cmd: "bmctl check config -c {{ cluster_name }} --bootstrap-cluster-pod-cidr={{ pod_cidr }} --bootstrap-cluster-service-cidr={{ service_cidr }} --reuse-bootstrap-cluster --keep-bootstrap-cluster"
+    chdir: "{{ login_user_home }}"
+  when: cluster_type != "user"
+
+- name: Preflight check
+  shell:
+    cmd: "bmctl check preflight -c {{ cluster_name }} --bootstrap-cluster-pod-cidr={{ pod_cidr }} --bootstrap-cluster-service-cidr={{ service_cidr }} --reuse-bootstrap-cluster --keep-bootstrap-cluster"
+    chdir: "{{ login_user_home }}"
+  when: cluster_type != "user"
+
+- name: Create Cluster
+  shell:
+    cmd: "bmctl create cluster -c {{ cluster_name }} --bootstrap-cluster-pod-cidr={{ pod_cidr }} --bootstrap-cluster-service-cidr={{ service_cidr }} --reuse-bootstrap-cluster --keep-bootstrap-cluster"
+    chdir: "{{ login_user_home }}"
+  when: cluster_type != "user"
+
+- name: Create User Cluster
+  shell:
+    cmd: "bmctl create cluster -c {{ cluster_name }} --kubeconfig {{ admin_kubeconfig_path }} --bootstrap-cluster-pod-cidr={{ pod_cidr }} --bootstrap-cluster-service-cidr={{ service_cidr }}"
+    chdir: "{{ login_user_home }}"
+  when: cluster_type == "user"
+
+- name: Get kubeconfig location
+  shell: echo "{{ login_user_home }}/{{ bmctl_workspace_dir }}/{{ cluster_name }}/{{ cluster_name }}-kubeconfig"
+  register: kubeconfig_location
+
+- name: Print Kubeconfig file location
+  ansible.builtin.debug:
+    msg: "Kubeconfig file for the cluster is: {{ kubeconfig_location.stdout }}"
+
+- name: Copy Cloud Console Cluster Role manifest file
+  copy:
+    src: cloud-console-reader.yaml
+    dest: "{{ login_user_home }}/{{ bmctl_workspace_dir }}/{{ cluster_name }}/"
+    
+- name: Create Cloud Console Reader Cluster Role
+  shell:
+    cmd: "kubectl --kubeconfig {{ kubeconfig_location.stdout }} apply -f {{ login_user_home }}/{{ bmctl_workspace_dir }}/{{ cluster_name }}/cloud-console-reader.yaml"
+
+- name: Remove Cloud Console Cluster Role manifest file
+  file: 
+    path: "{{ login_user_home }}/{{ bmctl_workspace_dir }}/{{ cluster_name }}/cloud-console-reader.yaml"
+    state: absent
+
+- name: Create Kubernetes Service Account
+  shell:
+    cmd: "kubectl --kubeconfig {{ kubeconfig_location.stdout }} create serviceaccount anthos-ksa"
+
+- name: Grant view cluster role to Kubernetes Service Account
+  shell:
+    cmd: "kubectl --kubeconfig {{ kubeconfig_location.stdout }} create clusterrolebinding anthos-cluster-view --clusterrole view --serviceaccount default:anthos-ksa"
+
+- name: Grant Cloud Console Reader cluster role to Kubernetes Service Account
+  shell:
+    cmd: "kubectl --kubeconfig {{ kubeconfig_location.stdout }} create clusterrolebinding anthos-cloud-console-reader --clusterrole cloud-console-reader --serviceaccount default:anthos-ksa"
+
+- name: Get Kubernetes Service Account Secret Name
+  shell: 
+    cmd: "kubectl --kubeconfig {{ kubeconfig_location.stdout }} get serviceaccount anthos-ksa -o jsonpath='{$.secrets[0].name}'"
+  register: secret_name
+
+- name: Get Authentication Token
+  shell: 
+    cmd: "kubectl --kubeconfig {{ kubeconfig_location.stdout }} get secret {{ secret_name.stdout }} -o jsonpath='{$.data.token}' | base64 --decode"
+  register: auth_token
+
+- name: Print Authentication Token
+  ansible.builtin.debug:
+    msg: "{{ auth_token.stdout }}"

--- a/tools/anthosbm-ansible-module/roles/anthos/templates/cluster.yaml.j2
+++ b/tools/anthosbm-ansible-module/roles/anthos/templates/cluster.yaml.j2
@@ -1,0 +1,101 @@
+{#
+# Copyright 2021 Google LLC
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#}
+
+{% if (cluster_type != 'user') %}
+sshPrivateKeyPath: {{ ssh_private_key_path }}
+gcrKeyPath: {{ gcp_sa_key_dir }}/{{ local_gcr_sa_name }}.json
+cloudOperationsServiceAccountKeyPath: {{ gcp_sa_key_dir }}/{{ local_cloud_operations_sa_name }}.json
+{% endif %}
+gkeConnectAgentServiceAccountKeyPath: {{ gcp_sa_key_dir }}/{{ local_connect_agent_sa_name }}.json
+gkeConnectRegisterServiceAccountKeyPath: {{ gcp_sa_key_dir }}/{{ local_connect_register_sa_name }}.json
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cluster-{{ cluster_name }}
+---
+apiVersion: baremetal.cluster.gke.io/v1
+kind: Cluster
+metadata:
+  name: {{ cluster_name }}
+  namespace: cluster-{{ cluster_name }}
+spec:
+  type: {{ cluster_type }}
+{% set bmctl_version = bmctl_download_url.split('/')[4] %}
+  anthosBareMetalVersion: {{ bmctl_version }}
+  gkeConnect:
+    projectID: {{ project_id }} 
+  controlPlane:
+    nodePoolSpec:
+      nodes:
+{% for cp_node in groups['cp_nodes'] %}
+      - address: {{ cp_node }}
+{% endfor %}
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+      - {{ pod_cidr }}
+    services:
+      cidrBlocks:
+      - {{ service_cidr }}
+  loadBalancer:
+    mode: bundled
+    ports:
+      controlPlaneLBPort: 443
+    vips:
+      controlPlaneVIP: {{ cp_vip }}
+{% if (cluster_type != 'admin') %}
+      ingressVIP: {{ ingress_vip }}
+    addressPools:
+    - name: pool1
+      addresses:
+{% for lb_address in lb_address_pool %}
+      - {{ lb_address }}
+{% endfor %}
+{% endif %}
+  clusterOperations:
+    projectID: {{ project_id }}
+    location: {{ location }}
+    enableApplication: {{ app_logs }}
+  storage:
+    lvpNodeMounts:
+      path: /mnt/localpv-disk
+      storageClassName: local-disks
+    lvpShare:
+      path: /mnt/localpv-share
+      storageClassName: local-shared
+      numPVUnderSharedPath: 5
+  nodeConfig:
+    podDensity:
+      maxPodsPerNode: {{ max_pod_per_node }}
+    containerRuntime: {{ container_runtime }}
+  nodeAccess:
+    loginUser: {{ login_user }}
+{% if (cluster_type != 'admin') and groups['worker_nodes'] %}
+---
+apiVersion: baremetal.cluster.gke.io/v1
+kind: NodePool
+metadata:
+  name: node-pool-{{ cluster_name }}
+  namespace: cluster-{{ cluster_name }}
+spec:
+  clusterName: {{ cluster_name }}
+  nodes:
+{% for worker_node in groups['worker_nodes'] %}
+  - address: {{ worker_node }}
+{% endfor %}
+{% endif %}
+  

--- a/tools/anthosbm-ansible-module/roles/bmctl-tool/tasks/main.yml
+++ b/tools/anthosbm-ansible-module/roles/bmctl-tool/tasks/main.yml
@@ -1,0 +1,32 @@
+# Copyright 2021 Google LLC
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+- name: Remove bmctl if present
+  ansible.builtin.file:
+    path: /usr/local/sbin/bmctl
+    state: absent
+
+- name: Download bmctl
+  shell:
+    cmd: gsutil cp {{ bmctl_download_url }} .
+
+- name: Make bmctl executable
+  ansible.builtin.file:
+    path: bmctl
+    mode: a+x
+
+- name: Move bmctl to /usr/local/sbin
+  shell:
+    cmd: mv bmctl /usr/local/sbin/

--- a/tools/anthosbm-ansible-module/roles/connect-gateway/tasks/main.yml
+++ b/tools/anthosbm-ansible-module/roles/connect-gateway/tasks/main.yml
@@ -1,0 +1,61 @@
+# Copyright 2021 Google LLC
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Enable Google Cloud APIs
+  shell: >
+    gcloud services enable --project "{{ project_id }}"
+    connectgateway.googleapis.com
+    cloudbuild.googleapis.com
+
+- name: Grant gkehub.gatewayAdmin role to members
+  shell: gcloud projects add-iam-policy-binding "{{ project_id }}" --member "{{ item }}" --role roles/gkehub.gatewayAdmin
+  with_items: " {{ cgw_members }}"
+
+- name: Grant gkehub.viewer role to members
+  shell: gcloud projects add-iam-policy-binding "{{ project_id }}" --member "{{ item }}" --role roles/gkehub.viewer
+  with_items: " {{ cgw_members }}"
+
+- name: Create impersonate manifest file
+  ansible.builtin.template:
+    src: impersonate.yaml.j2
+    dest: "{{ login_user_home }}/impersonate.yaml"
+    owner: "{{ login_user }}"
+    group: "{{ login_user_group }}"
+
+- name: Create admin permission manifest file
+  ansible.builtin.template:
+    src: admin-permission.yaml.j2
+    dest: "{{ login_user_home }}/admin-permission.yaml"
+    owner: "{{ login_user }}"
+    group: "{{ login_user_group }}"
+
+- name: Apply impersonate.yaml
+  shell: > 
+    kubectl --kubeconfig="{{ login_user_home }}/bmctl-workspace/{{ cluster_name }}/{{ cluster_name }}-kubeconfig"
+    apply -f "{{ login_user_home }}/impersonate.yaml"
+
+- name: Delete impersonate.yaml file
+  ansible.builtin.file:
+    path: "{{ login_user_home }}/impersonate.yaml"
+    state: absent
+
+- name: Apply admin-permission.yaml
+  shell: > 
+    kubectl --kubeconfig="{{ login_user_home }}/bmctl-workspace/{{ cluster_name }}/{{ cluster_name }}-kubeconfig"
+    apply -f "{{ login_user_home }}/admin-permission.yaml"
+
+- name: Delete impersonate.yaml file
+  ansible.builtin.file:
+    path: "{{ login_user_home }}/admin-permission.yaml"
+    state: absent

--- a/tools/anthosbm-ansible-module/roles/connect-gateway/templates/admin-permission.yaml.j2
+++ b/tools/anthosbm-ansible-module/roles/connect-gateway/templates/admin-permission.yaml.j2
@@ -1,0 +1,30 @@
+{#
+# Copyright 2021 Google LLC
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#}
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: gateway-cluster-admin
+subjects:
+{% for cgw_member in cgw_members %}
+{% set member_list = cgw_member.split(':') %}
+- kind: User
+  name: {{ member_list[1] }}
+{% endfor %}
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io

--- a/tools/anthosbm-ansible-module/roles/connect-gateway/templates/impersonate.yaml.j2
+++ b/tools/anthosbm-ansible-module/roles/connect-gateway/templates/impersonate.yaml.j2
@@ -1,0 +1,46 @@
+
+{#
+# Copyright 2021 Google LLC
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#}
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: gateway-impersonate
+rules:
+- apiGroups:
+  - ""
+  resourceNames:
+{% for cgw_member in cgw_members %}
+{% set member_list = cgw_member.split(':') %}
+  - {{ member_list[1] }}
+{% endfor %}
+  resources:
+  - users
+  verbs:
+  - impersonate
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: gateway-impersonate
+roleRef:
+  kind: ClusterRole
+  name: gateway-impersonate
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: connect-agent-sa
+  namespace: gke-connect

--- a/tools/anthosbm-ansible-module/roles/gcloud-sdk/tasks/main.yml
+++ b/tools/anthosbm-ansible-module/roles/gcloud-sdk/tasks/main.yml
@@ -1,0 +1,67 @@
+# Copyright 2021 Google LLC
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+- name: Remove gcloud pacakge source file if present [Ubuntu]
+  ansible.builtin.file:
+    path: /etc/apt/sources.list.d/google-cloud-sdk.list
+    state: absent
+  when: os_type == "ubuntu"
+
+- name: Add gcloud distribution URI as package source [Ubuntu]
+  shell:
+    cmd: echo "deb https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+  when: os_type == "ubuntu"
+
+- name: install required packages [Ubuntu]
+  apt:
+    pkg:
+    - apt-transport-https
+    - ca-certificates
+    - gnupg
+    - curl
+    state: present
+  when: os_type == "ubuntu"
+
+- name: Import the Google Cloud public key [Ubuntu]
+  shell:
+    cmd: curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+    warn: false
+  when: os_type == "ubuntu"
+
+- name: install google cloud sdk [Ubuntu]
+  apt:
+    name: google-cloud-sdk
+    update_cache: yes
+  when: os_type == "ubuntu"
+
+- name: Add gcloud SDK yum repository [RHEL/CentOS]
+  yum_repository:
+    name: google-cloud-sdk
+    description: Google Cloud SDK
+    baseurl: https://packages.cloud.google.com/yum/repos/cloud-sdk-el7-x86_64
+    enabled: yes
+    gpgcheck: yes
+    repo_gpgcheck: no
+    gpgkey: |-
+            https://packages.cloud.google.com/yum/doc/yum-key.gpg
+              https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+  when: os_type == "rhel"
+
+- name: Install gcloud sdk [RHEL/CentOS]
+  yum:
+    name: google-cloud-sdk
+    state: present
+  when: os_type == "rhel"
+

--- a/tools/anthosbm-ansible-module/roles/kubectl-tool/tasks/main.yml
+++ b/tools/anthosbm-ansible-module/roles/kubectl-tool/tasks/main.yml
@@ -1,0 +1,31 @@
+# Copyright 2021 Google LLC
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+- name: Remove kubectl if present
+  ansible.builtin.file:
+    path: /usr/local/sbin/kubectl
+    state: absent
+
+- name: Get stable version of Kubectl
+  uri: 
+    url: https://storage.googleapis.com/kubernetes-release/release/stable.txt
+    return_content: yes
+  register: kubectl_version
+
+- name: Download kubectl
+  get_url:
+    url: "https://storage.googleapis.com/kubernetes-release/release/{{ kubectl_version.content }}/bin/linux/amd64/kubectl"
+    dest: /usr/local/sbin/
+    mode: 'a+x'

--- a/tools/anthosbm-ansible-module/roles/rhel-prereq/tasks/main.yml
+++ b/tools/anthosbm-ansible-module/roles/rhel-prereq/tasks/main.yml
@@ -1,0 +1,29 @@
+# Copyright 2021 Google LLC
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+- name: Disable SELinux
+  selinux:
+    state: disabled
+
+- name: Stop firewalld service
+  ansible.builtin.systemd:
+    name: firewalld
+    state: stopped
+
+- name: Disable firewalld service
+  ansible.builtin.systemd:
+    name: firewalld
+    enabled: no
+

--- a/tools/anthosbm-ansible-module/roles/service-accounts/tasks/main.yml
+++ b/tools/anthosbm-ansible-module/roles/service-accounts/tasks/main.yml
@@ -1,0 +1,126 @@
+# Copyright 2021 Google LLC
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Enable Google Cloud APIs for Anthos
+  shell: >
+    gcloud services enable --project="{{ project_id }}"
+    anthos.googleapis.com
+    anthosgke.googleapis.com
+    cloudresourcemanager.googleapis.com
+    container.googleapis.com
+    gkeconnect.googleapis.com
+    gkehub.googleapis.com
+    logging.googleapis.com
+    monitoring.googleapis.com
+    servicecontrol.googleapis.com
+    servicemanagement.googleapis.com
+    serviceusage.googleapis.com
+    stackdriver.googleapis.com
+
+- name: Create GCR Service Account
+  shell: gcloud iam service-accounts create "{{ local_gcr_sa_name }}" --project="{{ project_id }}"
+
+- name: Generate and download GCR Service Account Key
+  shell: >
+    gcloud iam service-accounts keys create "{{ local_gcr_sa_name }}".json
+    --iam-account="{{ local_gcr_sa_name }}@{{ project_id }}.iam.gserviceaccount.com"
+    --project="{{ project_id }}"
+
+- name: Create directory for GCP Keys if it does not exist
+  ansible.builtin.file:
+    path: "{{ gcp_sa_key_dir }}"
+    state: directory
+
+- name: Move GCR Service Account key file
+  shell: mv "{{ local_gcr_sa_name }}".json "{{ gcp_sa_key_dir }}"
+
+- name: Create Connect Agent Service Account
+  shell: gcloud iam service-accounts create "{{ local_connect_agent_sa_name }}" --project="{{ project_id }}"
+
+- name: Grant gkehub.connect role to Connect Agent Service Account
+  shell: >
+    gcloud projects add-iam-policy-binding "{{ project_id }}"
+    --member="serviceAccount:{{ local_connect_agent_sa_name }}@{{ project_id }}.iam.gserviceaccount.com"
+    --role="roles/gkehub.connect"
+
+- name: Generate and download Connect Agent Service Account key
+  shell: >
+    gcloud iam service-accounts keys create "{{ local_connect_agent_sa_name }}".json
+    --iam-account="{{ local_connect_agent_sa_name }}@{{ project_id }}.iam.gserviceaccount.com"
+    --project="{{ project_id }}"
+
+- name: Move Connect Agent Service Account key file
+  shell: mv "{{ local_connect_agent_sa_name }}".json "{{ gcp_sa_key_dir }}"
+
+- name: Create Connect Register Service Account
+  shell: gcloud iam service-accounts create "{{ local_connect_register_sa_name }}" --project="{{ project_id }}"
+
+- name: Grant gkehub.admin role to Connect Register Service account
+  shell: >
+    gcloud projects add-iam-policy-binding "{{ project_id }}"
+    --member="serviceAccount:{{ local_connect_register_sa_name }}@{{ project_id }}.iam.gserviceaccount.com"
+    --role="roles/gkehub.admin"
+
+- name: Generate and download Connect Register Service Account keys
+  shell: >
+    gcloud iam service-accounts keys create "{{ local_connect_register_sa_name }}".json
+    --iam-account="{{ local_connect_register_sa_name }}@{{ project_id }}.iam.gserviceaccount.com"
+    --project="{{ project_id }}"
+
+- name: Move Connect Register Service Account key file
+  shell: mv "{{ local_connect_register_sa_name }}".json "{{ gcp_sa_key_dir }}"
+
+- name: Create Cloud Operations Service Account
+  shell: gcloud iam service-accounts create "{{ local_cloud_operations_sa_name }}" --project="{{ project_id }}"
+
+- name: Grant logging.logWriter role to Cloud Operations Service Account
+  shell: >
+    gcloud projects add-iam-policy-binding "{{ project_id }}"
+    --member="serviceAccount:{{ local_cloud_operations_sa_name }}@{{ project_id }}.iam.gserviceaccount.com"
+    --role="roles/logging.logWriter"
+
+- name: Grant monitoring.metricWriter role to Cloud Operations Service Account
+  shell: >
+    gcloud projects add-iam-policy-binding "{{ project_id }}"
+    --member="serviceAccount:{{ local_cloud_operations_sa_name }}@{{ project_id }}.iam.gserviceaccount.com"
+    --role="roles/monitoring.metricWriter"
+
+- name: Grant stackdriver.resourceMetadata.writer role to Cloud Operations Service Account
+  shell: >
+    gcloud projects add-iam-policy-binding "{{ project_id }}"
+    --member="serviceAccount:{{ local_cloud_operations_sa_name }}@{{ project_id }}.iam.gserviceaccount.com"
+    --role="roles/stackdriver.resourceMetadata.writer"
+
+- name: Grant monitoring.dashboardEditor role to Cloud Operations Service Account
+  shell: >
+    gcloud projects add-iam-policy-binding "{{ project_id }}"
+    --member="serviceAccount:{{ local_cloud_operations_sa_name }}@{{ project_id }}.iam.gserviceaccount.com"
+    --role="roles/monitoring.dashboardEditor"
+
+- name: Generate and download Cloud Operations Service Account keys
+  shell: >
+    gcloud iam service-accounts keys create "{{ local_cloud_operations_sa_name }}".json
+    --iam-account="{{ local_cloud_operations_sa_name }}@{{ project_id }}.iam.gserviceaccount.com"
+    --project="{{ project_id }}"
+
+- name: Move Cloud Operations Service Account key file
+  shell: mv "{{ local_cloud_operations_sa_name }}".json "{{ gcp_sa_key_dir }}"
+
+- name: Recursively change ownership of GCP Key directory
+  ansible.builtin.file:
+    path: "{{ gcp_sa_key_dir }}"
+    state: directory
+    recurse: yes
+    owner: "{{ login_user }}"
+    group: "{{ login_user_group }}"

--- a/tools/anthosbm-ansible-module/roles/ubuntu-prereq/tasks/main.yml
+++ b/tools/anthosbm-ansible-module/roles/ubuntu-prereq/tasks/main.yml
@@ -1,0 +1,34 @@
+# Copyright 2021 Google LLC
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+- name: Stop Apparmor service
+  ansible.builtin.systemd:
+    name: apparmor
+    state: stopped
+
+- name: Disable Apparmor service
+  ansible.builtin.systemd:
+    name: apparmor
+    enabled: no
+
+- name: Stop UFW service
+  ansible.builtin.systemd:
+    name: ufw
+    state: stopped
+
+- name: Disable UFW service
+  ansible.builtin.systemd:
+    name: ufw
+    enabled: no

--- a/tools/anthosbm-ansible-module/roles/ws-docker/tasks/main.yml
+++ b/tools/anthosbm-ansible-module/roles/ws-docker/tasks/main.yml
@@ -1,0 +1,102 @@
+# Copyright 2021 Google LLC
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+- name: Remove previous docker versions [Ubuntu]
+  apt:
+    pkg:
+    - docker
+    - docker-engine
+    - docker.io
+    - containerd
+    - runc
+    state: absent
+    autoremove: yes
+  when: os_type == "ubuntu"
+
+- name: Update apt package manager [Ubuntu]
+  apt:
+    update_cache: yes
+  when: os_type == "ubuntu"
+
+- name: install docker [Ubuntu]
+  apt:
+    pkg:
+    - apt-transport-https
+    - ca-certificates
+    - curl
+    - gnupg-agent
+    - software-properties-common
+    - docker.io
+    state: present
+  when: os_type == "ubuntu"
+
+- name: Remove previous docker versions [RHEL/CentOS]
+  dnf:
+    name:
+      - docker
+      - docker-client
+      - docker-client-latest
+      - docker-common
+      - docker-latest
+      - docker-latest-logrotate
+      - docker-logrotate
+      - docker-engine
+    state: absent
+    autoremove: yes
+  when: os_type == "rhel"
+
+- name: Remove podman-manpages [RHEL/CentOS]
+  dnf:
+    name: podman-manpages
+    state: absent
+    autoremove: yes
+  when: os_type == "rhel"
+
+#- name: Install yum-utils
+#  dnf:
+#    name: yum-utils
+#    state: present
+#  when: os_type == "rhel"
+
+- name: Add docker-ce repo [RHEL/CentOS]
+  command:
+    cmd: dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+    warn: false
+  when: os_type == "rhel"
+
+- name: Install docker-ce [RHEL/CentOS]
+  dnf:
+    name:
+    - docker-ce 
+    - docker-ce-cli 
+    - containerd.io
+    state: present
+  when: os_type == "rhel"
+
+- name: Start docker service
+  ansible.builtin.systemd:
+    name: docker
+    state: started
+
+- name: Ensure group "docker" exists
+  ansible.builtin.group:
+    name: docker
+    state: present
+
+- name: add anthos user to docker group
+  ansible.builtin.user:
+    name: "{{ login_user }}"
+    groups: docker
+    append: yes

--- a/tools/anthosbm-ansible-module/vars/anthos_vars.yml
+++ b/tools/anthosbm-ansible-module/vars/anthos_vars.yml
@@ -1,0 +1,67 @@
+# Copyright 2021 Google LLC
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+login_user: anthos
+login_user_group: anthos
+login_user_home: /home/anthos
+
+# Possible values: ubuntu | rhel 
+# Use rhel for CentOS as well
+os_type: "ubuntu"
+# Set value to "yes" to apply the respective role
+ws_docker: "yes"
+gcloud_sdk: "yes"
+kubectl_tool: "yes"
+bmctl_tool: "yes"
+# if the GCP service accounts have already been created, copy the keys files to gcp_sa_key_dir directory
+service_accounts: "yes"
+
+bmctl_download_url: gs://anthos-baremetal-release/bmctl/1.7.0/linux-amd64/bmctl
+bmctl_workspace_dir: bmctl-workspace
+gcp_sa_key_dir: /home/anthos/gcp_keys
+local_gcr_sa_name: anthos-gcr-svc-account
+local_connect_agent_sa_name: connect-agent-svc-account
+local_connect_register_sa_name: connect-register-svc-account
+local_cloud_operations_sa_name: cloud-ops-svc-account
+
+ssh_private_key_path: /home/anthos/.ssh/id_rsa
+# the GCP project ID
+project_id: 
+# GCP region e.g. us-central1
+location: 
+# anthos cluster name
+cluster_name: 
+# cluster type, possible values: standalone | hybrid | admin | user
+cluster_type: 
+max_pod_per_node: 250
+# container runtime, possible values: docker | contianerd
+container_runtime: docker
+# enable/disable application logging for cluster workloads. use 'true' to enable
+app_logs: false
+# change pod and service cidr if the default ones overlap with cluster nodes subnets
+pod_cidr: 192.168.0.0/16
+service_cidr: 10.96.0.0/12
+# cp_vip should be different than nodes ip addresses and should not be in lb_address_pool but should be from Control plane cluster node subnets
+cp_vip: 10.200.0.47
+# ingress_vip should be in lb_address_pool
+ingress_vip: 10.200.0.48
+lb_address_pool: 
+- 10.200.0.48/28
+# For a 'user' cluster, place the admin cluster kubeconfig file on workstation machine 
+# and set admin_kubeconfig_path to the absolute path of this file
+admin_kubeconfig_path: 
+# list of users or service accounts that will be connect gateway members
+cgw_members: 
+- user:EXAMPLE_USER@google.com
+- serviceAccount:EXAMPLE_SA@GCP_PROJECT_ID.iam.gserviceaccount.com


### PR DESCRIPTION
The ansible module for Anthos on Bare Metal is a tool that can be used for installing Anthos on Bare Metal nodes. This can be used for creating various kind of clusters (admin, user, hybrid and standalone).