### PR TITLE
Fix recursion bug in example/gcs-fixity-function

### DIFF
--- a/examples/gcs-fixity-function/README.md
+++ b/examples/gcs-fixity-function/README.md
@@ -52,7 +52,8 @@ The setup instructions create the following BigQuery views:
 - `fixity.file_operations`: A running list of all file operations (file updated, file changed, file created) across all bags.
 
 ## Setup
-[Setup Instructions](./docs/setup.md)
+Use **[Setup Instructions](./docs/setup.md)** to setup Fixity functions.
+Use **[Removal Instructions](./docs/remove.md)** to disable or remove Fixity functions.
 
 ## Limitations
 This Cloud Functions has a default memory limit of 256MB per function invocation. To avoid hitting memory limits, distribute bags and objects across many different buckets. It's recommended to maintain under 250,000 objects per bucket to avoid running into memory limitations.

--- a/examples/gcs-fixity-function/docs/remove.md
+++ b/examples/gcs-fixity-function/docs/remove.md
@@ -1,0 +1,25 @@
+# Setup
+Clone this repository and run locally, or use Cloud Shell to walk through the steps:
+
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.png)](https://ssh.cloud.google.com/cloudshell/open?page=shell&cloudshell_git_repo=https://github.com/GoogleCloudPlatform/professional-services&cloudshell_tutorial=examples%2Fgcs-fixity-function%2Fdocs%2Fremove.md)
+
+## Prepare
+To setup this function, run through these instructions from the root of the repository or using Cloud Shell. 
+
+Set the following environment variables, replacing the values with those for your project and bucket:
+```bash
+export PROJECT_ID=<my-project-id>
+```
+```bash
+export BUCKET_NAME=<my-target-bucket-name>
+```
+Then run the following command as-is:
+```bash
+gcloud config set project $PROJECT_ID
+```
+
+## Remove
+Run the following to remove Fixity functions.
+```bash
+make remove
+```

--- a/examples/gcs-fixity-function/remove.sh
+++ b/examples/gcs-fixity-function/remove.sh
@@ -1,21 +1,30 @@
-# Copyright 2019 Google LLC
+#!/usr/bin/env bash
+
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-prepare:
-		./prepare.sh
 
-deploy:
-		./deploy.sh
+function try_and_delete {
+    gcloud functions describe "$1" &> /dev/null;
+    if [ $? -eq 1 ]; then
+        echo "Function $1 doesn't exist" >&2
+    else
+        gcloud functions delete "$1"
+    fi
+}
 
-remove:
-		./remove.sh
+try_and_delete fixity-"${BUCKET_NAME}"-deletes
+
+try_and_delete fixity-"${BUCKET_NAME}"-updates
+
+try_and_delete fixity-"${BUCKET_NAME}"-manual 


### PR DESCRIPTION
Fixes bug that would recursively run the function on all cloud storage files; not just the files within the targeted directory. This also adds a removal script.
