### PR TITLE
Allow diferent loginUser for admin and worker nodes

### DIFF
--- a/tools/anthosbm-ansible-module/README.md
+++ b/tools/anthosbm-ansible-module/README.md
@@ -387,6 +387,8 @@ The variable file is placed in the**vars** directory under the root of the code 
 login_user: anthos
 login_user_group: anthos
 login_user_home: /home/anthos
+# node login user, when "login_user" used for admin node is different for worker node.
+# node_login_user: anthos2
 # Possible values: ubuntu | rhel 
 # Use rhel for CentOS as well
 os_type: "ubuntu"
@@ -662,6 +664,7 @@ You need to set the _cluster\_type_ and _cluster\_name_ variables in the variabl
 login_user: anthos
 login_user_group: anthos
 login_user_home: /home/anthos
+node_login_user: anthos2
 os_type: "ubuntu"
 ws_docker: "yes"
 gcloud_sdk: "yes"

--- a/tools/anthosbm-ansible-module/roles/anthos/templates/cluster.yaml.j2
+++ b/tools/anthosbm-ansible-module/roles/anthos/templates/cluster.yaml.j2
@@ -83,7 +83,11 @@ spec:
       maxPodsPerNode: {{ max_pod_per_node }}
     containerRuntime: {{ container_runtime }}
   nodeAccess:
++{% if node_login_user is defined %}
++    loginUser: {{ node_login_user }}
++{% else %}
     loginUser: {{ login_user }}
++{% endif %}
 {% if (cluster_type != 'admin') and groups['worker_nodes'] %}
 ---
 apiVersion: baremetal.cluster.gke.io/v1

--- a/tools/anthosbm-ansible-module/vars/anthos_vars.yml
+++ b/tools/anthosbm-ansible-module/vars/anthos_vars.yml
@@ -16,6 +16,9 @@ login_user: anthos
 login_user_group: anthos
 login_user_home: /home/anthos
 
+# node login user, when "login_user" used for admin node is different for worker node.
+# node_login_user: anthos2
+
 # Possible values: ubuntu | rhel 
 # Use rhel for CentOS as well
 os_type: "ubuntu"


### PR DESCRIPTION
Description of Changes
- update existing field `loginUser` in cluster config template(jinja) file based on the new config attribute in vars/anthos.yml
- Updated README
- Engineering Council bug id is 202891463
- Closes #702 

UT logs attached to eng council bug id.