### PR TITLE
Mainframe Connector: add copybook support for unsigned int fields

### DIFF
--- a/tools/bigquery-zos-mainframe-connector/gszutil/build.sbt
+++ b/tools/bigquery-zos-mainframe-connector/gszutil/build.sbt
@@ -31,7 +31,8 @@ val log4j1 = ExclusionRule(organization = "log4j", name = "log4j")
 libraryDependencies ++= Seq(
   "com.google.cloud.imf" %% "mainframe-util" % "2.2.0",
   // enable users to compile without IBM JZOS jars
-  "com.google.cloud.imf" %% "jzos-shim" % "0.1" % Provided, 
+  // comment this line out and place IBM jars in lib directory to test against IBM classes
+  "com.google.cloud.imf" %% "jzos-shim" % "0.2" % Provided,
   "com.github.scopt" %% "scopt" % "3.7.1",
   "org.scalatest" %% "scalatest" % "3.2.9" % Test,
   "org.powermock" % "powermock-module-junit4" % "2.0.9" % Test,

--- a/tools/bigquery-zos-mainframe-connector/gszutil/proclib/BQSH
+++ b/tools/bigquery-zos-mainframe-connector/gszutil/proclib/BQSH
@@ -31,50 +31,68 @@
 //KEYFILE  DD DUMMY
 //STDENV   DD *,SYMBOLS=EXECSYS
 
+# Service Account Keyfile
+# Edit the line below to specify a unix filesystem path where
+# the service account keyfile is stored.
+# The service account should be granted Storage, BigQuery and Logging permissions.
+export GKEYFILE="/path/to/keyfile.json"
+
+# Path to directory containing google jar files
+# Edit this to set actual path selected for your site
+# it's recommended to have a path with a version identifier
+# and create a symlink to the directory of the latest version
+GOOGLE_DIR="/opt/google/mainframe-connector/latest/lib"
+GOOGLE_CLASSPATH="$GOOGLE_DIR/*"
+
+# Do not modify the 3 lines below
+# Collect system symbols from JES
 export JOBNAME=&JOBNAME
 export JOBDATE=&YYMMDD
 export JOBTIME=&HHMMSS
 
 # IBM JZOS JDK Location
-JH="/usr/lpp/java/alias"
+JH="/usr/lpp/java/J8.0_64"
 export JAVA_HOME="$JH"
 export PATH="/bin:$JH/bin"
 
 # Log Level
 export BQSH_ROOT_LOGGER=DEBUG
 
-# Service Account Keyfile
-export GKEYFILE="/path/to/keyfile.json"
-
 # Binary Data Sets
-export GCSDSNURI="gs://databucket/prefix"
+# Uncomment the line below to set a default output bucket for scp.
+# The DSN of the input file is used as the object name.
+# this may greatly reduce effort across many job steps
+#export GCSDSNURI="gs://[BUCKET]/[PREFIX]"
 
 # Generational Data Sets
-export GCSGDGURI="gs://versionedbucket/prefix"
+# Uncomment the line below to set a default output bucket for scp GDG datasets.
+# The Cloud GDG feature emulates a GDG dataset in a versioned object.
+# Cloud Storage objects take precedence over local DSN when this is set.
+#export GCSGDGURI="gs://[BUCKET]/[PREFIX]"
 
-# Transcoded ORC files
-export GCSOUTURI="gs://outputbucket/prefix"
+# Uncomment the line below to set a default output bucket for the gszutil command.
+#export GCSOUTURI="gs://[BUCKET]/[PREFIX]"
 
-# Transcoding Server IP Address or Hostname
-export SRVREMOTE="0.0.0.0"
-
-# Transcoding Server Port
-export SRVPORT=52701
+# Mainframe Connector gRPC service
+# Uncomment and edit the lines below to set the Hostname or IP Address and
+# port of the gRPC data set transcoding service.
+# The gRPC service converts z/OS datasets to ORC format on VMs running in
+# Google Cloud VPC. This is strongly recommended when processing high volumes
+# of data.
+#export SRVREMOTE=
+#export SRVPORT=
 
 # Native Libraries
 JL="$JH/lib"
 LP="/lib:/usr/lib:$JH/bin:$JL/s390x:$JL/s390x/j9vm:$JH/bin/classic"
 export LIBPATH="$LP:/usr/lib/java_runtime64"
 
-# Path to directory containing google jar files
-LD=/opt/google/lib
-
 # Java Classpath
-CP="$LD/*:$JL:$JL/ext:/usr/include/java_classes/*"
-export CLASSPATH="$CP"
+CP="$JL:$JL/ext:/usr/include/java_classes/*"
+export CLASSPATH="$CP:GOOGLE_CLASSPATH"
 
 # JVM options
-IJO="-Xms1g -Xmx1g -Xcompressedrefs -Djava.net.preferIPv4Stack=true"
+IJO="-Xms512m -Xmx512m -Xcompressedrefs -Djava.net.preferIPv4Stack=true"
 export IBM_JAVA_OPTIONS="$IJO"
 export JZOS_MAIN_ARGS=""
 /*

--- a/tools/bigquery-zos-mainframe-connector/gszutil/src/main/scala/com/google/cloud/bqsh/cmd/Scp.scala
+++ b/tools/bigquery-zos-mainframe-connector/gszutil/src/main/scala/com/google/cloud/bqsh/cmd/Scp.scala
@@ -31,6 +31,9 @@ import com.google.common.io.CountingOutputStream
 /** Simple binary copy
   * Single connection - not recommended for large uploads
   * Writes gzip compressed object
+  * If GCSDSNURI envvar is set, output URI is automatically set
+  * by appending the DSN to the base URI, thus does not
+  * need to be specified via command-line arguments.
   */
 object Scp extends Command[ScpConfig] with Logging {
   override val name: String = "scp"

--- a/tools/bigquery-zos-mainframe-connector/gszutil/src/main/scala/com/google/cloud/gszutil/CopyBookDecoderAndEncoderOps.scala
+++ b/tools/bigquery-zos-mainframe-connector/gszutil/src/main/scala/com/google/cloud/gszutil/CopyBookDecoderAndEncoderOps.scala
@@ -23,8 +23,11 @@ object CopyBookDecoderAndEncoderOps {
 
   val charRegex = """PIC X\((\d{1,3})\)""".r
   val charRegex2 = """PIC T\((\d{1,4})\)""".r
+  val charRegex3 = """PIC (X{1,9})""".r
   val bytesRegex = """PIC X\((\d{4,})\)""".r
   val numStrRegex = """PIC 9\((\d{1,3})\)""".r
+  val numStrRegex2 = """PIC (9{1,9})""".r
+  val decStrRegex = """PIC 9\((\d{1,3})\)V9\((\d{1,3})\)""".r
   val intRegex = """PIC S9\((\d{1,3})\) COMP""".r
   val uintRegex = """PIC 9\((\d{1,3})\) COMP""".r
   val decRegex = """PIC S9\((\d{1,3})\) COMP-3""".r

--- a/tools/bigquery-zos-mainframe-connector/gszutil/src/main/scala/com/google/cloud/gszutil/Decoding.scala
+++ b/tools/bigquery-zos-mainframe-connector/gszutil/src/main/scala/com/google/cloud/gszutil/Decoding.scala
@@ -211,7 +211,7 @@ object Decoding extends Logging {
         .setTyp(Field.FieldType.STRING)
   }
 
-  class StringAsIntDecoder(transcoder: Transcoder,
+  case class StringAsIntDecoder(transcoder: Transcoder,
                            override val size: Int,
                            override val filler: Boolean = false) extends Decoder {
     override def get(buf: ByteBuffer, col: ColumnVector, i: Int): Unit = {
@@ -411,7 +411,7 @@ object Decoding extends Logging {
   }
 
 
-  class StringAsDecimalDecoder(transcoder: Transcoder,
+  case class StringAsDecimalDecoder(transcoder: Transcoder,
                                override val size: Int,
                                val precision: Int,
                                val scale: Int,
@@ -726,6 +726,12 @@ object Decoding extends Logging {
           if (isDate && size == 10) Array.fill(size)(EBCDIC0)
           else Array.emptyByteArray
         new NullableStringDecoder(transcoder, size, filler = filler, nullIf = nullIfBytes)
+      case charRegex3(s) =>
+        val size = s.length
+        val nullIfBytes =
+          if (isDate && size == 10) Array.fill(size)(EBCDIC0)
+          else Array.emptyByteArray
+        new NullableStringDecoder(transcoder, size, filler = filler, nullIf = nullIfBytes)
       case charRegex2(s) =>
         val size = s.toInt
         val nullIfBytes =
@@ -738,10 +744,18 @@ object Decoding extends Logging {
         new BytesDecoder(s.toInt, filler)
       case numStrRegex(size) =>
         new StringDecoder(transcoder, size.toInt, filler = filler)
+      case numStrRegex2(s) =>
+        val size = s.length
+        new StringAsIntDecoder(transcoder, size, filler = filler)
       case decRegex(p) if p.toInt >= 1 =>
         Decimal64Decoder(p.toInt, 0, filler = filler)
       case decRegex2(p, s) if p.toInt >= 1 =>
         Decimal64Decoder(p.toInt, s.toInt, filler = filler)
+      case decStrRegex(p, s) if p.toInt >= 1 =>
+        val scale = s.toInt
+        val precision = p.toInt + scale
+        val size = precision
+        new StringAsDecimalDecoder(transcoder, size, precision, scale, filler = filler)
       case decRegex3(p, s) if p.toInt >= 1 =>
         Decimal64Decoder(p.toInt, s.length, filler = filler)
       case "PIC S9 COMP" =>

--- a/tools/bigquery-zos-mainframe-connector/gszutil/src/main/scala/com/google/cloud/imf/gzos/CloudDataSet.scala
+++ b/tools/bigquery-zos-mainframe-connector/gszutil/src/main/scala/com/google/cloud/imf/gzos/CloudDataSet.scala
@@ -22,9 +22,12 @@ import com.google.cloud.gszutil.io.CloudRecordReader
 import com.google.cloud.imf.util.{Logging, StatsUtil}
 import com.google.cloud.storage.{Blob, BlobId, Storage}
 
-/**  add these lines to environment file:
-  *  export GCSDSNURI=gs://bucket/prefix
-  *  export GCSGDGURI=gs://bucket-with-versioning/prefix
+/**  Cloud Data Set features enhance convenience of storing and
+  *  retrieving data sets to/from Cloud Storage Buckets.
+  *  To enable, set the optional environment variable:
+  *  export GCSDSNURI=gs://[BUCKET]/[PREFIX]
+  *  export GCSGDGURI=gs://[BUCKET]/[PREFIX]
+  *  Note that the GDG bucket must have object versioning enabled.
   */
 object CloudDataSet extends Logging {
   val DsnVar = "GCSDSNURI"

--- a/tools/bigquery-zos-mainframe-connector/gszutil/src/test/scala/com/google/cloud/bqsh/CopyBookSpec.scala
+++ b/tools/bigquery-zos-mainframe-connector/gszutil/src/test/scala/com/google/cloud/bqsh/CopyBookSpec.scala
@@ -41,7 +41,23 @@ class CopyBookSpec extends AnyFlatSpec with Logging {
     "PIC 9(9) COMP." -> (UnsignedLongDecoder(4), LongToBinaryEncoder(4)),
     "PIC 9(10) COMP." -> (UnsignedLongDecoder(8), LongToBinaryEncoder(8)),
     "PIC 9(18) COMP." -> (UnsignedLongDecoder(8), LongToBinaryEncoder(8)),
+    "PIC 9." -> (new StringAsIntDecoder(Ebcdic, 1), UnsignedIntStringEncoder(transcoder, 1)),
+    "PIC 99." -> (new StringAsIntDecoder(Ebcdic, 2), UnsignedIntStringEncoder(transcoder, 2)),
+    "PIC 999." -> (new StringAsIntDecoder(Ebcdic, 3), UnsignedIntStringEncoder(transcoder, 3)),
+    "PIC 9999." -> (new StringAsIntDecoder(Ebcdic, 4), UnsignedIntStringEncoder(transcoder, 4)),
+    "PIC 99999." -> (new StringAsIntDecoder(Ebcdic, 5), UnsignedIntStringEncoder(transcoder, 5)),
+    "PIC 999999." -> (new StringAsIntDecoder(Ebcdic, 6), UnsignedIntStringEncoder(transcoder, 6)),
+    "PIC 9(4)V9(1)." -> (new StringAsDecimalDecoder(Ebcdic, 5, 5, 1), UnsignedDecimalStringEncoder(transcoder, 5,1)),
+    "PIC 9(6)V9(2)." -> (new StringAsDecimalDecoder(Ebcdic, 8, 8, 2), UnsignedDecimalStringEncoder(transcoder, 8,2)),
+    "PIC 9(6)V9(4)." -> (new StringAsDecimalDecoder(Ebcdic, 10, 10, 4), UnsignedDecimalStringEncoder(transcoder, 10,4)),
+    "PIC 9(6)V9(6)." -> (new StringAsDecimalDecoder(Ebcdic, 12, 12, 6), UnsignedDecimalStringEncoder(transcoder, 12,6)),
+    "PIC 9(8)V9(2)." -> (new StringAsDecimalDecoder(Ebcdic, 10, 10, 2), UnsignedDecimalStringEncoder(transcoder, 10,2)),
+    "PIC 9(9)V9(5)." -> (new StringAsDecimalDecoder(Ebcdic, 14, 14, 5), UnsignedDecimalStringEncoder(transcoder, 14,5)),
+    "PIC 9(10)V9(2)." -> (new StringAsDecimalDecoder(Ebcdic, 12, 12, 2), UnsignedDecimalStringEncoder(transcoder, 12,2)),
     "PIC X." -> (new NullableStringDecoder(transcoder, 1, Array.emptyByteArray), StringToBinaryEncoder(transcoder, 1)),
+    "PIC XX." -> (new NullableStringDecoder(transcoder, 2, Array.emptyByteArray), StringToBinaryEncoder(transcoder, 2)),
+    "PIC XXX." -> (new NullableStringDecoder(transcoder, 3, Array.emptyByteArray), StringToBinaryEncoder(transcoder, 3)),
+    "PIC XXXX." -> (new NullableStringDecoder(transcoder, 4, Array.emptyByteArray), StringToBinaryEncoder(transcoder, 4)),
     "PIC X(8)." -> (new NullableStringDecoder(transcoder, 8, Array.emptyByteArray), StringToBinaryEncoder(transcoder, 8)),
     "PIC X(16)." -> (new NullableStringDecoder(transcoder, 16, Array.emptyByteArray), StringToBinaryEncoder(transcoder, 16)),
     "PIC X(30)." -> (new NullableStringDecoder(transcoder, 30, Array.emptyByteArray), StringToBinaryEncoder(transcoder, 30)),
@@ -134,7 +150,7 @@ class CopyBookSpec extends AnyFlatSpec with Logging {
       val picString = x._1
       val expectedDecoder = x._2._1
       val decoder = Decoding.typeMap(picString, transcoder, picTCharset, filler = false, isDate = false)
-      assert(decoder == expectedDecoder)
+      assert(decoder == expectedDecoder, s"$picString expected decoder $expectedDecoder")
     }
   }
 
@@ -144,7 +160,7 @@ class CopyBookSpec extends AnyFlatSpec with Logging {
       val expectedEncoder = x._2._2
       val decoder = Decoding.typeMap(picString, transcoder, picTCharset, filler = false, isDate = true)
       val encoder = Encoding.getEncoder(CopyBookField("", decoder, picString), transcoder, picTCharset)
-      assert(encoder == expectedEncoder)
+      assert(encoder == expectedEncoder, s"$picString expected $expectedEncoder")
     }
   }
 

--- a/tools/bigquery-zos-mainframe-connector/jzos-shim/src/main/java/com/ibm/jzos/fields/daa/BinarySignedIntL2Field.java
+++ b/tools/bigquery-zos-mainframe-connector/jzos-shim/src/main/java/com/ibm/jzos/fields/daa/BinarySignedIntL2Field.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC All Rights Reserved
+ * Copyright 2022 Google LLC All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,14 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-organization := "com.google.cloud.imf"
-name := "jzos-shim"
-version := "0.2"
 
-scalaVersion := "2.13.1"
+package com.ibm.jzos.fields.daa;
 
-libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest" % "3.2.9" % Test
-)
-
-publishMavenStyle := true
+public class BinarySignedIntL2Field {
+    public BinarySignedIntL2Field(int len) {}
+    public void putInt(int testValue, byte[] exampleData, int i) {
+        throw new RuntimeException("not implemented - add IBM jzos jars to classpath");
+    }
+}

--- a/tools/bigquery-zos-mainframe-connector/jzos-shim/src/main/java/com/ibm/jzos/fields/daa/BinarySignedIntL4Field.java
+++ b/tools/bigquery-zos-mainframe-connector/jzos-shim/src/main/java/com/ibm/jzos/fields/daa/BinarySignedIntL4Field.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC All Rights Reserved
+ * Copyright 2022 Google LLC All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,14 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-organization := "com.google.cloud.imf"
-name := "jzos-shim"
-version := "0.2"
 
-scalaVersion := "2.13.1"
+package com.ibm.jzos.fields.daa;
 
-libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest" % "3.2.9" % Test
-)
-
-publishMavenStyle := true
+public class BinarySignedIntL4Field {
+    public BinarySignedIntL4Field(int len) {}
+    public void putInt(int testValue, byte[] exampleData, int i) {
+        throw new RuntimeException("not implemented - add IBM jzos jars to classpath");
+    }
+}

--- a/tools/bigquery-zos-mainframe-connector/jzos-shim/src/main/java/com/ibm/jzos/fields/daa/BinarySignedLongL8Field.java
+++ b/tools/bigquery-zos-mainframe-connector/jzos-shim/src/main/java/com/ibm/jzos/fields/daa/BinarySignedLongL8Field.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC All Rights Reserved
+ * Copyright 2022 Google LLC All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,14 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-organization := "com.google.cloud.imf"
-name := "jzos-shim"
-version := "0.2"
 
-scalaVersion := "2.13.1"
+package com.ibm.jzos.fields.daa;
 
-libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest" % "3.2.9" % Test
-)
-
-publishMavenStyle := true
+public class BinarySignedLongL8Field {
+    public BinarySignedLongL8Field(int len) {}
+    public void putLong(long testValue, byte[] exampleData, int i) {
+        throw new RuntimeException("not implemented - add IBM jzos jars to classpath");
+    }
+}

--- a/tools/bigquery-zos-mainframe-connector/jzos-shim/src/main/java/com/ibm/jzos/fields/daa/BinaryUnsignedIntL4Field.java
+++ b/tools/bigquery-zos-mainframe-connector/jzos-shim/src/main/java/com/ibm/jzos/fields/daa/BinaryUnsignedIntL4Field.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC All Rights Reserved
+ * Copyright 2022 Google LLC All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,14 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-organization := "com.google.cloud.imf"
-name := "jzos-shim"
-version := "0.2"
 
-scalaVersion := "2.13.1"
+package com.ibm.jzos.fields.daa;
 
-libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest" % "3.2.9" % Test
-)
-
-publishMavenStyle := true
+public class BinaryUnsignedIntL4Field {
+    public BinaryUnsignedIntL4Field(int len) {}
+    public void putInt(int testValue, byte[] exampleData, int i) {
+        throw new RuntimeException("not implemented - add IBM jzos jars to classpath");
+    }
+}

--- a/tools/bigquery-zos-mainframe-connector/jzos-shim/src/main/java/com/ibm/jzos/fields/daa/BinaryUnsignedLongL8Field.java
+++ b/tools/bigquery-zos-mainframe-connector/jzos-shim/src/main/java/com/ibm/jzos/fields/daa/BinaryUnsignedLongL8Field.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC All Rights Reserved
+ * Copyright 2022 Google LLC All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,14 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-organization := "com.google.cloud.imf"
-name := "jzos-shim"
-version := "0.2"
 
-scalaVersion := "2.13.1"
+package com.ibm.jzos.fields.daa;
 
-libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest" % "3.2.9" % Test
-)
-
-publishMavenStyle := true
+public class BinaryUnsignedLongL8Field {
+    public BinaryUnsignedLongL8Field(int len) {}
+    public void putLong(long testValue, byte[] exampleData, int i) {
+        throw new RuntimeException("not implemented - add IBM jzos jars to classpath");
+    }
+}

--- a/tools/bigquery-zos-mainframe-connector/jzos-shim/src/main/java/com/ibm/jzos/fields/daa/PackedSignedIntP7Field.java
+++ b/tools/bigquery-zos-mainframe-connector/jzos-shim/src/main/java/com/ibm/jzos/fields/daa/PackedSignedIntP7Field.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC All Rights Reserved
+ * Copyright 2022 Google LLC All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,14 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-organization := "com.google.cloud.imf"
-name := "jzos-shim"
-version := "0.2"
 
-scalaVersion := "2.13.1"
+package com.ibm.jzos.fields.daa;
 
-libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest" % "3.2.9" % Test
-)
-
-publishMavenStyle := true
+public class PackedSignedIntP7Field {
+    public PackedSignedIntP7Field(int len) {}
+    public void putInt(int testValue, byte[] exampleData, int i) {
+        throw new RuntimeException("not implemented - add IBM jzos jars to classpath");
+    }
+}

--- a/tools/bigquery-zos-mainframe-connector/jzos-shim/src/main/java/com/ibm/jzos/fields/daa/PackedSignedLongP11Field.java
+++ b/tools/bigquery-zos-mainframe-connector/jzos-shim/src/main/java/com/ibm/jzos/fields/daa/PackedSignedLongP11Field.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC All Rights Reserved
+ * Copyright 2022 Google LLC All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,14 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-organization := "com.google.cloud.imf"
-name := "jzos-shim"
-version := "0.2"
 
-scalaVersion := "2.13.1"
+package com.ibm.jzos.fields.daa;
 
-libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest" % "3.2.9" % Test
-)
-
-publishMavenStyle := true
+public class PackedSignedLongP11Field {
+    public PackedSignedLongP11Field(int len) {}
+    public void putLong(long testValue, byte[] exampleData, int i) {
+        throw new RuntimeException("not implemented - add IBM jzos jars to classpath");
+    }
+}

--- a/tools/bigquery-zos-mainframe-connector/jzos-shim/src/main/java/com/ibm/jzos/fields/daa/PackedSignedLongP18Field.java
+++ b/tools/bigquery-zos-mainframe-connector/jzos-shim/src/main/java/com/ibm/jzos/fields/daa/PackedSignedLongP18Field.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC All Rights Reserved
+ * Copyright 2022 Google LLC All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,14 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-organization := "com.google.cloud.imf"
-name := "jzos-shim"
-version := "0.2"
 
-scalaVersion := "2.13.1"
+package com.ibm.jzos.fields.daa;
 
-libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest" % "3.2.9" % Test
-)
-
-publishMavenStyle := true
+public class PackedSignedLongP18Field {
+    public PackedSignedLongP18Field(int len) {}
+    public void putLong(long testValue, byte[] exampleData, int i) {
+        throw new RuntimeException("not implemented - add IBM jzos jars to classpath");
+    }
+}


### PR DESCRIPTION
This PR adds support for parsing of additional copybook field types. It also enhances documentation of environment variables to increase initial success rate of installation.

Examples of new field types: 
PIC XXX.    3 byte character string
PIC 999.     3 byte character string containing unsigned integer
PIC 9(6)V9(2).    8 byte character string containing unsigned decimal with scale 2