### PR TITLE
fix(sts-job-manager): Fix accessing `objectConditions`

### DIFF
--- a/tools/sts-job-manager/sts_job_manager.py
+++ b/tools/sts-job-manager/sts_job_manager.py
@@ -200,8 +200,12 @@ def get_latest_operation_by_prefix(services: Services,
             break
 
         for operation in response['operations']:
-            object_conditions = \
-                operation['metadata']['transferSpec']['objectConditions']
+            transfer_spec = operation['metadata']['transferSpec']
+
+            if 'objectConditions' not in transfer_spec:
+                continue
+
+            object_conditions = transfer_spec['objectConditions']
 
             if 'includePrefixes' not in object_conditions:
                 continue


### PR DESCRIPTION
Not all operations will have `objectConditions` - namely, if a job has been created outside of the STS Job Manager. This will ensure the process doesn't crash and operate as expected.