### PR TITLE
Pubsub2Inbox enhancements (GCS copier, GCS read, filemagic)

### DIFF
--- a/tools/pubsub2inbox/README.md
+++ b/tools/pubsub2inbox/README.md
@@ -33,6 +33,8 @@ Out of the box, you'll have the following functionality:
      - From [Recommender API](https://cloud.google.com/recommender/docs/overview).
      - Also see [example with attached spreadsheet](examples/recommendations-example-2.yaml).
   - [Cloud Monitoring alerts](examples/monitoring-config.yaml)
+  - [Cloud Storage copier](examples/gcscopy-example.yaml)
+     - Copies objects between two buckets, useful for backing up.
   - Any JSON
     - [See the example of generic JSON processing](examples/generic-config.yaml)
 
@@ -89,6 +91,8 @@ Available output processors are:
   - [gcs.py](output/gcs.py): can create objects on GCS from any inputs.
   - [webhook.py](output/webhook.py): can send arbitrary HTTP requests, optionally
     with added OAuth2 bearer token from GCP.
+  - [gcscopy.py](output/gcscopy.py): copies files between buckets.
+  - [logger.py](output/logger.py): Logs message in Cloud Logging.
 
 Please note that the output processors have some IAM requirements to be able to
 pull information from GCP:

--- a/tools/pubsub2inbox/examples/bigquery-example.yaml
+++ b/tools/pubsub2inbox/examples/bigquery-example.yaml
@@ -1,3 +1,16 @@
+#   Copyright 2021 Google LLC
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
 
 retryPeriod: 3 days ago
 

--- a/tools/pubsub2inbox/examples/budget-config.yaml
+++ b/tools/pubsub2inbox/examples/budget-config.yaml
@@ -1,3 +1,17 @@
+#   Copyright 2021 Google LLC
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
 # Input processors to use
 processors:
   - budget

--- a/tools/pubsub2inbox/examples/gcscopy-example.yaml
+++ b/tools/pubsub2inbox/examples/gcscopy-example.yaml
@@ -1,0 +1,35 @@
+#   Copyright 2021 Google LLC
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# Copies files from one bucket to another based on Storage Notifications API.
+# You may want to increase function timeout for large files, or use Cloud Run for longer timeouts.
+# (copying 6 GB might take from 7 minutes to 2 second depending on source/destination region,
+# storage class, etc.)
+retryPeriod: 3 day ago
+
+processors:
+  - genericjson
+
+processIf: "{% if event.attributes.eventType == 'OBJECT_FINALIZE' %}1{% endif %}"
+
+outputs:
+  - type: logger
+    message: 'Backing up object from source bucket.'
+    variables:
+      mime_type: "{{ ('gs://' ~ data.bucket ~ '/' ~ data.name)|read_gcs_object(0, 1024)|filemagic }}"
+  - type: gcscopy
+    sourceBucket: "{{ data.bucket }}"
+    sourceObject: "{{ data.name }}"
+    destinationBucket: "my-gcscopy-testing-bucket"
+    destinationObject: "copy-{{ data.name }}"

--- a/tools/pubsub2inbox/examples/generic-config.yaml
+++ b/tools/pubsub2inbox/examples/generic-config.yaml
@@ -1,3 +1,16 @@
+#   Copyright 2021 Google LLC
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
 processors:
   - genericjson
 

--- a/tools/pubsub2inbox/examples/monitoring-config.yaml
+++ b/tools/pubsub2inbox/examples/monitoring-config.yaml
@@ -1,3 +1,17 @@
+#   Copyright 2021 Google LLC
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
 # Generates alert emails from Cloud Monitoring alert Pub/Sub messages
 #
 processors:

--- a/tools/pubsub2inbox/examples/recommendations-example.yaml
+++ b/tools/pubsub2inbox/examples/recommendations-example.yaml
@@ -1,3 +1,16 @@
+#   Copyright 2021 Google LLC
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
 retryPeriod: 10 years ago
 
 processors:

--- a/tools/pubsub2inbox/examples/scc-config.yaml
+++ b/tools/pubsub2inbox/examples/scc-config.yaml
@@ -1,3 +1,16 @@
+#   Copyright 2021 Google LLC
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
 processors:
   - scc
 

--- a/tools/pubsub2inbox/examples/storage-example.yaml
+++ b/tools/pubsub2inbox/examples/storage-example.yaml
@@ -1,4 +1,17 @@
-
+#   Copyright 2021 Google LLC
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
 retryPeriod: 3 day ago
 
 processors:

--- a/tools/pubsub2inbox/filters/__init__.py
+++ b/tools/pubsub2inbox/filters/__init__.py
@@ -13,7 +13,7 @@
 #   limitations under the License.
 from .regex import regex_replace
 from .lists import split, index
-from .strings import add_links, urlencode, generate_signed_url, json_encode, csv_encode, html_table_to_xlsx, make_list
+from .strings import add_links, urlencode, generate_signed_url, json_encode, csv_encode, html_table_to_xlsx, make_list, read_gcs_object, filemagic
 from .date import strftime, recurring_date
 from .gcp import format_cost, get_cost
 
@@ -33,5 +33,7 @@ def get_jinja_filters():
         'format_cost': format_cost,
         'get_cost': get_cost,
         'recurring_date': recurring_date,
-        'make_list': make_list
+        'make_list': make_list,
+        'read_gcs_object': read_gcs_object,
+        'filemagic': filemagic
     }

