### PR TITLE
Add a Workload Identity Federation with Gitlab example

### DIFF
--- a/examples/workload_identity_federation/.gitlab-ci.yml
+++ b/examples/workload_identity_federation/.gitlab-ci.yml
@@ -1,0 +1,85 @@
+# This file is a template, and might need editing before it works on your project.
+# To contribute improvements to CI/CD templates, please follow the Development guide at:
+# https://docs.gitlab.com/ee/development/cicd/templates.html
+# This specific template is located at:
+# https://gitlab.com/gitlab-org/gitlab/-/blob/master/lib/gitlab/ci/templates/Getting-Started.gitlab-ci.yml
+
+# This is a sample GitLab CI/CD configuration file that should run without any modifications.
+# It demonstrates a basic 3 stage CI/CD pipeline. Instead of real tests or scripts,
+# it uses echo commands to simulate the pipeline execution.
+#
+# A pipeline is composed of independent jobs that run scripts, grouped into stages.
+# Stages run in sequential order, but jobs within stages run in parallel.
+#
+# For more information, see: https://docs.gitlab.com/ee/ci/yaml/index.html#stages
+
+#********************** VARIABLES ********************** #
+variables:
+#************ PROJECT COMMON - WORKLOAD IDENTITY FEDERATION ************
+PROJECT_ID        : "CHANGEME"
+PROJECT_NUMBER    : "CHANGEME"
+POOL_ID           : "CHANGEME"
+PROVIDER_ID       : "CHANGEME"
+SERVICE_ACCOUNT_EMAIL: "CHANGEME"
+
+
+#************************ STAGES *********************** #
+stages:
+  - auth
+  - provision
+
+
+#********************** STAGE 1: AUTH *********************** #
+1-gcp-auth:
+  stage: auth
+  image: google/cloud-sdk:slim
+  script:
+    - echo ${CI_JOB_JWT_V2} > .ci_job_jwt_file
+    - gcloud iam workload-identity-pools create-cred-config ${PROVIDER_ID}
+      --service-account="${SERVICE_ACCOUNT_EMAIL}"
+      --output-file=.gcp_temp_cred.json
+      --credential-source-file=.ci_job_jwt_file
+    - gcloud auth login --cred-file=`pwd`/.gcp_temp_cred.json
+    - gcloud auth list
+
+2-gcp-token:
+  stage: auth
+  image: dwdraju/alpine-curl-jq
+  script:
+    - chmod +x run_wif_gcp.sh
+    - ./run_wif_gcp.sh $PROJECT_NUMBER $POOL_ID $PROVIDER_ID $SERVICE_ACCOUNT_EMAIL >> 2-gcp-token.env
+  artifacts:
+    reports:
+      dotenv: 2-gcp-token.env
+
+
+#********************** STAGE 2: USE *********************** #
+1-config-plan:
+  stage: provision
+  image: hashicorp/terraform
+  script:
+    - cd 2-use-wif
+    - echo "***** ACCESS_TOKEN *****"
+    - echo "$ACCESS_TOKEN"
+    - terraform init
+    - |-
+        terraform apply -auto-approve \
+                        -var="access_token=$ACCESS_TOKEN" \
+                        -var="project_id=$PROJECT_ID"
+  dependencies:
+    - 2-gcp-token
+
+2-config-apply:
+  stage: provision
+  image: hashicorp/terraform
+  script:
+    - cd 2-use-wif
+    - echo "***** ACCESS_TOKEN *****"
+    - echo "$ACCESS_TOKEN"
+    - terraform init
+    - |-
+        terraform apply -auto-approve \
+                        -var="access_token=$ACCESS_TOKEN" \
+                        -var="project_id=$PROJECT_ID"
+  dependencies:
+    - 2-gcp-token

--- a/examples/workload_identity_federation/1-create-wif/main.tf
+++ b/examples/workload_identity_federation/1-create-wif/main.tf
@@ -1,0 +1,26 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+provider "google" {
+
+}
+
+module "workload_identity" {
+  source = "../modules/workload"
+
+  gcp_project_id         = var.project_id
+  gitlab_project_id      = var.gitlab_project
+  gitlab_service_account = var.gitlab_service_account
+}

--- a/examples/workload_identity_federation/1-create-wif/outputs.tf
+++ b/examples/workload_identity_federation/1-create-wif/outputs.tf
@@ -1,0 +1,13 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/examples/workload_identity_federation/1-create-wif/variables.tf
+++ b/examples/workload_identity_federation/1-create-wif/variables.tf
@@ -1,0 +1,34 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+variable "project_id" {
+  type        = string
+  description = "The GCP Project ID that will be used to host the Workload Identity Federation."
+}
+
+variable "gitlab_url" {
+  type    = string
+  default = "https://gitlab.com"
+}
+
+variable "gitlab_project" {
+  type        = string
+  description = "The Gitlab Project ID that will be used for running the pipelines."
+}
+
+variable "gitlab_service_account" {
+  type        = string
+  description = "Name for the service account that will be associated to the workload identity providers"
+}

