### PR TITLE
Remove invalid pip instructions - security fix

### DIFF
--- a/tools/gsuite-grant-analyzer/README.md
+++ b/tools/gsuite-grant-analyzer/README.md
@@ -4,16 +4,6 @@ G Suite Grant Analyzer is a tool to export to BigQuery data about all the OAuth 
 
 ## Installation
 
-### Install using pip
-
-To install using pip:
-
-```
-pip install --user gsuite-grant-analyzer
-```
-
-The required packages should be downloaded and installed automatically.
-
 ### Manual install
 
 Install the Python Google API Client and BigQuery Client libraries:


### PR DESCRIPTION
This removes obsolete / invalid pip instructions invoking an non-existent pypi package.
This was flagged as a security risk; the fix is to remove the invalid instructions.