### PR TITLE
Provide optional path for bmctl

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ The tools folder contains ready-made utilities which can simplify Google Cloud P
 
 * [Agile Machine Learning API](tools/agile-machine-learning-api) - A web application which provides the ability to train and deploy ML models on Google Cloud Machine Learning Engine, and visualize the predicted results using LIME through simple post request.
 * [Airpiler](tools/airpiler) - A python script to convert Autosys JIL files to dag-factory format to be executed in Cloud Composer (managed airflow environment).
+* [Anthos Bare Metal Installer](tools/anthosbm-ansible-module) - An [ansible](https://www.ansible.com/resources/get-started) playbook that can be used to install [Anthos Bare Metal](https://cloud.google.com/anthos/clusters/docs/bare-metal).
 * [Apache Beam Client Throttling](tools/apachebeam-throttling) - A library that can be used to limit the number of requests from an Apache Beam pipeline to an external service. It buffers requests to not overload the external service and activates client-side throttling when the service starts rejecting requests due to out of quota errors.
 * [API Key Rotation Checker](tools/api-key-rotation) - A tool that checks your GCP organization for API keys and compares them to a customizable rotation period. Regularly rotating API keys is a Google and industry standard recommended best practice.
 * [AssetInventory](tools/asset-inventory) - Import Cloud Asset Inventory resourcs into BigQuery.

--- a/tools/anthosbm-ansible-module/README.md
+++ b/tools/anthosbm-ansible-module/README.md
@@ -269,6 +269,16 @@ bmctl_download_url: gs://anthos-baremetal-release/bmctl/1.6.2/linux-amd64/bmctl
 ```
 
 
+The location of bmctl executable is defaulted to `/usr/local/sbin` which can be changed through below variable.
+
+
+*vars/anthos_vars.yml*
+
+```
+bmctl_path: /home/user1/baremetal
+```
+
+
 
 ## 4. Google Cloud Configuration
 

--- a/tools/anthosbm-ansible-module/roles/bmctl-tool/tasks/main.yml
+++ b/tools/anthosbm-ansible-module/roles/bmctl-tool/tasks/main.yml
@@ -13,9 +13,17 @@
 # limitations under the License.
 
 ---
+- set_fact: bmctl_path="/usr/local/sbin"
+  when: bmctl_path is undefined
+
+- name: Create bmctl_path if it does not exists
+  file:
+    path: "{{ bmctl_path }}"
+    state: directory
+
 - name: Remove bmctl if present
   ansible.builtin.file:
-    path: /usr/local/sbin/bmctl
+    path: "{{ bmctl_path }}/bmctl"
     state: absent
 
 - name: Download bmctl
@@ -27,6 +35,28 @@
     path: bmctl
     mode: a+x
 
-- name: Move bmctl to /usr/local/sbin
+- name: 'Move bmctl to {{ bmctl_path }}'
   shell:
-    cmd: mv bmctl /usr/local/sbin/
+    cmd: "mv bmctl {{ bmctl_path }}/"
+
+- name: Create .profile if it does not exists for non default path(/usr/local/sbin)
+  file:
+    path: "{{ login_user_home }}/.profile"
+    owner: "{{ login_user }}"
+    state: touch
+  when: bmctl_path != "/usr/local/sbin"
+
+- name: 'Add {{ bmctl_path }} if PATH does not exist'
+  lineinfile:
+    path: "{{ login_user_home }}/.profile"
+    line: 'PATH="{{ bmctl_path }}":$PATH'
+    insertafter: EOF
+  when: bmctl_path != "/usr/local/sbin" and lookup('file', "{{ login_user_home }}/.profile") is not search('^\s*PATH\s*=')
+
+- name: 'Add {{ bmctl_path }} to PATH'
+  lineinfile:
+    path: "{{ login_user_home }}/.profile"
+    regexp: 'PATH=(["])((?!.*?{{ bmctl_path }}).*?)(["])$'
+    line: 'PATH=\1\2:{{ bmctl_path }}\3'
+    backrefs: yes
+  when: bmctl_path != "/usr/local/sbin" and lookup('file', "{{ login_user_home }}/.profile") is search('^\s*PATH\s*=')

--- a/tools/anthosbm-ansible-module/roles/bmctl-tool/tasks/main.yml
+++ b/tools/anthosbm-ansible-module/roles/bmctl-tool/tasks/main.yml
@@ -49,7 +49,7 @@
 - name: 'Add {{ bmctl_path }} if PATH does not exist'
   lineinfile:
     path: "{{ login_user_home }}/.profile"
-    line: 'PATH="{{ bmctl_path }}":$PATH'
+    line: 'PATH="{{ bmctl_path }}:$PATH"'
     insertafter: EOF
   when: bmctl_path != "/usr/local/sbin" and lookup('file', "{{ login_user_home }}/.profile") is not search('^\s*PATH\s*=')
 
@@ -57,6 +57,6 @@
   lineinfile:
     path: "{{ login_user_home }}/.profile"
     regexp: 'PATH=(["])((?!.*?{{ bmctl_path }}).*?)(["])$'
-    line: 'PATH=\1\2:{{ bmctl_path }}\3'
+    line: 'PATH=\1{{ bmctl_path }}:\2\3'
     backrefs: yes
   when: bmctl_path != "/usr/local/sbin" and lookup('file', "{{ login_user_home }}/.profile") is search('^\s*PATH\s*=')


### PR DESCRIPTION
Existing playbook installs `bmctl` in `\usr\local\sbin`, for troubleshooting or development needs there is a need to have different ABM versions installed on admin workstation at any given time. This PR gives the user the ability to choose a custom path for where  `bmctl` resides for each install.

* Engineering Council bug ID - 192972086
* Closes #691

Unit test logs attached to the Engineering council bug id.