### PR TITLE
New add_load_date_suffix import option.

### DIFF
--- a/tools/asset-inventory/asset_inventory/import_pipeline_metadata
+++ b/tools/asset-inventory/asset_inventory/import_pipeline_metadata
@@ -32,6 +32,13 @@
     "regexes": ["^(WRITE_APPEND|WRITE_EMPTY)$"]
   },
   {
+    "name": "add_load_date_suffix",
+    "label": "If the load date [YYYYMMDD] is added as a table suffix.",
+    "help_text": "Either 'true' or 'false'.",
+    "isOptional": true,
+    "regexes": ["^(true|false)$"]
+  },
+  {
     "name": "dataset",
     "label": "BigQuery dataset to load to.",
     "help_text": "BigQuery dataset name such as project-1.dataset_id or just dataset_id.",

--- a/tools/asset-inventory/asset_inventory/pipeline_runner.py
+++ b/tools/asset-inventory/asset_inventory/pipeline_runner.py
@@ -67,7 +67,8 @@ def wait_on_pipeline_job(df_service, pipeline_job):
 
 def run_pipeline_template(dataflow_project, template_region, template_location,
                           input_location, group_by, write_disposition, dataset,
-                          stage, load_time, num_shards, runtime_environment):
+                          stage, load_time, num_shards, add_load_date_suffix,
+                          runtime_environment):
     """Invoke the suplied pipeline template.
 
     Args:
@@ -81,6 +82,7 @@ def run_pipeline_template(dataflow_project, template_region, template_location,
         stage: GCS path to write BigQuery load files.
         load_time: Timestamp or date to load data with.
         num_shards: Shards for for each asset type.
+        add_load_date_suffix: If the load date is added as a table suffix.
         runtime_environment: Dict  suppling other runtime overrides.
     Returns:
         End state of the pipline and job object.
@@ -100,6 +102,7 @@ def run_pipeline_template(dataflow_project, template_region, template_location,
             'group_by': group_by,
             'write_disposition': write_disposition,
             'num_shards': num_shards,
+            'add_load_date_suffix': add_load_date_suffix,
             'dataset': dataset,
         },
         'environment': runtime_environment
@@ -118,7 +121,8 @@ def run_pipeline_template(dataflow_project, template_region, template_location,
 
 def run_pipeline_beam_runner(pipeline_runner, dataflow_project, input_location,
                              group_by, write_disposition, dataset, stage,
-                             load_time, num_shards, pipeline_arguments):
+                             load_time, num_shards, add_load_date_suffix,
+                             pipeline_arguments):
     """Invokes the pipeline with a beam runner.
 
     Only tested with the dataflow and direct runners.
@@ -133,6 +137,7 @@ def run_pipeline_beam_runner(pipeline_runner, dataflow_project, input_location,
         stage: GCS path to write BigQuery load files.
         load_time: Timestamp to add to data during during BigQuery load.
         num_shards: Shards for for each asset type.
+        add_load_date_suffix: If the load date is added as a table suffix.
         pipeline_arguments: List of additional runner arguments.
     Returns:
         The end state of the pipeline run (a string), and PipelineResult.
@@ -155,6 +160,7 @@ def run_pipeline_beam_runner(pipeline_runner, dataflow_project, input_location,
         '--group_by': group_by,
         '--write_disposition': write_disposition,
         '--num_shards': num_shards,
+        '--add_load_date_suffix': add_load_date_suffix,
         '--dataset': dataset,
         '--stage': stage,
         '--runner': pipeline_runner

--- a/tools/asset-inventory/gae/config.yaml
+++ b/tools/asset-inventory/gae/config.yaml
@@ -83,5 +83,8 @@ import_write_disposition: WRITE_APPEND
 # *=1,resource=100,google.cloud.bigquery.Table=100
 import_num_shards: "*=1"
 
+# If the load date [YYYYMMDD] is added as a table suffix.
+import_add_load_date_suffix: False
+
 # If we are running on App Engine and only want to be invoked by cron tasks for security reasons.
 restrict_to_cron_tasks: True

--- a/tools/asset-inventory/gae/main.py
+++ b/tools/asset-inventory/gae/main.py
@@ -73,6 +73,7 @@ def get_import_arguments():
             CONFIG.import_template_region, CONFIG.import_template_location,
             '{}/*.json'.format(CONFIG.gcs_destination), CONFIG.import_group_by,
             CONFIG.import_write_disposition, CONFIG.import_dataset,
+            CONFIG.import_add_load_date_suffix,
             CONFIG.import_stage,
             datetime.datetime.now().isoformat(),
             CONFIG.import_num_shards,
@@ -87,7 +88,8 @@ def run_import():
     import_arguments = get_import_arguments()
     logging.info('running import %s', import_arguments)
     (runner, dataflow_project, template_region, template_location,
-     input_location, group_by, write_disposition, dataset, stage, load_time,
+     input_location, group_by, write_disposition, dataset,
+     add_load_date_suffix, stage, load_time,
      num_shards, pipeline_arguments,
      pipeline_runtime_environment) = import_arguments
 
@@ -96,12 +98,13 @@ def run_import():
             dataflow_project, template_region,
             template_location, input_location,
             group_by, write_disposition, dataset, stage,
-            load_time, num_shards, pipeline_runtime_environment)
+            load_time, num_shards, add_load_date_suffix,
+            pipeline_runtime_environment)
     else:
         return pipeline_runner.run_pipeline_beam_runner(
             runner, dataflow_project, input_location,
             group_by, write_disposition, dataset, stage, load_time,
-            num_shards, pipeline_arguments)
+            num_shards, add_load_date_suffix, pipeline_arguments)
 
 
 @app.route('/export_import')


### PR DESCRIPTION
With the new import option , the pipeline will now create
a new BigQuery table for each new load date. This helps handle API incompatible
schema changes better as each day's imports only need to be consistent rather
then all prior imports.