--- a/examples/workload_identity_federation/1-create-wif/versions.tf
+++ b/examples/workload_identity_federation/1-create-wif/versions.tf
@@ -1,0 +1,18 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+terraform {
+  required_version = "~> 1.2.0"
+}

--- a/examples/workload_identity_federation/2-use-wif/main.tf
+++ b/examples/workload_identity_federation/2-use-wif/main.tf
@@ -1,0 +1,26 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+provider "google" {
+  access_token = var.access_token
+}
+
+module "vpc" {
+  source = "../modules/vpc"
+
+  project_id = var.project_id
+  vpc_name   = local.vpc_name
+  subnets    = local.subnets
+}

--- a/examples/workload_identity_federation/2-use-wif/outputs.tf
+++ b/examples/workload_identity_federation/2-use-wif/outputs.tf
@@ -1,0 +1,13 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/examples/workload_identity_federation/2-use-wif/variables.tf
+++ b/examples/workload_identity_federation/2-use-wif/variables.tf
@@ -1,0 +1,24 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+variable "project_id" {
+  type        = string
+  description = "The GCP Project ID for managing the interconnectivity between onpremise architecture and the project ftc-cl-intercon-prod"
+}
+
+variable "access_token" {
+  type        = string
+  description = "Temporary OAuth 2.0 access token obtained from the Google Authorization server"
+}

--- a/examples/workload_identity_federation/2-use-wif/versions.tf
+++ b/examples/workload_identity_federation/2-use-wif/versions.tf
@@ -1,0 +1,18 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+terraform {
+  required_version = "~> 1.2.0"
+}

--- a/examples/workload_identity_federation/2-use-wif/vpc.tf
+++ b/examples/workload_identity_federation/2-use-wif/vpc.tf
@@ -1,0 +1,31 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+locals {
+  vpc_name = "vpc_name"
+
+  subnets = [
+    {
+      name   = "subnet-us-east4",
+      ip     = "10.0.0.0/24",
+      region = "us-east4"
+    },
+    {
+      name   = "subnet-us-west2",
+      ip     = "10.0.0.0/24",
+      region = "us-west2"
+    },
+  ]
+}

