### PR TITLE
Adding google-cloud-support-slackbot to the exclusion list

### DIFF
--- a/helpers/exclusion_list.txt
+++ b/helpers/exclusion_list.txt
@@ -26,6 +26,7 @@
 ./tools/site-verification-group-sync
 ./tools/terraform-module-update-scanner
 ./tools/bigquery-hive-external-table-loader
+./tools/google-cloud-support-slackbot
 ./examples/bigquery-audit-log
 ./examples/bigquery-billing-dashboard
 ./examples/bigquery-cross-project-slot-monitoring


### PR DESCRIPTION
Adding google-cloud-support-slackbot to the exclusion list.

This folder breaks CI as it doesn't pass our automated linting.

