### PR TITLE
Fix java formatting As it breaks Cloud Build

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The tools folder contains ready-made utilities which can simpilfy Google Cloud P
 * [Agile Machine Learning API](tools/agile-machine-learning-api) - A web application which provides the ability to train and deploy ML models on Google Cloud Machine Learning Engine, and visualize the predicted results using LIME through simple post request.
 * [Apache Beam Client Throttling](tools/apachebeam-throttling) - A library that can be used to limit the number of requests from an Apache Beam pipeline to an external service. It buffers requests to not overload the external service and activates client-side throttling when the service starts rejecting requests due to out of quota errors.
 * [AssetInventory](tools/asset-inventory) - Import Cloud Asset Inventory resourcs into BigQuery.
-* [AnthosBMAnsibleModule](tools/anthosbm-ansible-module) - Ansible module for installation of Anthos on Bare Metal
+* [Ansible Module for Anthos on Bare Metal](tools/anthosbm-ansible-module) - Ansible module for installation of Anthos on Bare Metal
 * [BigQuery Discount Per-Project Attribution](tools/kunskap) - A tool that automates the generation of a BigQuery table that uses existing exported billing data, by attributing both CUD and SUD charges on a per-project basis.
 * [BigQuery Query Plan Exporter](tools/bigquery-query-plan-exporter) - Command line utility for exporting BigQuery query plans in a given date range.
 * [BigQuery Query Plan Visualizer](tools/bq-visualizer) - A web application which provides the ability to visualise the execution stages of BigQuery query plans to aid in the optimization of queries.

--- a/helpers/check_format.sh
+++ b/helpers/check_format.sh
@@ -19,6 +19,9 @@
 #
 # The following languages are currently supported:
 # - python (using yapf)
+# - golang (using gofmt)
+# - typescript (using npm)
+# - java (using google-java-format 1.7)
 
 # need_formatting - helper function to error out when
 # a folder contains files that need formatting

--- a/helpers/exclusion_list.txt
+++ b/helpers/exclusion_list.txt
@@ -26,6 +26,7 @@
 ./tools/site-verification-group-sync
 ./tools/terraform-module-update-scanner
 ./tools/bigquery-hive-external-table-loader
+./tools/quota-monitoring-alerting
 ./examples/bigquery-audit-log
 ./examples/bigquery-billing-dashboard
 ./examples/bigquery-cross-project-slot-monitoring

--- a/helpers/format.sh
+++ b/helpers/format.sh
@@ -22,6 +22,9 @@
 #
 # The following languages are currently supported:
 # - python (using yapf)
+# - golang (using gofmt)
+# - typescript (using npm)
+# - java (using google-java-format 1.7)
 
 # temporary list of folders to exclude
 EXCLUDE_FOLDERS=$(cat helpers/exclusion_list.txt)
@@ -69,10 +72,12 @@ do
         echo "Formatting java files (if any)"
 
         FILES_TO_FORMAT=$(find "$FOLDER" -type f -name "*.java")
+        # write the list to a temporary files which will be the input to google-java-format
+        echo "$FILES_TO_FORMAT" > /tmp/file.txt
         if [[ ! -z "$FILES_TO_FORMAT" ]]
         then
             # format all java files in place
-            java -jar /usr/share/java/google-java-format-1.7-all-deps.jar -i "$FILES_TO_FORMAT"
+            java -jar /usr/share/java/google-java-format-1.7-all-deps.jar -i @/tmp/file.txt
         else
             echo "No java files found for $FOLDER - SKIP"
         fi


### PR DESCRIPTION
google-java-format breaks when a Pull request contains Java code. That's because the list of files to format was passed via a variables with double quotes "".

google-java-format doesn't like that and complains cannot read file. It considered the input as a string which contains a long list of files.

Removing the quotes doesn't work, this is because the linter will complain about it (the next step in Cloud Build)

So the straightforward solution is to write the list of files to format temporary to a file and pass that list to the google-java-format via an @ directive which works.

Also updated some documentation
