### PR TITLE
Mainframe Connector: remove inlining compiler options

### DIFF
--- a/tools/bigquery-zos-mainframe-connector/gszutil/build.sbt
+++ b/tools/bigquery-zos-mainframe-connector/gszutil/build.sbt
@@ -75,8 +75,6 @@ Compile / resourceGenerators += Def.task {
 Test / testOptions := Seq(Tests.Filter(!_.endsWith("ITSpec")))
 
 scalacOptions ++= Seq(
-  "-opt:l:inline",
-  "-opt-inline-from:**",
   "-deprecation",
   "-opt-warnings",
   "-feature"


### PR DESCRIPTION
recently added jzos-shim method stubs must not be inlined by compiler, else IBM provided jzos libraries will not be used at runtime

This pull request removes compiler options that cause inlining of methods that must be provided by IBM libraries, resolving an issue which prevent the connector from working correctly when compiled against the recently added jzos-shim module.