--- a/tools/pubsub2inbox/main.py
+++ b/tools/pubsub2inbox/main.py
@@ -42,14 +42,20 @@ def load_configuration(file_name):
     if os.getenv('CONFIG'):
         logger = logging.getLogger('pubsub2inbox')
         secret_manager_url = os.getenv('CONFIG')
-        logger.debug('Loading configuration from Secret Manager: %s' %
-                     (secret_manager_url))
-        client_info = grpc_client_info.ClientInfo(
-            user_agent='google-pso-tool/pubsub2inbox/1.1.0')
-        client = secretmanager.SecretManagerServiceClient(
-            client_info=client_info)
-        response = client.access_secret_version(name=secret_manager_url)
-        configuration = response.payload.data.decode('UTF-8')
+        if secret_manager_url.startswith('projects/'):
+            logger.debug('Loading configuration from Secret Manager: %s' %
+                         (secret_manager_url))
+            client_info = grpc_client_info.ClientInfo(
+                user_agent='google-pso-tool/pubsub2inbox/1.1.0')
+            client = secretmanager.SecretManagerServiceClient(
+                client_info=client_info)
+            response = client.access_secret_version(name=secret_manager_url)
+            configuration = response.payload.data.decode('UTF-8')
+        else:
+            logger.debug('Loading configuration from bundled file: %s' %
+                         (secret_manager_url))
+            with open(secret_manager_url) as config_file:
+                configuration = config_file.read()
     else:
         with open(file_name) as config_file:
             configuration = config_file.read()
@@ -225,6 +231,18 @@ def process_message(config, data, event, context):
             if 'type' not in output_config:
                 raise NoTypeConfiguredException(
                     'No type configured for output!')
+
+            if 'processIf' in output_config:
+                processif_template = jinja_environment.from_string(
+                    output_config['processIf'])
+                processif_template.name = 'processif'
+                processif_contents = processif_template.render()
+                if processif_contents.strip() == '':
+                    logger.info(
+                        'Will not use output processor %s because processIf evaluated to empty.'
+                        % output_config['type'])
+                continue
+
             logger.debug('Processing message using output processor: %s' %
                          output_config['type'])
 
