### PR TITLE
Fix: Sanitize arrays of primitive values in asset-inventory

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,3 @@
+# Ignore [ ! -n "$VAR" ] tests (instead of [ -z "$VAR" ])
+# https://github.com/koalaman/shellcheck/wiki/SC2236
+disable=SC2236

--- a/examples/dbt-on-cloud-composer/basic/dag/dbt_with_kubernetes.py
+++ b/examples/dbt-on-cloud-composer/basic/dag/dbt_with_kubernetes.py
@@ -45,8 +45,7 @@ default_args = {
 
 # Select and use the correct Docker image from the private Google Cloud Repository (GCR)
 IMAGE = 'gcr.io/{project}/dbt-builder-basic:latest'.format(
-    project=project,
-    env=env
+    project=project
 )
 
 # A Secret is an object that contains a small amount of sensitive data such as

--- a/examples/dbt-on-cloud-composer/optimized/dag/dbt_with_kubernetes_optimized.py
+++ b/examples/dbt-on-cloud-composer/optimized/dag/dbt_with_kubernetes_optimized.py
@@ -45,8 +45,7 @@ default_args = {
 
 # Select and use the correct Docker image from the private Google Cloud Repository (GCR)
 IMAGE = 'gcr.io/{project}/dbt-builder:latest'.format(
-    project=project,
-    env=env
+    project=project
 )
 
 # A Secret is an object that contains a small amount of sensitive data such as

--- a/tools/asset-inventory/asset_inventory/bigquery_schema.py
+++ b/tools/asset-inventory/asset_inventory/bigquery_schema.py
@@ -399,9 +399,13 @@ def sanitize_property_value(property_value, depth=0, num_properties=0):
 
     # sanitize each nested list element.
     if isinstance(property_value, list):
-        for array_item in property_value:
-            sanitize_property_value(array_item, depth, num_properties)
-
+        for i in range(len(property_value)):
+            if isinstance(property_value[i], (dict, list)):
+                sanitize_property_value(property_value[i], depth, num_properties)
+            else:
+                # if the list element has a primitive type, we need to re-affect the sanitized value
+                property_value[i] = sanitize_property_value(property_value[i], depth, num_properties)
+    
     # and each nested json object.
     if isinstance(property_value, dict):
         remove_duplicates(property_value)


### PR DESCRIPTION
- asset-inventory: fix sanitizing of arrays of primitive values
- shellcheck: adding `.checkshellrc` to make `make test` good again.
- examples/dbt-on-cloud-composer: fix linter warnings (to make `make test` good again.)