### PR TITLE
Mainframe Connector: PDS upload

### DIFF
--- a/tools/bigquery-zos-mainframe-connector/gszutil/build.sbt
+++ b/tools/bigquery-zos-mainframe-connector/gszutil/build.sbt
@@ -16,7 +16,7 @@
  */
 organization := "com.google.cloud.imf"
 name := "mainframe-connector"
-version := "5.7.3"
+version := "5.7.4"
 
 scalaVersion := "2.13.8"
 

--- a/tools/bigquery-zos-mainframe-connector/gszutil/build.sbt
+++ b/tools/bigquery-zos-mainframe-connector/gszutil/build.sbt
@@ -16,7 +16,7 @@
  */
 organization := "com.google.cloud.imf"
 name := "mainframe-connector"
-version := "5.7.2"
+version := "5.7.3"
 
 scalaVersion := "2.13.8"
 

--- a/tools/bigquery-zos-mainframe-connector/gszutil/src/main/scala/com/google/cloud/bqsh/Bqsh.scala
+++ b/tools/bigquery-zos-mainframe-connector/gszutil/src/main/scala/com/google/cloud/bqsh/Bqsh.scala
@@ -141,6 +141,8 @@ object Bqsh extends Logging {
               runCommand(Query, subArgs, zos, cmd.env)
             case "export" =>
               runCommand(Export, subArgs, zos, cmd.env)
+            case "extract" =>
+              runCommand(Extract, subArgs, zos, cmd.env)
             case "load" =>
               runCommand(Load, subArgs, zos, cmd.env)
             case "rm" =>

--- a/tools/bigquery-zos-mainframe-connector/gszutil/src/main/scala/com/google/cloud/bqsh/ExtractConfig.scala
+++ b/tools/bigquery-zos-mainframe-connector/gszutil/src/main/scala/com/google/cloud/bqsh/ExtractConfig.scala
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2022 Google LLC All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.bqsh
+
+import com.google.cloud.imf.gzos.MVSStorage.{DSN, MVSDataset, MVSPDSMember}
+
+case class ExtractConfig(
+                         // Custom Options
+                         destinationUri: String = "",
+                         sourceTable: String = "",
+                         sql: String = "",
+                         queryDSN: String = "",
+                         delimiter: String = "",
+                         timeoutMinutes: Int = 90,
+                         compress: Boolean = false,
+                         replace: Boolean = false,
+                         format: String = "",
+
+                         // Standard Options
+                         allowLargeResults: Boolean = false,
+                         useLegacySql: Boolean = false,
+                         destinationTable: String = "",
+                         batch: Boolean = false,
+                         dryRun: Boolean = false,
+                         maximumBytesBilled: Long = -1,
+                         requireCache: Boolean = false,
+                         useCache: Boolean = true,
+
+                         // Global Options
+                         datasetId: String = "",
+                         debugMode: Boolean = false,
+                         jobId: String = "",
+                         jobProperties: Map[String, String] = Map.empty,
+                         location: String = "",
+                         projectId: String = "",
+                         sync: Boolean = true,
+                         statsTable: String = ""
+                       ) {
+  def dsn: Option[DSN] = {
+    val i = queryDSN.indexOf('(')
+    val j = queryDSN.indexOf(')')
+    if (i > 1 && j > i+1){
+      Option(MVSPDSMember(queryDSN.substring(0,i),queryDSN.substring(i+1,j)))
+    } else if (i > 0 && j > i+1) {
+      Option(MVSDataset(queryDSN))
+    } else None
+  }
+
+  override def toString: String =
+    s"""
+      |destinationUri=$destinationUri
+      |sourceTable=$sourceTable
+      |sql=$sql,
+      |queryDSN=$queryDSN,
+      |delimiter=$delimiter,
+      |format=$format,
+      |timeoutMinutes=$timeoutMinutes,
+      |batch=$batch,
+      |compress=$compress,
+      |sync=$sync,
+      |replace=$replace,
+      |dryRun=$dryRun,
+      |maximumBytesBilled=$maximumBytesBilled,
+      |useCache=$useCache,
+      |requireCache=$requireCache,
+      |datasetId=$datasetId,
+      |location=$location,
+      |projectId=$projectId,
+      |statsTable=$statsTable,
+      |allowLargeResults=$allowLargeResults,
+      |useLegacySql=$useLegacySql,
+      |destinationTable=$destinationTable
+      |""".stripMargin
+}

--- a/tools/bigquery-zos-mainframe-connector/gszutil/src/main/scala/com/google/cloud/bqsh/ExtractOptionParser.scala
+++ b/tools/bigquery-zos-mainframe-connector/gszutil/src/main/scala/com/google/cloud/bqsh/ExtractOptionParser.scala
@@ -52,7 +52,13 @@ object ExtractOptionParser
 
   opt[String]("field_delimiter")
     .text("(optional) For CSV exports, specifies the character that marks the boundary between columns in the output file. The delimiter can be any ISO-8859-1 single-byte character. You can use \\t or tab to specify tab delimiters.")
-    .action((x,c) => c.copy(delimiter = x))
+    .action {(x, c) =>
+      if (x.equalsIgnoreCase("dle")) {
+        c.copy(delimiter = "\u0010")
+      } else {
+        c.copy(delimiter = x)
+      }
+    }
 
   opt[Int]("timeOutMinutes")
     .action{(x,c) => c.copy(timeoutMinutes = x)}

--- a/tools/bigquery-zos-mainframe-connector/gszutil/src/main/scala/com/google/cloud/bqsh/ExtractOptionParser.scala
+++ b/tools/bigquery-zos-mainframe-connector/gszutil/src/main/scala/com/google/cloud/bqsh/ExtractOptionParser.scala
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2022 Google LLC All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.bqsh
+
+import scopt.OptionParser
+
+object ExtractOptionParser
+  extends OptionParser[ExtractConfig]("extract")
+  with ArgParser[ExtractConfig] {
+  override def parse(args: Seq[String], env: Map[String,String]): Option[ExtractConfig] =
+    parse(args, ExtractConfig())
+
+  head("extract", Bqsh.UserAgent)
+
+  help("help")
+    .text("prints this usage text")
+
+  // z/OS Options
+  opt[String]("destinationUri")
+    .text("Cloud Storage location to write extracted data")
+    .action((x, c) => c.copy(destinationUri = x))
+
+  opt[String]("query_dsn")
+    .text("(optional) DSN to read query from in format HLQ.MEMBER or HLQ.PDS(MEMBER). When provided, takes precedence over QUERY DD.")
+    .action((x,c) => c.copy(queryDSN = x))
+
+  opt[String]("sql")
+    .text("(optional) SQL query to be extracted. When provided, takes precedence over QUERY DD.")
+    .action((x,c) => c.copy(sql = x))
+
+  opt[String]("sourceTable")
+    .text("(optional) Tablespec to extract from. When provided, table will be extracted directly and SQL query job will not be submitted.")
+    .action((x,c) => c.copy(sourceTable = x))
+
+  opt[String]("format")
+    .text("(optional) Format to extract to. Default is CSV.")
+    .action((x,c) => c.copy(format = x))
+
+  opt[String]("field_delimiter")
+    .text("(optional) For CSV exports, specifies the character that marks the boundary between columns in the output file. The delimiter can be any ISO-8859-1 single-byte character. You can use \\t or tab to specify tab delimiters.")
+    .action((x,c) => c.copy(delimiter = x))
+
+  opt[Int]("timeOutMinutes")
+    .action{(x,c) => c.copy(timeoutMinutes = x)}
+    .text("(optional) Timeout in minutes for extract job. (default: 90 minutes)")
+
+  // Standard Options
+  opt[Unit]("allow_large_results")
+    .text("(optional) When specified, enables large destination table sizes for legacy SQL queries.")
+    .action((x,c) => c.copy(allowLargeResults = true))
+
+  opt[Unit]("use_legacy_sql")
+    .text("(optional) When specified, uses legacy SQL. The default value is false (uses Standard SQL).")
+    .action((x,c) => c.copy(useLegacySql = true))
+
+  opt[String]("destination_table")
+    .text("(optional) The name of the destination table for writing query results. The default value is ''")
+    .action((x,c) => c.copy(destinationTable = x))
+
+  opt[Boolean]("use_cache")
+    .text("(optional) When specified, caches the query results. The default value is true.")
+    .action((x,c) => c.copy(useCache = x))
+
+  opt[Unit]("batch")
+    .text("(optional) When specified, run the query in batch mode. The default value is false.")
+    .action((_,c) => c.copy(batch = true))
+
+  opt[Unit]("dry_run")
+    .text("(optional) When specified, the query is validated but not run.")
+    .action((_,c) => c.copy(dryRun = true))
+
+  opt[Long]("maximum_bytes_billed")
+    .text("(optional) An integer that limits the bytes billed for the query. If the query goes beyond the limit, it fails (without incurring a charge). If not specified, the bytes billed is set to the project default.")
+    .action((x,c) => c.copy(maximumBytesBilled = x))
+
+  opt[Boolean]("use_cache")
+    .text("(optional) When specified, caches the query results. The default value is true.")
+    .action((x,c) => c.copy(useCache = x))
+
+  // Global options
+  opt[String]("dataset_id")
+    .text(GlobalConfig.datasetIdText)
+    .action((x,c) => c.copy(datasetId = x))
+
+  opt[Unit]("debug_mode")
+    .text(GlobalConfig.debugModeText)
+    .action((x,c) => c.copy(debugMode = true))
+
+  opt[String]("job_id")
+    .text(GlobalConfig.jobIdText)
+    .action((x,c) => c.copy(jobId = x))
+
+  opt[String]("location")
+    .required()
+    .text(GlobalConfig.locationText)
+    .action((x,c) => c.copy(location = x))
+
+  opt[String]("project_id")
+    .required()
+    .text(GlobalConfig.projectIdText)
+    .action((x,c) => c.copy(projectId = x))
+
+  opt[Boolean]("synchronous_mode")
+    .text(GlobalConfig.synchronousModeText)
+    .action((x,c) => c.copy(sync = x))
+
+  opt[Boolean]("sync")
+    .text(GlobalConfig.syncText)
+    .action((x,c) => c.copy(sync = x))
+
+  // Custom Options
+  opt[String]("stats_table")
+    .optional()
+    .text("(optional) tablespec of table to insert stats")
+    .action((x,c) => c.copy(statsTable = x))
+}

--- a/tools/bigquery-zos-mainframe-connector/gszutil/src/main/scala/com/google/cloud/bqsh/ScpConfig.scala
+++ b/tools/bigquery-zos-mainframe-connector/gszutil/src/main/scala/com/google/cloud/bqsh/ScpConfig.scala
@@ -15,8 +15,14 @@
  */
 package com.google.cloud.bqsh
 
+import com.google.cloud.imf.gzos.MVSStorage.{DSN, MVSDataset}
+
 case class ScpConfig(inDD: String = "",
                      inDsn: String = "",
                      gcsOutUri: String = "",
-                     compress: Boolean = true,
-                     limit: Long = Long.MaxValue)
+                     convert: Boolean = true,
+                     encoding: String = "CP037",
+                     compress: Boolean = false,
+                     limit: Long = -1) {
+  def inDSN: DSN = MVSDataset(inDsn)
+}