@@ -266,7 +284,8 @@ def decode_and_process(logger, config, event, context):
     logger.debug('Starting Pub/Sub message processing...',
                  extra={
                      'event_id': context.event_id,
-                     'data': data
+                     'data': data,
+                     'attributes': event['attributes']
                  })
     process_message(config, data, event, context)
     logger.debug('Pub/Sub message processing finished.',

--- a/tools/pubsub2inbox/output/gcscopy.py
+++ b/tools/pubsub2inbox/output/gcscopy.py
@@ -1,0 +1,104 @@
+#   Copyright 2021 Google LLC
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+from .base import Output, NotConfiguredException
+from google.cloud import storage
+from google.api_core.gapic_v1 import client_info as grpc_client_info
+
+
+class GcscopyOutput(Output):
+
+    def output(self):
+        if 'sourceBucket' not in self.output_config:
+            raise NotConfiguredException(
+                'No source bucket defined in GCS output.')
+        if 'sourceObject' not in self.output_config:
+            raise NotConfiguredException(
+                'No source object defined in GCS output.')
+        if 'destinationBucket' not in self.output_config:
+            raise NotConfiguredException(
+                'No destination bucket defined in GCS output.')
+        if 'destinationObject' not in self.output_config:
+            raise NotConfiguredException(
+                'No destination object defined in GCS output.')
+
+        bucket_template = self.jinja_environment.from_string(
+            self.output_config['sourceBucket'])
+        bucket_template.name = 'bucket'
+        source_bucket = bucket_template.render()
+
+        object_template = self.jinja_environment.from_string(
+            self.output_config['sourceObject'])
+        object_template.name = 'object'
+        source_object = object_template.render()
+
+        bucket_template = self.jinja_environment.from_string(
+            self.output_config['destinationBucket'])
+        bucket_template.name = 'bucket'
+        destination_bucket = bucket_template.render()
+
+        object_template = self.jinja_environment.from_string(
+            self.output_config['destinationObject'])
+        object_template.name = 'object'
+        destination_object = object_template.render()
+
+        self.logger.debug('Starting to copy source to destination.',
+                          extra={
+                              'source_url':
+                                  'gs://%s/%s' % (source_bucket, source_object),
+                              'destination_url':
+                                  'gs://%s/%s' %
+                                  (destination_bucket, destination_object)
+                          })
+
+        client_info = grpc_client_info.ClientInfo(
+            user_agent='google-pso-tool/pubsub2inbox/1.1.0')
+        project = self.output_config[
+            'project'] if 'project' in self.output_config else None
+        storage_client = storage.Client(client_info=client_info,
+                                        project=project)
+
+        bucket = storage_client.bucket(source_bucket)
+        source_blob = bucket.blob(source_object)
+
+        bucket = storage_client.bucket(destination_bucket)
+        destination_blob = bucket.blob(destination_object)
+        token = None
+        while True:
+            self.logger.debug(
+                'Copying file...',
+                extra={
+                    'token':
+                        token,
+                    'source_url':
+                        'gs://%s/%s' % (source_bucket, source_object),
+                    'destination_url':
+                        'gs://%s/%s' % (destination_bucket, destination_object)
+                })
+            ret = destination_blob.rewrite(source_blob, token=token)
+            token = ret[0]
+            if token is None:
+                break
+
+        self.logger.info('Object copied from source to destination.',
+                         extra={
+                             'bytes_rewritten':
+                                 ret[1],
+                             'total_bytes':
+                                 ret[2],
+                             'source_url':
+                                 'gs://%s/%s' % (source_bucket, source_object),
+                             'destination_url':
+                                 'gs://%s/%s' %
+                                 (destination_bucket, destination_object)
+                         })

--- a/tools/pubsub2inbox/output/logger.py
+++ b/tools/pubsub2inbox/output/logger.py
@@ -1,0 +1,47 @@
+#   Copyright 2021 Google LLC
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+from .base import Output, NotConfiguredException
+
+
+class LoggerOutput(Output):
+
+    def output(self):
+        if 'message' not in self.output_config:
+            raise NotConfiguredException('No log message defined!')
+
+        message_template = self.jinja_environment.from_string(
+            self.output_config['message'])
+        message_template.name = 'message'
+        message_rendered = message_template.render()
+
+        extra_vars = {}
+        if 'variables' in self.output_config:
+            for k, v in self.output_config['variables'].items():
+                variable_template = self.jinja_environment.from_string(v)
+                variable_template.name = 'variable'
+                val = variable_template.render()
+                extra_vars[k] = val
+
+        log_level = 'info'
+        if 'level' in self.output_config:
+            loglevel_template = self.jinja_environment.from_string(
+                self.output_config['level'])
+            loglevel_template.name = 'loglevel'
+            log_level = loglevel_template.render()
+        if log_level == 'error' or log_level == 'err':
+            self.logger.error(message_rendered, extra=extra_vars)
+        elif log_level == 'warn' or log_level == 'warning':
+            self.logger.warning(message_rendered, extra=extra_vars)
+        else:
+            self.logger.info(message_rendered, extra=extra_vars)

--- a/tools/pubsub2inbox/requirements.txt
+++ b/tools/pubsub2inbox/requirements.txt
@@ -20,3 +20,4 @@ google-cloud-recommender~=2.0.0
 openpyxl~=3.0.7
 tablepyxl~=0.6.1
 recurrent~=0.4.0
+filemagic~=1.6

--- a/tools/pubsub2inbox/variables.tf
+++ b/tools/pubsub2inbox/variables.tf
@@ -60,3 +60,9 @@ variable "bucket_name" {
 
   default = "cf-pubsub2inbox"
 }
+
+variable "function_timeout" {
+  type        = number
+  description = "Cloud Function timeout (maximum 540 seconds)"
+  default     = 60
+}


### PR DESCRIPTION
Adding new features to Pubsub2Inbox:
- GCS copier example (copies files between buckets, useful for backing up buckets via Storage Notifications)
- Read GCS files with Jinja2 filter
- Filemagic support for detecting mime types
- Refactored some of the Terraform code to use archive provider
