### PR TITLE
Mainframe Connector date envvars, sql quoting, safe job id generation

### DIFF
--- a/tools/bigquery-zos-mainframe-connector/gszutil/src/main/scala/com/google/cloud/bqsh/Bqsh.scala
+++ b/tools/bigquery-zos-mainframe-connector/gszutil/src/main/scala/com/google/cloud/bqsh/Bqsh.scala
@@ -184,8 +184,10 @@ object Bqsh extends Logging {
         if (!(singleQuoted || doubleQuoted)) {
           if (c == '\'') {
             singleQuoted = true
+            sb.append(c)
           } else if (c == '"') {
             doubleQuoted = true
+            sb.append(c)
           } else if (c == '\\' && next == '$') {
             i += 1
             sb.append(next)
@@ -201,8 +203,10 @@ object Bqsh extends Logging {
         } else {
           if (singleQuoted && c == '\'') {
             singleQuoted = false
+            sb.append(c)
           } else if (doubleQuoted && c == '"') {
             doubleQuoted = false
+            sb.append(c)
           } else if (c == '\\' && next == '$') {
             i += 1
             sb.append(next)

--- a/tools/bigquery-zos-mainframe-connector/gszutil/src/main/scala/com/google/cloud/bqsh/Bqsh.scala
+++ b/tools/bigquery-zos-mainframe-connector/gszutil/src/main/scala/com/google/cloud/bqsh/Bqsh.scala
@@ -20,6 +20,8 @@ import com.google.cloud.bqsh.cmd._
 import com.google.cloud.imf.gzos.{MVS, Util}
 import com.google.cloud.imf.util.{Logging, Services}
 
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 
@@ -40,11 +42,42 @@ object Bqsh extends Logging {
     logger.info(jobInfoMap)
 
     // TODO collect job-specific environment variables from parm file
-    val jobEnv: Map[String, String] = sys.env
-    val interpreter = new Interpreter(zos, jobEnv, true, true)
+    val interpreter = new Interpreter(zos, getEnv(sys.env), true, true)
     val result = interpreter.runScript(script)
     if (result.exitCode == 0) Util.exit
     else System.exit(result.exitCode)
+  }
+
+  /** adds date and time environment variables
+    * useful for naming
+    * @return
+    */
+  def getEnv(env0: Map[String, String]): Map[String, String] = {
+    val env = mutable.Map.from(env0)
+    val t = LocalDateTime.now()
+
+    def format(t: LocalDateTime, pattern: String): String =
+      t.format(DateTimeFormatter.ofPattern(pattern))
+
+    // date '+%Y%m%d' YYYYMMDD
+    env.put("DATE", format(t,"uuuuMMdd"))
+
+    // date '+%Y%m%d%H%M%S' YYYYMMDDHHMMSS
+    // timestamp at second resolution
+    env.put("DATE14", format(t,"uuuuMMddHHmmss"))
+    env.put("DATE15", format(t,"uuuuMMdd_HHmmss"))
+
+    // date '+%H%M' HHMM
+    env.put("TIME", format(t,"HHmm"))
+    // date '+%H%M%S' HHMMSS
+    env.put("TIME6", format(t,"HHmmss"))
+
+    // timestamp at minute resolution
+    // date '+%Y%m%d%H%M' YYYYMMDDHHMM
+    env.put("DATE12", format(t,"uuuuMMddHHmm"))
+    env.put("UNIXTIME", (System.currentTimeMillis() / 1000L).toString)
+
+    env.toMap
   }
 
   class Interpreter(zos: MVS, sysEnv: Map[String, String], var exitOnError: Boolean = true, var printCommands: Boolean = true) {

--- a/tools/bigquery-zos-mainframe-connector/gszutil/src/main/scala/com/google/cloud/bqsh/cmd/BqQueryJobExecutor.scala
+++ b/tools/bigquery-zos-mainframe-connector/gszutil/src/main/scala/com/google/cloud/bqsh/cmd/BqQueryJobExecutor.scala
@@ -40,7 +40,7 @@ class BqQueryJobExecutor(bq: BigQuery, cfg: QueryConfig, zos: MVS) extends Loggi
 
     @tailrec
     def run(query: String): (JobId, Job) = {
-      val jobId = BQ.genJobId(cfg.projectId, cfg.location, zos, "query", generateHashString)
+      val jobId = BQ.genJobId(cfg.projectId, cfg.location, zos.getInfo, "query", randomSuffix = true)
       logger.info(s"Submitting Query Job\njobid=${BQ.toStr(jobId)}, jobQuery=\n$query")
       val job = BQ.runJob(bq, queryConfigurer(query, cfg), jobId, cfg.timeoutMinutes * 60, cfg.sync)
 

--- a/tools/bigquery-zos-mainframe-connector/gszutil/src/main/scala/com/google/cloud/bqsh/cmd/Cp.scala
+++ b/tools/bigquery-zos-mainframe-connector/gszutil/src/main/scala/com/google/cloud/bqsh/cmd/Cp.scala
@@ -126,7 +126,7 @@ object Cp extends Command[GsUtilConfig] with Logging {
     if (c.statsTable.nonEmpty) {
       val statsTable = BQ.resolveTableSpec(c.statsTable, c.projectId, c.datasetId)
       logger.debug(s"writing stats to ${BQ.tableSpec(statsTable)}")
-      val jobId = BQ.genJobId(c.projectId, c.location, zos, "cp")
+      val jobId = BQ.genJobId(c.projectId, c.location, zos.getInfo, "cp")
       val bqProj = if (c.projectId.nonEmpty) c.projectId else statsTable.getProject
       StatsUtil.retryableInsertJobStats(
         zos = zos,

--- a/tools/bigquery-zos-mainframe-connector/gszutil/src/main/scala/com/google/cloud/bqsh/cmd/Export.scala
+++ b/tools/bigquery-zos-mainframe-connector/gszutil/src/main/scala/com/google/cloud/bqsh/cmd/Export.scala
@@ -76,7 +76,7 @@ object Export extends Command[ExportConfig] with Logging {
       // Publish results
       if (cfg.statsTable.nonEmpty) {
         val statsTable = BQ.resolveTableSpec(cfg.statsTable, cfg.projectId, cfg.datasetId)
-        val jobId = BQ.genJobId(cfg.projectId, cfg.location, zos, "query")
+        val jobId = BQ.genJobId(cfg.projectId, cfg.location, zos.getInfo, "query")
         val tblspec = s"${statsTable.getProject}:${statsTable.getDataset}.${statsTable.getTable}"
         logger.debug(s"Writing stats to $tblspec, with jobId ${jobId}")
         StatsUtil.retryableInsertJobStats(zos, jobId, bq, statsTable, jobType = "export", recordsOut = result.activityCount)

--- a/tools/bigquery-zos-mainframe-connector/gszutil/src/main/scala/com/google/cloud/bqsh/cmd/GsZUtil.scala
+++ b/tools/bigquery-zos-mainframe-connector/gszutil/src/main/scala/com/google/cloud/bqsh/cmd/GsZUtil.scala
@@ -118,7 +118,7 @@ object GsZUtil extends Command[GsZUtilConfig] with Logging {
       val statsTable: TableId = BQ.resolveTableSpec(c.statsTable, c.projectId, c.datasetId)
       logger.info(s"writing stats to ${BQ.tableSpec(statsTable)}")
       val bqProj = if (c.projectId.nonEmpty) c.projectId else statsTable.getProject
-      val jobId = BQ.genJobId(bqProj, c.location, zos, "gszutil")
+      val jobId = BQ.genJobId(bqProj, c.location, zos.getInfo, "gszutil")
       StatsUtil.retryableInsertJobStats(
         zos = zos,
         jobId = jobId,

--- a/tools/bigquery-zos-mainframe-connector/gszutil/src/main/scala/com/google/cloud/bqsh/cmd/Load.scala
+++ b/tools/bigquery-zos-mainframe-connector/gszutil/src/main/scala/com/google/cloud/bqsh/cmd/Load.scala
@@ -35,7 +35,7 @@ object Load extends Command[LoadConfig] with Logging {
     val jobConfig = configureLoadJob(cfg)
     logger.info("submitting load job")
 
-    val jobId = BQ.genJobId(cfg.projectId, cfg.location, zos, "load")
+    val jobId = BQ.genJobId(cfg.projectId, cfg.location, zos.getInfo, "load")
     bq.create(JobInfo.of(jobId, jobConfig))
     logger.info(s"Waiting for Load Job jobid=${BQ.toStr(jobId)}")
     val completed = BQ.waitForJob(bq, jobId, timeoutMillis = 60L * 60L * 1000L)

--- a/tools/bigquery-zos-mainframe-connector/gszutil/src/test/scala/com/google/cloud/bqsh/QueryITSpec.scala
+++ b/tools/bigquery-zos-mainframe-connector/gszutil/src/test/scala/com/google/cloud/bqsh/QueryITSpec.scala
@@ -289,7 +289,7 @@ class QueryITSpec extends AnyFlatSpec with BeforeAndAfterAll with BeforeAndAfter
          |  (1, "STORE_1")
          |;""".stripMargin
     val jobConfiguration_create = configureQueryJob(createTableScript, cfg)
-    val jobId_create = BQ.genJobId(cfg.projectId, cfg.location, zos, "query")
+    val jobId_create = BQ.genJobId(cfg.projectId, cfg.location, zos.getInfo, "query")
     val job_create = BQ.runJob(bq, jobConfiguration_create, jobId_create, cfg.timeoutMinutes * 60, true)
 
     val status = BQ.getStatus(job_create)
@@ -320,7 +320,7 @@ class QueryITSpec extends AnyFlatSpec with BeforeAndAfterAll with BeforeAndAfter
          |;""".stripMargin
 
     val jobConfiguration_insert = configureQueryJob(insertScript, cfg)
-    val jobId_insert = BQ.genJobId(cfg.projectId, cfg.location, zos, "query")
+    val jobId_insert = BQ.genJobId(cfg.projectId, cfg.location, zos.getInfo, "query")
     BQ.runJob(bq, jobConfiguration_insert, jobId_insert, cfg.timeoutMinutes * 60, cfg.sync)
     val job_insert = BQ.apiGetJob(bqApi, jobId_insert)
     val insert_result = MergeStats.forJob(job_insert)
@@ -343,7 +343,7 @@ class QueryITSpec extends AnyFlatSpec with BeforeAndAfterAll with BeforeAndAfter
          |;""".stripMargin
 
     val jobConfiguration_update = configureQueryJob(updateScript, cfg)
-    val jobId_update = BQ.genJobId(cfg.projectId, cfg.location, zos, "query")
+    val jobId_update = BQ.genJobId(cfg.projectId, cfg.location, zos.getInfo, "query")
     BQ.runJob(bq, jobConfiguration_update, jobId_update, cfg.timeoutMinutes * 60, cfg.sync)
     val job_update = BQ.apiGetJob(bqApi, jobId_update)
     val update_result = MergeStats.forJob(job_update)
@@ -366,7 +366,7 @@ class QueryITSpec extends AnyFlatSpec with BeforeAndAfterAll with BeforeAndAfter
          |;""".stripMargin
 
     val jobConfiguration_delete = configureQueryJob(deleteScript, cfg)
-    val jobId_delete = BQ.genJobId(cfg.projectId, cfg.location, zos, "query")
+    val jobId_delete = BQ.genJobId(cfg.projectId, cfg.location, zos.getInfo, "query")
     BQ.runJob(bq, jobConfiguration_delete, jobId_delete, cfg.timeoutMinutes * 60, cfg.sync)
     val job_delete = BQ.apiGetJob(bqApi, jobId_delete)
     val delete_result = MergeStats.forJob(job_delete)

--- a/tools/bigquery-zos-mainframe-connector/gszutil/src/test/scala/com/google/cloud/bqsh/ShellSpec.scala
+++ b/tools/bigquery-zos-mainframe-connector/gszutil/src/test/scala/com/google/cloud/bqsh/ShellSpec.scala
@@ -55,6 +55,27 @@ class ShellSpec extends AnyFlatSpec {
     assert(parsed == expected)
   }
 
+  it should "handle quotes and replace envvars" in {
+    val example =
+      """bq --project_id project query \
+        |  --sql "select '|$table' as a, b from $table"""".stripMargin
+    val parsed = Bqsh.readArgs(example)
+    val expected = Seq(
+      "bq", "--project_id", "project",
+      // outer double quotes should be removed by readArgs
+      "query", "--sql", "select '|$table' as a, b from $table"
+    )
+    assert(parsed == expected)
+    val env = Map(("table","tablename"))
+    val replaced = parsed.map(Bqsh.replaceEnvVars(_, env))
+    val expected2 = Seq(
+      "bq", "--project_id", "project",
+      // shouldn't replace envvar within single quotes
+      "query", "--sql", "select '|$table' as a, b from tablename"
+    )
+    assert(replaced == expected2)
+  }
+
   it should "split commands" in {
     val in =
       """gsutil cp INFILE gs://bucket/path.orc
@@ -81,7 +102,7 @@ class ShellSpec extends AnyFlatSpec {
       "SOURCE" -> "gs://mybucket/path.orc/*"
     )
     val cmd = """bq --project_id=project --dataset_id='dataset' mk   --external_table_definition="ORC=$SOURCE" $TABLE"""
-    val expected = """bq --project_id=project --dataset_id=dataset mk   --external_table_definition=ORC=gs://mybucket/path.orc/* project:dataset.table"""
+    val expected = """bq --project_id=project --dataset_id='dataset' mk   --external_table_definition="ORC=gs://mybucket/path.orc/*" project:dataset.table"""
     assert(Bqsh.replaceEnvVars(cmd, env) == expected)
   }
 


### PR DESCRIPTION
This PR includes the following changes to the mainframe connector:
- prevent BigQuery API failure due to disallowed character in job name or step name by filtering during job id creation
- fix issue preventing use of single quotes in sql provided by command-line
- add date and time environment variables