### PR TITLE
Bug fixes for the vm-migrator and troubleshooting info for vpc-flowlogs-toptalkers

### DIFF
--- a/tools/vm-migrator/src/migrator/instance.py
+++ b/tools/vm-migrator/src/migrator/instance.py
@@ -92,6 +92,7 @@ def shutdown(instance_uri: uri.Instance) -> str:
                                           zone=instance_uri.zone,
                                           instance=instance_uri.name).execute()
         wait_for_zonal_operation(compute, instance_uri, result['name'])
+        wait_for_instance(compute, instance_uri)
         return instance_uri.name
     except Exception as ex:
         logging.error(ex)

--- a/tools/vm-migrator/src/migrator/instance.py
+++ b/tools/vm-migrator/src/migrator/instance.py
@@ -25,6 +25,7 @@ from .exceptions import GCPOperationException, NotFoundException
 from ratemate import RateLimit
 from . import uri
 from typing import Optional
+import re
 
 RATE_LIMIT = RateLimit(max_count=2000, per=100)
 
@@ -215,7 +216,7 @@ def reserve_internal_ip(compute, instance_uri: uri.Instance, name,
     return insert_operation['selfLink']
 
 
-def create_instance(compute, instance_uri: uri.Instance, network,
+def prepare_create_instance(compute, instance_uri: uri.Instance, network,
                     subnet_uri: uri.Subnet, alias_ip_ranges, node_group,
                     disk_names, ip, target_machine_type_uri: uri.MachineType,
                     image_project, target_service_account, target_scopes) \
@@ -310,9 +311,11 @@ def create_instance(compute, instance_uri: uri.Instance, network,
                 i = i + 1
         config['networkInterfaces'][0]['aliasIpRanges'] = alias_ip_ranges
 
-    return compute.instances().insert(project=instance_uri.project,
-                                      zone=instance_uri.zone,
-                                      body=config).execute()
+    return {
+        "project": instance_uri.project,
+        "zone": instance_uri.zone,
+        "body": config
+    }
 
 
 def wait_for_instance(compute, instance_uri: uri.Instance):
@@ -348,25 +351,42 @@ def create(instance_uri: uri.Instance,
     """
     Main function to create the instance.
     """
-    try:
-        waited_time = RATE_LIMIT.wait()  # wait before starting the task
-        logging.info('  task: waited for %s secs', waited_time)
-        compute = get_compute()
-        logging.info('Creating instance %s', instance_uri.name)
+    waited_time = RATE_LIMIT.wait()  # wait before starting the task
+    logging.info('  task: waited for %s secs', waited_time)
+    compute = get_compute()
+    logging.info('Creating instance %s', instance_uri.name)
 
-        operation = create_instance(compute, instance_uri, network, subnet,
-                                    alias_ip_ranges, node_group, disk_names,
-                                    ip, machine_type_uri, image_project,
-                                    target_service_account, target_scopes)
+    kwargs = prepare_create_instance(compute, instance_uri, network, subnet,
+                                alias_ip_ranges, node_group, disk_names,
+                                ip, machine_type_uri, image_project,
+                                target_service_account, target_scopes)
 
-        if wait:
-            wait_for_zonal_operation(compute, instance_uri, operation['name'])
-            result = wait_for_instance(compute, instance_uri)
-        created_instance_uri = uri.Instance.from_uri(result['selfLink'])
-        logging.info('Instance %s created from source MachineImage %s and '
-                     'successfully started', created_instance_uri,
-                     instance_uri.name)
-        return created_instance_uri.name
-    except Exception as ex:
-        logging.error(ex)
-        raise ex
+    retry_count=0
+    while True:
+        try:
+            if 0 < retry_count:
+                wait_time = min(retry_count * 30, 300)
+                logging.info("Retry #{} for instance {}: Waiting {} seconds.".format(retry_count, instance_uri.name, wait_time))
+                time.sleep(wait_time)
+                logging.info("Retry #{} for instance {}: Sleeping finished, attempting creation...".format(retry_count, instance_uri.name))
+
+            operation = compute.instances().insert(**kwargs).execute()
+
+            if wait:
+                wait_for_zonal_operation(compute, instance_uri, operation['name'])
+                result = wait_for_instance(compute, instance_uri)
+            created_instance_uri = uri.Instance.from_uri(result['selfLink'])
+            logging.info('Instance %s created from source MachineImage %s and '
+                        'successfully started', created_instance_uri,
+                        instance_uri.name)
+            return created_instance_uri.name
+        except Exception as ex:
+            if re.search("INTERNAL_ERROR", str(ex)):
+                if retry_count < 5:
+                    logging.warn("Retry #{} for instance {} failed.".format(retry_count, instance_uri.name))
+                    retry_count += 1
+                    continue
+                else:
+                    logging.error("Retry #{} for instance {} failed.".format(retry_count, instance_uri.name))
+            logging.error(ex)
+            raise ex

--- a/tools/vm-migrator/src/migrator/instance.py
+++ b/tools/vm-migrator/src/migrator/instance.py
@@ -92,7 +92,6 @@ def shutdown(instance_uri: uri.Instance) -> str:
                                           zone=instance_uri.zone,
                                           instance=instance_uri.name).execute()
         wait_for_zonal_operation(compute, instance_uri, result['name'])
-        wait_for_instance(compute, instance_uri)
         return instance_uri.name
     except Exception as ex:
         logging.error(ex)

--- a/tools/vm-migrator/src/migrator/subnet.py
+++ b/tools/vm-migrator/src/migrator/subnet.py
@@ -255,7 +255,8 @@ def release_ip(project: str, subnet_uri: uri.Subnet) -> bool:
     ips = compute.addresses().list(project=project,
                                    region=subnet_uri.region,
                                    filter='subnetwork="' +
-                                   subnet_uri.abs_beta_uri + '"').execute()
+                                   subnet_uri.abs_beta_uri + '"',
+                                   maxResults=3000).execute()
 
     result = True
     if ips.get('items'):

--- a/tools/vm-migrator/src/migrator/subnet_region_migrator.py
+++ b/tools/vm-migrator/src/migrator/subnet_region_migrator.py
@@ -190,7 +190,7 @@ def bulk_instance_start(file_name) -> bool:
             for row in csv_dict_reader:
                 instance_uri = uri.Instance.from_uri(row['self_link'])
                 instance_future.append(
-                    executor.submit(instance.shutdown, instance_uri))
+                    executor.submit(instance.start, instance_uri))
                 count = count + 1
 
             for future in concurrent.futures.as_completed(instance_future):

--- a/tools/vpc-flowlogs-toptalkers/README.md
+++ b/tools/vpc-flowlogs-toptalkers/README.md
@@ -72,3 +72,17 @@ Example of the generated output:
 ## Costs
 
 If you enable VPC flow logs, they will be sent by default to the `_Default` log sink. You can either disable the `_Default` log sink (not recommended) or create an exclusion rule that skips VPC flow logs.
+
+## Troubleshooting
+
+If you get an error like this:
+
+> │ Error: googleapi: Error 400: Field name dest_vpc does not exist in STRUCT<start_time STRING, src_instance STRUCT<project_id STRING, vm_name STRING, region STRING, ...>, src_vpc STRUCT<project_id STRING, subnetwork_name STRING, vpc_name STRING>, ...> at [213:19], invalidQuery
+
+It is probably because the VPC flow logs are not generating specific type of traffic that implicitly creates all the required columns in the BigQuery Tables. In order to fix this, please execute the following command:
+
+```
+bq ls --format json <BG_PROJECT>:<BQ_DATASET> | jq -r '.[].id' | grep compute_googleapis_com_vpc_flows_ | xargs -I{} bq update {} $(pwd)/vpc_flows_schema.json
+```
+
+This will apply the predefined schema stored in this project to all the tables inside the dataset dedicated to this utility after which `terraform apply` should succeed.

--- a/tools/vpc-flowlogs-toptalkers/routines.tf
+++ b/tools/vpc-flowlogs-toptalkers/routines.tf
@@ -204,5 +204,5 @@ EOF
     name      = "ip_str"
     data_type = "{\"typeKind\" :  \"STRING\"}"
   }