--- a/examples/workload_identity_federation/README.md
+++ b/examples/workload_identity_federation/README.md
@@ -1,0 +1,66 @@
+# Workload Identity Federation
+
+This repository provides an example for creating a Workload Identity Federation (WIF) Component that could be used for
+authenticating to Google Cloud from a GitLab CI/CD job using a JSON Web Token (JWT) token. This configuration generates
+on-demand, short-lived credentials without needing to store any secrets.
+
+This example assumes you have a Google Cloud account and a Google Cloud project. 
+Your account must have at least the Workload Identity Pool Admin permission on the Google Cloud project.
+
+## Create Workload Identity Federation
+
+- Create an account in [Google Cloud](https://cloud.google.com/sdk/gcloud)
+- Create an account in [GitLab](https://about.gitlab.com/)
+- Install [GCloud CLI](https://cloud.google.com/sdk/gcloud) following this [guide](https://cloud.google.com/sdk/docs/install)
+- Install [Terraform](https://www.terraform.io/) following this [guide](https://learn.hashicorp.com/tutorials/terraform/install-cli)
+- Install [GCloud CLI](https://cloud.google.com/sdk/gcloud) following this [guide](https://cloud.google.com/sdk/docs/install)
+
+## Create Workload Identity Federation
+
+- Configure the variables required for creating the Workload Identity Provider.
+```
+cd 1-create-wif
+vim terraform.tfvars
+
+#Edit this variables
+project_id             = {id of the gcp project in which you will povision the WIF}
+gitlab_url             = {url of gitlab, by default is https://gitlab.com}
+gitlab_project         = {url of the project in gitlab}
+gitlab_service_account = {a name for the service account that will be created}
+```
+
+- Execute Terraform command to provision .
+```
+terraform init
+terraform plan
+terraform apply
+```
+
+## Use Workload Identity Federation in GitLab
+
+Since this repository includes an example for authenticating to Google Cloud from a GitLab CI/CD job, the file .gitlab-ci.yml should be changed in these values:
+```
+PROJECT_ID           : {id of the gcp project in which you will povision your infrastructure}
+PROJECT_NUMBER       : {number of the gcp project in which you created the WIF}
+POOL_ID              : {name of the workload identity pool that you created in WIF}
+PROVIDER_ID          : {name of the workload identity provider that you created in WIF}
+SERVICE_ACCOUNT_EMAIL: {name of the service account asssociated to WIF}
+```
+
+## Collaborate with your team
+
+- [ ] [Invite team members and collaborators](https://docs.gitlab.com/ee/user/project/members/)
+- [ ] [Create a new merge request](https://docs.gitlab.com/ee/user/project/merge_requests/creating_merge_requests.html)
+- [ ] [Automatically close issues from merge requests](https://docs.gitlab.com/ee/user/project/issues/managing_issues.html#closing-issues-automatically)
+- [ ] [Enable merge request approvals](https://docs.gitlab.com/ee/user/project/merge_requests/approvals/)
+- [ ] [Automatically merge when pipeline succeeds](https://docs.gitlab.com/ee/user/project/merge_requests/merge_when_pipeline_succeeds.html)
+
+## Test and Deploy
+
+Push this repository in the Gitlab project and verify that the VPC included in the main.tf file was provisioned.
+
+## References
+- [ ] [Get started with Workload Identity Federation](https://cloud.google.com/iam/docs/workload-identity-federation)
+- [ ] [Get started with GitLab CI/CD](https://docs.gitlab.com/ee/ci/quick_start/index.html)
+- [ ] [Configure OpenID Connect with GCP Workload Identity Federation](https://docs.gitlab.com/ee/ci/environments/protected_environments.html)
+

--- a/examples/workload_identity_federation/modules/vpc/main.tf
+++ b/examples/workload_identity_federation/modules/vpc/main.tf
@@ -1,0 +1,42 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module "vpc" {
+  source  = "terraform-google-modules/network/google"
+  version = "3.3.0"
+
+  project_id   = var.project_id
+  network_name = var.vpc_name
+
+  mtu = 1460
+
+  auto_create_subnetworks = false
+  routing_mode            = "GLOBAL"
+
+  subnets = [
+    for subnet in var.subnets : {
+      subnet_name = subnet.name
+
+      subnet_ip     = subnet.ip
+      subnet_region = subnet.region
+
+      subnet_private_access = true
+
+      subnet_flow_logs          = true
+      subnet_flow_logs_interval = "INTERVAL_5_SEC"
+      subnet_flow_logs_sampling = "0.5"
+      subnet_flow_logs_metadata = "INCLUDE_ALL_METADATA"
+    }]
+}

--- a/examples/workload_identity_federation/modules/vpc/outputs.tf
+++ b/examples/workload_identity_federation/modules/vpc/outputs.tf
@@ -1,0 +1,22 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+output "vpc_link" {
+  value = module.vpc.network_self_link
+}
+
+output "subnets_links" {
+  value = module.vpc.subnets_self_links
+}

--- a/examples/workload_identity_federation/modules/vpc/variables.tf
+++ b/examples/workload_identity_federation/modules/vpc/variables.tf
@@ -1,0 +1,29 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+variable "project_id" {
+  type        = string
+  description = "The Project ID that will be enable APIs on"
+}
+
+variable "vpc_name" {
+  type        = string
+  description = "The VPC name that will be provisioned"
+}
+
+variable "subnets" {
+  type        = list
+  description = "List of subnets that will be associated to the VPC"
+}

--- a/examples/workload_identity_federation/modules/vpc/versions.tf
+++ b/examples/workload_identity_federation/modules/vpc/versions.tf
@@ -1,0 +1,18 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+terraform {
+  required_version = "~> 1.2.0"
+}

--- a/examples/workload_identity_federation/modules/workload/main.tf
+++ b/examples/workload_identity_federation/modules/workload/main.tf
@@ -1,0 +1,66 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+resource "random_id" "random" {
+  byte_length = 4
+}
+
+resource "google_iam_workload_identity_pool" "gitlab-pool" {
+  provider                  = google-beta
+  workload_identity_pool_id = "gitlab-pool-${random_id.random.hex}"
+  project                   = var.gcp_project_id
+}
+
+resource "google_iam_workload_identity_pool_provider" "gitlab-provider-jwt" {
+  provider                           = google-beta
+  workload_identity_pool_id          = google_iam_workload_identity_pool.gitlab-pool.workload_identity_pool_id
+  workload_identity_pool_provider_id = "gitlab-jwt-${random_id.random.hex}"
+  project                            = var.gcp_project_id
+  attribute_condition                = ""
+  attribute_mapping = {
+    "google.subject"           = "assertion.sub",
+    "attribute.aud"            = "assertion.aud",
+    "attribute.project_path"   = "assertion.project_path",
+    "attribute.project_id"     = "assertion.project_id",
+    "attribute.namespace_id"   = "assertion.namespace_id",
+    "attribute.namespace_path" = "assertion.namespace_path",
+    "attribute.user_email"     = "assertion.user_email",
+    "attribute.ref"            = "assertion.ref",
+    "attribute.ref_type"       = "assertion.ref_type",
+  }
+  oidc {
+    issuer_uri        = var.gitlab_url
+    allowed_audiences = [var.gitlab_url]
+  }
+}
+
+resource "google_service_account" "gitlab-runner" {
+  project      = var.gcp_project_id
+  account_id   = var.gitlab_service_account
+  display_name = "Service Account for GitLab Runner"
+}
+
+resource "google_service_account_iam_binding" "gitlab-runner-oidc" {
+  provider           = google-beta
+  service_account_id = google_service_account.gitlab-runner.name
+  role               = "roles/iam.workloadIdentityUser"
+
+  members = [
+    "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.gitlab-pool.name}/attribute.project_id/${var.gitlab_project_id}"
+  ]
+}
+
+
+

--- a/examples/workload_identity_federation/modules/workload/outputs.tf
+++ b/examples/workload_identity_federation/modules/workload/outputs.tf
@@ -1,0 +1,22 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+output "gcp_workload_identity_provider" {
+  value = google_iam_workload_identity_pool_provider.gitlab-provider-jwt.name
+}
+
+output "gcp_service_account" {
+  value = google_service_account.gitlab-runner.email
+}

--- a/examples/workload_identity_federation/modules/workload/variables.tf
+++ b/examples/workload_identity_federation/modules/workload/variables.tf
@@ -1,0 +1,34 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+variable "gcp_project_id" {
+  type        = string
+  description = "The Project ID that host de workload identity configuration"
+}
+
+variable "gitlab_url" {
+  type    = string
+  default = "https://gitlab.falabella.com"
+}
+
+variable "gitlab_project_id" {
+  type        = string
+  description = "Project ID to restrict authentication from."
+}
+
+variable "gitlab_service_account" {
+  type        = string
+  description = "Name for the service account that will be associated to the workload identity provider"
+}

--- a/examples/workload_identity_federation/modules/workload/versions.tf
+++ b/examples/workload_identity_federation/modules/workload/versions.tf
@@ -1,0 +1,18 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+terraform {
+  required_version = "~> 1.2.0"
+}

--- a/examples/workload_identity_federation/run_wif_gcp.sh
+++ b/examples/workload_identity_federation/run_wif_gcp.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+#$1 PROJECT_NUMBER
+#$2 POOL_ID
+#$3 PROVIDER_ID
+#$4 SERVICE_ACCOUNT_EMAIL
+
+PAYLOAD=$(cat <<EOF
+{
+"audience": "//iam.googleapis.com/projects/$1/locations/global/workloadIdentityPools/$2/providers/$3",
+"grantType": "urn:ietf:params:oauth:grant-type:token-exchange",
+"requestedTokenType": "urn:ietf:params:oauth:token-type:access_token",
+"scope": "https://www.googleapis.com/auth/cloud-platform",
+"subjectTokenType": "urn:ietf:params:oauth:token-type:jwt",
+"subjectToken": "${CI_JOB_JWT_V2}"
+}
+EOF
+)
+
+FEDERATED_TOKEN="$(curl --fail-with-body "https://sts.googleapis.com/v1/token" \
+ --header "Accept: application/json" \
+ --header "Content-Type: application/json" \
+ --data "${PAYLOAD}" \
+ | jq -r '.access_token'
+)"
+
+ACCESS_TOKEN="$(curl --fail-with-body "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/$4:generateAccessToken" \
+--header "Accept: application/json" \
+--header "Content-Type: application/json" \
+--header "Authorization: Bearer $FEDERATED_TOKEN" \
+--data '{"scope": ["https://www.googleapis.com/auth/cloud-platform"]}' \
+| jq -r '.accessToken'
+)"
+
+#REMINDER Enable for debugging
+#echo "***** ENVIRONMENT VARIABLES *****"
+#echo $1
+#echo $2
+#echo $3
+#echo $4
+#echo "***** AUDIENCE *****"
+#echo "//iam.googleapis.com/projects/$1/locations/global/workloadIdentityPools/$2/providers/$3"
+#echo "***** FEDERATED TOKEN *****"
+#echo $FEDERATED_TOKEN
+#echo "***** ACCESS TOKEN *****"
+#echo $ACCESS_TOKEN
+
+echo "ACCESS_TOKEN=${ACCESS_TOKEN}"


### PR DESCRIPTION
Add a Workload Identity Federation with Gitlab example

This repository provides an example for creating a Workload Identity Federation (WIF) component that can be used for
authenticating to Google Cloud from a GitLab CI/CD job using a JSON Web Token (JWT) token. 