### PR TITLE
Update to latest log4j dependency

### DIFF
--- a/examples/e2e-test-dataflow/pom.xml
+++ b/examples/e2e-test-dataflow/pom.xml
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.13.0</version>
+            <version>2.16.0</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>


### PR DESCRIPTION
Updating to the latest version of log4j (2.16.0).

Code compiles, integration tests not checked.