### PR TITLE
Projects recursion added to gcpohv-cli.py to fetch all projects instead of limited projects

### DIFF
--- a/tools/gcp-org-hierarchy-viewer/gcpohv_cli.py
+++ b/tools/gcp-org-hierarchy-viewer/gcpohv_cli.py
@@ -105,6 +105,19 @@ class Cli:
         self.use_org_id = use_org_id
         self._crm_v1, self._crm_v2 = setup_clients(credentials_file)
 
+    # Default projects.list() returns limited number of items and a nextPageToken
+    # This function will recursively load all projects
+    def load_all_projects(self,token = None):
+        projects = None
+        if token == None:
+            projects = self._crm_v1.projects().list().execute()
+        else:
+            projects = self._crm_v1.projects().list(pageToken=token).execute()
+        if "nextPageToken" in projects:
+            next_page_projects = self.load_all_projects(projects["nextPageToken"])
+            projects["projects"] = projects["projects"] + next_page_projects["projects"]
+        return projects
+
     def _get_projects(self):
         """ Gets all available projects and organize by parent type,
           organization and folder.
@@ -112,8 +125,8 @@ class Cli:
         Returns:
             2-tuple of dicts
         """
-        projs = self._crm_v1.projects().list().execute()
-
+        projs = self.load_all_projects()
+        
         fold_parents = collections.defaultdict(list)
 
         gen = (p for p in projs['projects']
@@ -240,7 +253,7 @@ def parse_args():
         '-k',
         '--key-file',
         help='Path to service account credentials. If you chose to omit this, '
-        'SDK will fall back to default credentials and possibly spew '
+        'SDK will fall ba ck to default credentials and possibly spew '
         'warnings.')
     parser.add_argument('--use-id',
                         action='store_true',

--- a/tools/gcp-org-hierarchy-viewer/gcpohv_cli.py
+++ b/tools/gcp-org-hierarchy-viewer/gcpohv_cli.py
@@ -253,7 +253,7 @@ def parse_args():
         '-k',
         '--key-file',
         help='Path to service account credentials. If you chose to omit this, '
-        'SDK will fall ba ck to default credentials and possibly spew '
+        'SDK will fall back to default credentials and possibly spew '
         'warnings.')
     parser.add_argument('--use-id',
                         action='store_true',


### PR DESCRIPTION
For GCP Organization Hierarchy Viewer, the projects were loaded initially using:

`projs = self._crm_v1.projects().list().execute()`

The problem with this approach was it didn't fetch all projects due to pagination. I have added a recursion function which uses the nextPageToken to get all projects and then manipulate them for the output.