### PR TITLE
pubsub2inbox: avoid compatibility issues caused by jinja2 and markupsafe

### DIFF
--- a/tools/pubsub2inbox/requirements.txt
+++ b/tools/pubsub2inbox/requirements.txt
@@ -26,3 +26,4 @@ tftest~=1.6.0
 msal~=1.16.0
 requests~=2.26.0
 responses~=0.18.0
+markupsafe~=2.0.0


### PR DESCRIPTION
### Context
The [Markupsafe](https://github.com/pallets/markupsafe) released new minor version 2.1.0 that removes `soft_unicode()` function. This change is backwards incompatible and violates [semver2](https://semver.org) *(although it is not stated that they follow semver2)*.

The `soft_unicode()` function is used by Jinja2 2.11.3 (highest Jinja2 version from the minor version 2). 
The problem is that Jinja2 2.11.3 has no upper bound version limit for Markupsafe.
```
    - Jinja2 [required: >=2.10.1,<3.0, installed: 2.11.3]
      - MarkupSafe [required: >=0.23, installed: 2.1.0]
```
Due to above, Jinja2 2.11.3 with Markupsafe 2.1.0 are installed. This causes `pubsub2inbox` CF to fail like below:

```
ImportError: cannot import name 'soft_unicode' from 'markupsafe' (/layers/google.python.pip/pip/lib/python3.8/site-packages/markupsafe/__init__.py)

at .<module> ( [/layers/google.python.pip/pip/lib/python3.8/site-packages/jinja2/filters.py:13](https://pantheon.corp.google.com/debug?referrer=fromlog&file=%2Flayers%2Fgoogle.python.pip%2Fpip%2Flib%2Fpython3.8%2Fsite-packages%2Fjinja2%2Ffilters.py&line=13&project=monitoring-and-dashboards) )
at .<module> ( [/layers/google.python.pip/pip/lib/python3.8/site-packages/jinja2/defaults.py:3](https://pantheon.corp.google.com/debug?referrer=fromlog&file=%2Flayers%2Fgoogle.python.pip%2Fpip%2Flib%2Fpython3.8%2Fsite-packages%2Fjinja2%2Fdefaults.py&line=3&project=monitoring-and-dashboards) )
at .<module> ( [/layers/google.python.pip/pip/lib/python3.8/site-packages/jinja2/environment.py:25](https://pantheon.corp.google.com/debug?referrer=fromlog&file=%2Flayers%2Fgoogle.python.pip%2Fpip%2Flib%2Fpython3.8%2Fsite-packages%2Fjinja2%2Fenvironment.py&line=25&project=monitoring-and-dashboards) )
at .<module> ( [/layers/google.python.pip/pip/lib/python3.8/site-packages/jinja2/__init__.py:12](https://pantheon.corp.google.com/debug?referrer=fromlog&file=%2Flayers%2Fgoogle.python.pip%2Fpip%2Flib%2Fpython3.8%2Fsite-packages%2Fjinja2%2F__init__.py&line=12&project=monitoring-and-dashboards) )
at .<module> ( [/layers/google.python.pip/pip/lib/python3.8/site-packages/flask/__init__.py:14](https://pantheon.corp.google.com/debug?referrer=fromlog&file=%2Flayers%2Fgoogle.python.pip%2Fpip%2Flib%2Fpython3.8%2Fsite-packages%2Fflask%2F__init__.py&line=14&project=monitoring-and-dashboards) )
at .<module> ( [/layers/google.python.pip/pip/lib/python3.8/site-packages/functions_framework/__init__.py:26](https://pantheon.corp.google.com/debug?referrer=fromlog&file=%2Flayers%2Fgoogle.python.pip%2Fpip%2Flib%2Fpython3.8%2Fsite-packages%2Ffunctions_framework%2F__init__.py&line=26&project=monitoring-and-dashboards) )
at .<module> ( [/layers/google.python.pip/pip/bin/functions-framework:5](https://pantheon.corp.google.com/debug?referrer=fromlog&file=%2Flayers%2Fgoogle.python.pip%2Fpip%2Fbin%2Ffunctions-framework&line=5&project=monitoring-and-dashboards) )
```

### Solution

Forced `markupsafe~=2.0.0` in requirements.txt.
Upgrading jinja2 to version 3 should be considered in future.

### References
* https://github.com/pallets/jinja/issues/1585