### PR TITLE
fix(sts-job-manager): Support Fast Operations and Ignore Deleted Jobs

### DIFF
--- a/tools/sts-job-manager/README.md
+++ b/tools/sts-job-manager/README.md
@@ -189,7 +189,7 @@ optional arguments:
 
 ## Limits
 
-When preparing a loaded table one may have to wait up to 90 minutes before [rows are available](https://cloud.google.com/bigquery/streaming-data-into-bigquery#dataavailability) the STS Job Manager tool. It is recommended to follow the [latest limits on BigQuery's Data Manipulation Language (DML)](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-manipulation-language#limitations) while using this tool.
+When preparing a loaded table one may have to wait up to 90 minutes before [rows are available](https://cloud.google.com/bigquery/streaming-data-into-bigquery#dataavailability) for the STS Job Manager tool. It is recommended to follow the [latest limits on BigQuery's Data Manipulation Language (DML)](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-manipulation-language#limitations) while using this tool.
 
 It is recommended to follow the latest [ramp-up practices for Google Cloud Storage](https://cloud.google.com/storage/docs/request-rate#ramp-up) for a smoother transfer experience.
 

--- a/tools/sts-job-manager/README.md
+++ b/tools/sts-job-manager/README.md
@@ -189,7 +189,7 @@ optional arguments:
 
 ## Limits
 
-When preparing a loaded table one may have to wait up to 90 minutes before using the STS Job Manager tool. It is recommended to follow the [latest limits on BigQuery's Data Manipulation Language (DML)](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-manipulation-language#limitations) while using this tool.
+When preparing a loaded table one may have to wait up to 90 minutes before [rows are available](https://cloud.google.com/bigquery/streaming-data-into-bigquery#dataavailability) the STS Job Manager tool. It is recommended to follow the [latest limits on BigQuery's Data Manipulation Language (DML)](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-manipulation-language#limitations) while using this tool.
 
 It is recommended to follow the latest [ramp-up practices for Google Cloud Storage](https://cloud.google.com/storage/docs/request-rate#ramp-up) for a smoother transfer experience.
 

--- a/tools/sts-job-manager/sts_job_manager.py
+++ b/tools/sts-job-manager/sts_job_manager.py
@@ -200,8 +200,12 @@ def get_latest_operation_by_prefix(services: Services,
             break
 
         for operation in response['operations']:
-            object_conditions = \
-                operation['metadata']['transferSpec']['objectConditions']
+            transfer_spec = operation['metadata']['transferSpec']
+
+            if 'objectConditions' not in transfer_spec:
+                continue
+
+            object_conditions = transfer_spec['objectConditions']
 
             if 'includePrefixes' not in object_conditions:
                 continue


### PR DESCRIPTION
This PR adds additional functionality to the STS Job Manager:
- __Support Fast Operations__: currently, operations that complete less than 90 minutes will have issues as `last_updated` queries will ignore operations that have state changes within 90 minutes; causing the potential of duplicated transfer operations
  - Ex: STS Job Manager sees a prefix with `waiting`, creates a job, attempts to update its state, silently fails, sees `waiting`... 
- __Ignore Deleted Jobs__: currently, the operations of deleted jobs are considered for the tool. This can cause issues when a prefix needs to be re-ran for any reason. STS Job Manager will now take into account deleted jobs when determining state.