--- a/tools/bigquery-zos-mainframe-connector/gszutil/src/main/scala/com/google/cloud/bqsh/ScpOptionParser.scala
+++ b/tools/bigquery-zos-mainframe-connector/gszutil/src/main/scala/com/google/cloud/bqsh/ScpOptionParser.scala
@@ -24,30 +24,46 @@ object ScpOptionParser extends OptionParser[ScpConfig]("scp") with ArgParser[Scp
 
   help("help").text("prints this usage text")
 
-  opt[Long]("count")
-    .optional
+  arg[String]("input")
+    .optional()
+    .text("DD or DSN to be uploaded")
+    .action {(x, c) =>
+      if (x.contains(".")) c.copy(inDsn = x)
+      else c.copy(inDD = x)
+    }
+
+  arg[String]("output")
+    .optional()
+    .text("URI of output in form gs://[BUCKET]/[PREFIX]")
+    .action((x, c) => c.copy(gcsOutUri = x))
+
+  opt[Long]('n', "count")
     .text("(optional) number of records to copy (default: unlimited)")
     .action((x,c) => c.copy(limit = x))
 
-  opt[Unit]("noCompress")
-    .optional
-    .text("(optional) compress output with gzip (default: true)")
-    .action((_,c) => c.copy(compress = false))
+  opt[Unit]("compress")
+    .text("(optional) compress output with gzip (default: disabled)")
+    .action((_,c) => c.copy(compress = true))
 
   opt[String]("inDD")
-    .optional
     .text("DD to be uploaded (INFILE will be used if not provided)")
     .action((x,c) => c.copy(inDD = x))
 
   opt[String]("inDsn")
-    .optional
     .text("DSN to be uploaded")
     .action((x,c) => c.copy(inDsn = x))
 
   opt[String]("gcsOutUri")
-    .optional
     .text("GCS URI of dataset copy")
     .action((x,c) => c.copy(gcsOutUri = x))
+
+  opt[String]("encoding")
+    .text("(optional) input character encoding. default: CP1037")
+    .action((x,c) => c.copy(encoding = x, convert = true))
+
+  opt[Unit]("noConvert")
+    .text("(optional) disable conversion of character input to ASCII. default: enabled")
+    .action((x,c) => c.copy(convert = false))
 
   checkConfig{x =>
     if (x.inDD.nonEmpty && x.inDsn.nonEmpty) {

--- a/tools/bigquery-zos-mainframe-connector/gszutil/src/main/scala/com/google/cloud/bqsh/cmd/Extract.scala
+++ b/tools/bigquery-zos-mainframe-connector/gszutil/src/main/scala/com/google/cloud/bqsh/cmd/Extract.scala
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2022 Google LLC All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.bqsh.cmd
+
+import com.google.cloud.bigquery.JobStatistics.QueryStatistics
+import com.google.cloud.bigquery.{BigQuery, BigQueryException, ExtractJobConfiguration, JobInfo, QueryJobConfiguration, TableId}
+import com.google.cloud.bqsh.{ArgParser, BQ, Command, ExtractConfig, ExtractOptionParser, QueryConfig}
+import com.google.cloud.imf.gzos.{MVS, Util}
+import com.google.cloud.imf.util.{Logging, Services, StatsUtil}
+
+/** BigQuery Extract command
+  * Creates an Extract Job to write a delimited file directly to Cloud Storage
+  * User must specify either a SQL query or a tablespec.
+  */
+object Extract extends Command[ExtractConfig] with Logging {
+  override val name: String = "bq extract"
+  override val parser: ArgParser[ExtractConfig] = ExtractOptionParser
+
+  override def run(cfg: ExtractConfig, zos: MVS, env: Map[String, String]): Result = {
+    val creds = zos.getCredentialProvider().getCredentials
+    logger.info(s"Starting $name\n$cfg")
+    val bq: BigQuery = Services.bigQuery(cfg.projectId, cfg.location, creds)
+
+    try {
+      if (cfg.sourceTable.nonEmpty) {
+        // Extract contents of a table
+        val table: TableId = BQ.resolveTableSpec(cfg.sourceTable, cfg.projectId, cfg.datasetId)
+        logger.info(s"Submitting BigQuery Extract job for source table: $table")
+        extract(table, bq, cfg, zos)
+      } else {
+        // Extract results of a SQL query
+        val query =
+          if (cfg.sql.nonEmpty) cfg.sql
+          else {
+            cfg.dsn match {
+              case Some(dsn) =>
+                logger.info(s"Reading query from DSN: $dsn")
+                zos.readDSNLines(dsn).mkString("\n")
+              case None =>
+                logger.info("Reading query from DD: QUERY")
+                zos.readDDString("QUERY", "\n")
+            }
+          }
+        logger.info(s"SQL Query:\n$query")
+        if (query.isEmpty) {
+          val msg = "Empty extract query"
+          logger.error(msg)
+          return Result.Failure(msg)
+        }
+
+        val queryConfig = QueryConfig(sql = query, queryDSN = cfg.queryDSN, timeoutMinutes = cfg.timeoutMinutes,
+          allowLargeResults = cfg.allowLargeResults, destinationTable = cfg.destinationTable, dryRun = cfg.dryRun,
+          maximumBytesBilled = cfg.maximumBytesBilled, requireCache = cfg.requireCache, useCache = cfg.useCache,
+          useLegacySql = cfg.useLegacySql, projectId = cfg.projectId, datasetId = cfg.datasetId,
+          location = cfg.location, debugMode = cfg.debugMode, batch = cfg.batch, sync = true,
+          jobProperties = cfg.jobProperties, replace = cfg.replace)
+        val (jobId, job) = BqQueryJobExecutor(bq, queryConfig, zos).execute(query, Query.configureQueryJob)
+        val table = job.getConfiguration[QueryJobConfiguration].getDestinationTable
+        val stats = job.getStatistics[QueryStatistics]
+        logger.info(s"Submitting BigQuery Extract job for SQL query")
+        extract(table, bq, cfg, zos)
+      }
+    } catch {
+      case e: Throwable =>
+        val msg = "Extract failed: " + e.getMessage + "\n"
+        logger.error(msg, e)
+        Result.Failure(msg)
+    }
+  }
+
+  def extract(table: TableId, bq: BigQuery, cfg: ExtractConfig, zos: MVS): Result = {
+    val extractConfig = ExtractJobConfiguration.newBuilder(table, cfg.destinationUri)
+    if (cfg.delimiter.nonEmpty)
+      extractConfig.setFieldDelimiter(cfg.delimiter)
+
+    if (cfg.compress)
+      extractConfig.setCompression("GZIP")
+
+    if (cfg.format.nonEmpty)
+      extractConfig.setFormat(cfg.format)
+
+    if (cfg.timeoutMinutes > 0)
+      extractConfig.setJobTimeoutMs(cfg.timeoutMinutes * 60L * 1000L)
+
+    val jobId = BQ.genJobId(cfg.projectId, cfg.location, zos.getInfo, "extract")
+    val rowCount = BQ.rowCount(bq, table)
+    try {
+      val startTime = System.currentTimeMillis()
+      val job = bq.create(JobInfo.of(jobId, extractConfig.build()))
+      if (cfg.sync) {
+        logger.info(s"Waiting for Job jobid=${BQ.toStr(jobId)}")
+        BQ.waitForJob(bq, jobId, timeoutMillis = cfg.timeoutMinutes * 60L * 1000L)
+        logger.info(s"Extract completed, extracted=${rowCount} rows, " +
+          s"time took: ${(System.currentTimeMillis() - startTime) / 1000} seconds.")
+      } else {
+        logger.info(s"Returning without waiting for job to complete because sync=false jobid=${BQ.toStr(jobId)}")
+        job
+      }
+
+      try {
+        // Publish results
+        if (cfg.statsTable.nonEmpty) {
+          val statsTable = BQ.resolveTableSpec(cfg.statsTable, cfg.projectId, cfg.datasetId)
+          val jobId = BQ.genJobId(cfg.projectId, cfg.location, zos.getInfo, "extract")
+          val tblspec = s"${statsTable.getProject}:${statsTable.getDataset}.${statsTable.getTable}"
+          logger.debug(s"Writing stats to $tblspec, with jobId ${jobId}")
+          StatsUtil.retryableInsertJobStats(zos, jobId, bq, statsTable, jobType = "export", recordsOut = rowCount)
+        }
+      } catch {
+        case e: Throwable =>
+          logger.warn(s"Failed to write stats for $jobId")
+      }
+
+      Result(activityCount = rowCount)
+    } catch {
+      case e: BigQueryException =>
+        if (e.getReason == "duplicate" && e.getMessage.startsWith("Already Exists: Job")) {
+          logger.warn(s"Job already exists, waiting for completion.\njobid=${BQ.toStr(jobId)}")
+          BQ.waitForJob(bq, jobId, timeoutMillis = cfg.timeoutMinutes * 60L)
+          Result(activityCount = rowCount)
+        } else {
+          logger.error(s"BQ API call failed for:$jobId\n$cfg\n$e")
+          Result.Failure(msg = e.getMessage)
+        }
+    }
+  }
+}

--- a/tools/bigquery-zos-mainframe-connector/gszutil/src/main/scala/com/google/cloud/bqsh/cmd/Scp.scala
+++ b/tools/bigquery-zos-mainframe-connector/gszutil/src/main/scala/com/google/cloud/bqsh/cmd/Scp.scala
@@ -19,21 +19,24 @@ import java.io.{BufferedOutputStream, OutputStream}
 import java.net.URI
 import java.nio.channels.Channels
 import java.util.zip.GZIPOutputStream
-
-import com.google.api.services.storage.StorageScopes
 import com.google.cloud.bqsh.{ArgParser, Command, ScpConfig, ScpOptionParser}
 import com.google.cloud.gszutil.io.ZRecordReaderT
-import com.google.cloud.imf.gzos.{CloudDataSet, DataSetInfo, MVS, MVSStorage, Util}
+import com.google.cloud.imf.gzos.MVSStorage.MVSPDSMember
+import com.google.cloud.imf.gzos.{CharsetTranscoder, CloudDataSet, DataSetInfo, MVS, MVSStorage, Util}
 import com.google.cloud.imf.util.{Logging, Services}
 import com.google.cloud.storage.{BlobId, BlobInfo, Storage}
 import com.google.common.io.CountingOutputStream
 
+import scala.util.{Failure, Success, Try}
+
 /** Simple binary copy
   * Single connection - not recommended for large uploads
-  * Writes gzip compressed object
+  * Writes gzip compressed object by default for non-PDS datasets
+  * Compression is disabled by default for PDS members
   * If GCSDSNURI envvar is set, output URI is automatically set
   * by appending the DSN to the base URI, thus does not
   * need to be specified via command-line arguments.
+  *
   */
 object Scp extends Command[ScpConfig] with Logging {
   override val name: String = "scp"
@@ -42,96 +45,36 @@ object Scp extends Command[ScpConfig] with Logging {
     logger.debug(s"Staring scp $config")
     try {
       CloudDataSet.readEnv(env)
-      val creds = zos.getCredentialProvider().getCredentials
-        .createScoped(StorageScopes.DEVSTORAGE_READ_WRITE)
-      val gcs = Services.storage(creds)
+      val gcs = Services.storage(Services.storageCredentials())
 
-      val in: ZRecordReaderT =
-        if (config.inDsn.nonEmpty) {
-          logger.debug(s"reading from DSN=${config.inDsn}")
-          zos.readDSN(MVSStorage.parseDSN(config.inDsn))
-        } else if (config.inDD.nonEmpty) {
-          logger.debug(s"reading from DD:${config.inDD}")
-          zos.readDD(config.inDD)
-        } else {
-          logger.info("input not specified, reading from default input DD:INFILE")
-          zos.readDD("INFILE")
-        }
-      val lrecl = in.lRecl
-
-      val outUri: String = {
-        val ds = DataSetInfo(in.getDsn)
-        // explicitly provided output URI takes precedence
-        if (config.gcsOutUri.nonEmpty) {
-          logger.info(s"using output location from --gcsOutUri:\n${config.gcsOutUri}, datasetInfo=$ds")
-          config.gcsOutUri
-        } else {
-          // otherwise, check CloudDataSet prefixes
-          CloudDataSet.getUri(ds) match {
-            case Some(uri) =>
-              logger.info(s"using output location from CloudDataSet:\n$uri")
-              uri
-            case None =>
-              val msg = "scp is unable to determine output location.\n" +
-                s"either provide --outUri option or " +
-                s"set ${CloudDataSet.DsnVar} and ${CloudDataSet.GdgVar}"
-              logger.error(msg)
-              return Result.Failure(msg)
+      Try(zos.listPDS(config.inDSN)) match {
+        case Success(members) =>
+          // inDSN is a PDS
+          logger.info(s"reading PDS ${config.inDSN.fqdsn}")
+          var result: Result = Result.Success
+          while (members.hasNext && result.exitCode == 0) {
+            val member = members.next()
+            val mbr = MVSPDSMember(config.inDsn, member.name)
+            logger.info(s"reading member ${mbr.fqdsn}")
+            result = copyToCloudStorage(in = zos.readDSN(mbr), config, gcs, member.name)
           }
-        }
+          result
+
+        case Failure(e) =>
+          // not a PDS
+          val in: ZRecordReaderT =
+            if (config.inDsn.nonEmpty) {
+              logger.debug(s"reading from DSN=${config.inDsn}")
+              zos.readDSN(MVSStorage.parseDSN(config.inDsn))
+            } else if (config.inDD.nonEmpty) {
+              logger.debug(s"reading from DD:${config.inDD}")
+              zos.readDD(config.inDD)
+            } else {
+              logger.info("input not specified, reading from default input DD:INFILE")
+              zos.readDD("INFILE")
+            }
+          copyToCloudStorage(in, config, gcs)
       }
-
-      val t0 = System.currentTimeMillis()
-      val os: CountingOutputStream =
-        new CountingOutputStream(openGcsUri(gcs, outUri, lrecl, config.compress))
-
-      var nRecordsRead: Long = 0
-      var n = 0
-      val buf = new Array[Byte](lrecl)
-      try {
-        logger.info("starting to write")
-        n = in.read(buf)
-        while (n > -1 && nRecordsRead < config.limit){
-          if (n > 0) {
-            nRecordsRead += 1
-            os.write(buf, 0, lrecl)
-          }
-          n = in.read(buf)
-        }
-        os.close()
-        in.close()
-        logger.info(s"finished writing $nRecordsRead records")
-      } catch {
-        case t: Throwable =>
-          in.close()
-          val msg = s"exception during upload:\n${t.getMessage}"
-          logger.error(msg,t)
-          return Result.Failure(msg)
-      }
-
-      val t1 = System.currentTimeMillis()
-
-      Option(gcs.get(blobId(outUri))) match {
-        case Some(blob) =>
-          val size = blob.getSize
-          val readRate = Util.fmbps(os.getCount, t1-t0)
-          val writeRate = Util.fmbps(size, t1-t0)
-          val msg =
-            s"""Wrote $nRecordsRead records
-               |$outUri
-               |${os.getCount} bytes read
-               |$size bytes written
-               |read rate: $readRate mbps
-               |write rate: $writeRate mbps
-               |$blob""".stripMargin
-          logger.info(msg)
-
-          Result(activityCount = nRecordsRead)
-        case None =>
-          Result.Failure(s"finished writing $nRecordsRead records, ${os.getCount} bytes " +
-            s"\nbut object not found at $outUri")
-      }
-
     } catch {
       case e: Throwable =>
         val sb = new StringBuilder
@@ -141,6 +84,135 @@ object Scp extends Command[ScpConfig] with Logging {
         val msg = sb.result
         logger.error(msg, e)
         Result.Failure(msg)
+    }
+  }
+
+  /** Create output URI for a given combination
+    * If prefix includes a trailing slash, DSN for a PDS will not be appended
+    * For a normal dataset (not a PDS), DSN is always used as the output object name
+    *
+    * @param prefix uri prefix of form gs://[BUCKET]/[PREFIX]
+    * @param dsn input DSN without member name
+    * @param memberName optional member name or empty string
+    * @return output URI as String
+    */
+  def mkOutUri(prefix: String, dsn: String, memberName: String = ""): String = {
+    if (memberName.nonEmpty) {
+      // PDS
+      if (prefix.endsWith("/")) {
+        // append DSN with member name to base uri
+        s"$prefix$dsn/$memberName"
+      } else {
+        // discard DSN and use member name only
+        s"$prefix/$memberName"
+      }
+    } else {
+      // normal dataset, not a PDS
+      if (prefix.endsWith("/")) {
+        s"$prefix$dsn"
+      } else {
+        s"$prefix/$dsn"
+      }
+    }
+  }
+
+  /** Copy data to Cloud Storage
+    * if copying a PDS member, convert EBCDIC to ASCII
+    *
+    * @param in ZRecordReaderT
+    * @param config ScpConfig
+    * @param gcs Storage client
+    * @param memberName optional member name, if copying a PDS member
+    * @return Result
+    */
+  def copyToCloudStorage(in: ZRecordReaderT, config: ScpConfig, gcs: Storage, memberName: String = ""): Result = {
+    val lrecl = in.lRecl
+
+    val outUri: String = {
+      // explicitly provided output URI takes precedence
+      if (config.gcsOutUri.nonEmpty) {
+        logger.info(s"writing to output location: ${config.gcsOutUri}")
+        mkOutUri(config.gcsOutUri, config.inDsn, memberName)
+      } else {
+        // otherwise, check CloudDataSet prefixes
+        CloudDataSet.getUri(DataSetInfo(in.getDsn)) match {
+          case Some(uri) =>
+            logger.info(s"writing to CloudDataSet: $uri")
+            uri
+          case None =>
+            val msg = "scp is unable to determine output location.\n" +
+              s"either provide --gcsOutUri option or " +
+              s"set ${CloudDataSet.DsnVar} and ${CloudDataSet.GdgVar}"
+            logger.error(msg)
+            return Result.Failure(msg)
+        }
+      }
+    }
+
+    val t0 = System.currentTimeMillis()
+    val contentType = if (config.convert) "text/plain" else "application/octet-stream"
+    val os: CountingOutputStream =
+      new CountingOutputStream(openGcsUri(gcs, outUri, lrecl, config.compress, contentType))
+
+    var nRecordsRead: Long = 0
+    var n = 0
+    val buf = new Array[Byte](lrecl)
+    try {
+      n = in.read(buf)
+      if (config.convert) {
+        val transcoder = CharsetTranscoder(config.encoding)
+        while (n > -1 && (nRecordsRead < config.limit || config.limit < 0)) {
+          if (n > 0) {
+            nRecordsRead += 1
+            transcoder.decodeBytes(buf)
+            // write converted character record
+            os.write(buf, 0, lrecl)
+            // append line break
+            os.write('\n')
+          }
+          n = in.read(buf)
+        }
+      } else {
+        while (n > -1 && (nRecordsRead < config.limit || config.limit < 0)) {
+          if (n > 0) {
+            nRecordsRead += 1
+            os.write(buf, 0, lrecl)
+          }
+          n = in.read(buf)
+        }
+      }
+      os.close()
+      in.close()
+      logger.info(s"finished writing $nRecordsRead records")
+    } catch {
+      case t: Throwable =>
+        in.close()
+        val msg = s"exception during upload:\n${t.getMessage}"
+        logger.error(msg, t)
+        return Result.Failure(msg)
+    }
+
+    val t1 = System.currentTimeMillis()
+
+    Option(gcs.get(blobId(outUri))) match {
+      case Some(blob) =>
+        val size = blob.getSize
+        val readRate = Util.fmbps(os.getCount, t1 - t0)
+        val writeRate = Util.fmbps(size, t1 - t0)
+        val msg =
+          s"""Wrote $nRecordsRead records
+             |$outUri
+             |${nRecordsRead * lrecl} bytes read
+             |$size bytes written
+             |read rate: $readRate mbps
+             |write rate: $writeRate mbps
+             |$blob""".stripMargin
+        logger.info(msg)
+
+        Result(activityCount = nRecordsRead)
+      case None =>
+        Result.Failure(s"finished writing $nRecordsRead records, ${os.getCount} bytes " +
+          s"\nbut object not found at $outUri")
     }
   }
 
@@ -163,10 +235,9 @@ object Scp extends Command[ScpConfig] with Logging {
     validateGcsUri(gcsUri)
     BlobId.of(gcsUri.getAuthority, gcsUri.getPath.stripPrefix("/"))
   }
-
-  def openGcsUri(gcs: Storage, uri: String, lrecl: Int, compress: Boolean): OutputStream = {
+  def openGcsUri(gcs: Storage, uri: String, lrecl: Int, compress: Boolean, contentType: String = "application/octet-stream"): OutputStream = {
     val blobInfo = BlobInfo.newBuilder(blobId(uri))
-      .setContentType("application/octet-stream")
+      .setContentType(contentType)
       .setContentEncoding(if (compress) "gzip" else "identity")
       .setMetadata(blobMetadata(lrecl)).build
     if (compress) openGcsBlobGzip(gcs, blobInfo)

--- a/tools/bigquery-zos-mainframe-connector/gszutil/src/test/scala/com/google/cloud/bqsh/ShellSpec.scala
+++ b/tools/bigquery-zos-mainframe-connector/gszutil/src/test/scala/com/google/cloud/bqsh/ShellSpec.scala
@@ -124,9 +124,14 @@ class ShellSpec extends AnyFlatSpec {
 
   it should "scp args" in {
     val examples = Seq(
+      Seq("HLQ.DATASET.NAME", "gs://bucket/prefix/"),
+      Seq("HLQ.DATASET.NAME", "gs://bucket/prefix/", "--encoding", "CP037"),
+      Seq("HLQ.DATASET.NAME", "gs://bucket/prefix/", "--noConvert"),
       Seq("--inDsn", "HLQ.DATASET.NAME"),
       Seq("--inDsn", "HLQ.DATASET.NAME", "--gcsOutUri", "gs://bucket/prefix/data.gz"),
-      Seq("--inDD", "DDNAME", "--count", "1000", "--noCompress"),
+      Seq("--inDD", "DDNAME", "--count", "1000"),
+      Seq("--inDD", "DDNAME", "-n", "1000"),
+      Seq("--inDD", "DDNAME", "--compress"),
     )
     for (args <- examples) {
       if (Scp.parser.parse(args, sys.env).isEmpty)


### PR DESCRIPTION
This PR adds PDS upload to the `scp` command.

Example usage:
`scp PATH.TO.PDS gs://bucket/prefix/`
would copy each member of PDS to `gs://bucket/prefix/PATH.TO.PDS/MEMBERNAME`

`scp PATH.TO.PDS gs://bucket/prefix`
would drop the DSN from the object name and copy each member of PDS to `gs://bucket/prefix/MEMBERNAME`

If the input DSN references a PDS, EBCDIC to ASCII conversion will be enabled by default but this can be disabled by specifying `--noConvert`. Encoding can be specified by the `--encoding` command-line option.