-  depends_on    = [module.destination]
+  depends_on    = [module.destination, google_bigquery_routine.IP_VERSION]
 }

--- a/tools/vpc-flowlogs-toptalkers/vpc_flows_schema.json
+++ b/tools/vpc-flowlogs-toptalkers/vpc_flows_schema.json
@@ -1,0 +1,423 @@
+[
+    {
+      "mode": "NULLABLE",
+      "name": "logName",
+      "type": "STRING"
+    },
+    {
+      "fields": [
+        {
+          "mode": "NULLABLE",
+          "name": "type",
+          "type": "STRING"
+        },
+        {
+          "fields": [
+            {
+              "mode": "NULLABLE",
+              "name": "location",
+              "type": "STRING"
+            },
+            {
+              "mode": "NULLABLE",
+              "name": "project_id",
+              "type": "STRING"
+            },
+            {
+              "mode": "NULLABLE",
+              "name": "subnetwork_id",
+              "type": "STRING"
+            },
+            {
+              "mode": "NULLABLE",
+              "name": "subnetwork_name",
+              "type": "STRING"
+            }
+          ],
+          "mode": "NULLABLE",
+          "name": "labels",
+          "type": "RECORD"
+        }
+      ],
+      "mode": "NULLABLE",
+      "name": "resource",
+      "type": "RECORD"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "textPayload",
+      "type": "STRING"
+    },
+    {
+      "fields": [
+        {
+          "mode": "NULLABLE",
+          "name": "start_time",
+          "type": "STRING"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "bytes_sent",
+          "type": "STRING"
+        },
+        {
+          "fields": [
+            {
+              "mode": "NULLABLE",
+              "name": "dest_ip",
+              "type": "STRING"
+            },
+            {
+              "mode": "NULLABLE",
+              "name": "protocol",
+              "type": "FLOAT"
+            },
+            {
+              "mode": "NULLABLE",
+              "name": "src_ip",
+              "type": "STRING"
+            },
+            {
+              "mode": "NULLABLE",
+              "name": "src_port",
+              "type": "FLOAT"
+            },
+            {
+              "mode": "NULLABLE",
+              "name": "dest_port",
+              "type": "FLOAT"
+            }
+          ],
+          "mode": "NULLABLE",
+          "name": "connection",
+          "type": "RECORD"
+        },
+        {
+          "fields": [
+            {
+              "mode": "NULLABLE",
+              "name": "vpc_name",
+              "type": "STRING"
+            },
+            {
+              "mode": "NULLABLE",
+              "name": "project_id",
+              "type": "STRING"
+            },
+            {
+              "mode": "NULLABLE",
+              "name": "subnetwork_name",
+              "type": "STRING"
+            }
+          ],
+          "mode": "NULLABLE",
+          "name": "dest_vpc",
+          "type": "RECORD"
+        },
+        {
+          "fields": [
+            {
+              "mode": "NULLABLE",
+              "name": "project_id",
+              "type": "STRING"
+            },
+            {
+              "mode": "NULLABLE",
+              "name": "region",
+              "type": "STRING"
+            },
+            {
+              "mode": "NULLABLE",
+              "name": "zone",
+              "type": "STRING"
+            },
+            {
+              "mode": "NULLABLE",
+              "name": "vm_name",
+              "type": "STRING"
+            }
+          ],
+          "mode": "NULLABLE",
+          "name": "src_instance",
+          "type": "RECORD"
+        },
+        {
+          "fields": [
+            {
+              "mode": "NULLABLE",
+              "name": "vm_name",
+              "type": "STRING"
+            },
+            {
+              "mode": "NULLABLE",
+              "name": "project_id",
+              "type": "STRING"
+            },
+            {
+              "mode": "NULLABLE",
+              "name": "zone",
+              "type": "STRING"
+            },
+            {
+              "mode": "NULLABLE",
+              "name": "region",
+              "type": "STRING"
+            }
+          ],
+          "mode": "NULLABLE",
+          "name": "dest_instance",
+          "type": "RECORD"
+        },
+        {
+          "fields": [
+            {
+              "mode": "NULLABLE",
+              "name": "project_id",
+              "type": "STRING"
+            },
+            {
+              "mode": "NULLABLE",
+              "name": "vpc_name",
+              "type": "STRING"
+            },
+            {
+              "mode": "NULLABLE",
+              "name": "subnetwork_name",
+              "type": "STRING"
+            }
+          ],
+          "mode": "NULLABLE",
+          "name": "src_vpc",
+          "type": "RECORD"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "packets_sent",
+          "type": "STRING"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "reporter",
+          "type": "STRING"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "end_time",
+          "type": "STRING"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "rtt_msec",
+          "type": "STRING"
+        },
+        {
+          "fields": [
+            {
+              "mode": "NULLABLE",
+              "name": "country",
+              "type": "STRING"
+            },
+            {
+              "mode": "NULLABLE",
+              "name": "continent",
+              "type": "STRING"
+            },
+            {
+              "mode": "NULLABLE",
+              "name": "asn",
+              "type": "FLOAT"
+            }
+          ],
+          "mode": "NULLABLE",
+          "name": "dest_location",
+          "type": "RECORD"
+        }
+      ],
+      "mode": "NULLABLE",
+      "name": "jsonPayload",
+      "type": "RECORD"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "timestamp",
+      "type": "TIMESTAMP"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "receiveTimestamp",
+      "type": "TIMESTAMP"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "severity",
+      "type": "STRING"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "insertId",
+      "type": "STRING"
+    },
+    {
+      "fields": [
+        {
+          "mode": "NULLABLE",
+          "name": "requestMethod",
+          "type": "STRING"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "requestUrl",
+          "type": "STRING"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "requestSize",
+          "type": "INTEGER"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "status",
+          "type": "INTEGER"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "responseSize",
+          "type": "INTEGER"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "userAgent",
+          "type": "STRING"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "remoteIp",
+          "type": "STRING"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "serverIp",
+          "type": "STRING"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "referer",
+          "type": "STRING"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "cacheLookup",
+          "type": "BOOLEAN"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "cacheHit",
+          "type": "BOOLEAN"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "cacheValidatedWithOriginServer",
+          "type": "BOOLEAN"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "cacheFillBytes",
+          "type": "INTEGER"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "protocol",
+          "type": "STRING"
+        }
+      ],
+      "mode": "NULLABLE",
+      "name": "httpRequest",
+      "type": "RECORD"
+    },
+    {
+      "fields": [
+        {
+          "mode": "NULLABLE",
+          "name": "id",
+          "type": "STRING"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "producer",
+          "type": "STRING"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "first",
+          "type": "BOOLEAN"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "last",
+          "type": "BOOLEAN"
+        }
+      ],
+      "mode": "NULLABLE",
+      "name": "operation",
+      "type": "RECORD"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "trace",
+      "type": "STRING"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "spanId",
+      "type": "STRING"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "traceSampled",
+      "type": "BOOLEAN"
+    },
+    {
+      "fields": [
+        {
+          "mode": "NULLABLE",
+          "name": "file",
+          "type": "STRING"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "line",
+          "type": "INTEGER"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "function",
+          "type": "STRING"
+        }
+      ],
+      "mode": "NULLABLE",
+      "name": "sourceLocation",
+      "type": "RECORD"
+    },
+    {
+      "fields": [
+        {
+          "mode": "NULLABLE",
+          "name": "uid",
+          "type": "STRING"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "index",
+          "type": "INTEGER"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "totalSplits",
+          "type": "INTEGER"
+        }
+      ],
+      "mode": "NULLABLE",
+      "name": "split",
+      "type": "RECORD"
+    }
+]


### PR DESCRIPTION
Summary:

* Provide a workaround for GCP enforced throttling when creating VMs too fast
* Provide a workaround for when VPC flowlogs datasets are not available while creating the BQ view through terraform
* Fix the start instances command (it was shutting down the VMs)
* Release 3000 IPs by default (it was releasing 500 IPs by default).