### PR TITLE
Update go.mod

### DIFF
--- a/tools/spiffe-gcp-proxy/go.mod
+++ b/tools/spiffe-gcp-proxy/go.mod
@@ -1,4 +1,4 @@
-module github.com/GoogleCloudPlatform/professional-services/spiffe-gcp-proxy
+module github.com/GoogleCloudPlatform/professional-services/tools/spiffe-gcp-proxy
 
 go 1.17
 


### PR DESCRIPTION
Fixes:
```
$ go install github.com/GoogleCloudPlatform/professional-services/tools/spiffe-gcp-proxy@latest

go: downloading github.com/GoogleCloudPlatform/professional-services/tools/spiffe-gcp-proxy v0.0.0-20220923224712-5b1b0042929b
go: downloading github.com/GoogleCloudPlatform/professional-services v0.0.0-20210423133912-01c3463d69bd
go: github.com/GoogleCloudPlatform/professional-services/tools/spiffe-gcp-proxy@latest: github.com/GoogleCloudPlatform/professional-services/tools/spiffe-gcp-proxy@v0.0.0-20220923224712-5b1b0042929b: parsing go.mod:
        module declares its path as: github.com/GoogleCloudPlatform/professional-services/spiffe-gcp-proxy
                but was required as: github.com/GoogleCloudPlatform/professional-services/tools/spiffe-gcp-proxy
```