### PR TITLE
Update to Beam 2.34 to avoid pulling log4j

### DIFF
--- a/examples/dataflow-dlp-hash-pipeline/pom.xml
+++ b/examples/dataflow-dlp-hash-pipeline/pom.xml
@@ -39,13 +39,13 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- Dependency properties -->
-    <beam.version>2.21.0</beam.version>
+    <beam.version>2.34.0</beam.version>
     <gson.version>2.7</gson.version>
-    <hamcrest.version>1.3</hamcrest.version>
+    <hamcrest.version>2.1</hamcrest.version>
     <java.version>1.8</java.version>
     <j2v8.version>4.8.0</j2v8.version>
     <json-data-generator.version>1.5</json-data-generator.version>
-    <junit.version>4.12</junit.version>
+    <junit.version>4.13.1</junit.version>
     <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
     <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
     <maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
@@ -64,7 +64,7 @@
     <maven-surefire-plugin.version>2.22.0</maven-surefire-plugin.version>
     <maven-versions-plugin.version>2.5</maven-versions-plugin.version>
     <mockito-core.version>2.21.0</mockito-core.version>
-    <slf4j.version>1.7.25</slf4j.version>
+    <slf4j.version>1.7.30</slf4j.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
This avoids pulling log4j as dependency in this example.