### PR TITLE
Update to Beam 2.34 to avoid pulling log4j

### DIFF
--- a/examples/bigtable-change-key/pom.xml
+++ b/examples/bigtable-change-key/pom.xml
@@ -27,9 +27,9 @@
     <packaging>jar</packaging>
 
     <properties>
-        <beam.version>2.31.0</beam.version>
-        <google-api-client.version>1.31.1</google-api-client.version>
-        <libraries-bom.version>20.0.0</libraries-bom.version>
+        <beam.version>2.34.0</beam.version>
+        <google-api-client.version>1.32.1</google-api-client.version>
+        <libraries-bom.version>22.0.0</libraries-bom.version>
         <guava.version>30.1-jre</guava.version>
         <apache-commons.version>3.12.0</apache-commons.version>
         <hamcrest.version>2.1</hamcrest.version>


### PR DESCRIPTION
This removes log4j as dependency from this example.