### PR TITLE
Mainframe Connector: add pubsub topics publish command

### DIFF
--- a/tools/bigquery-zos-mainframe-connector/gszutil/build.sbt
+++ b/tools/bigquery-zos-mainframe-connector/gszutil/build.sbt
@@ -16,7 +16,7 @@
  */
 organization := "com.google.cloud.imf"
 name := "mainframe-connector"
-version := "5.7.4"
+version := "5.7.5"
 
 scalaVersion := "2.13.8"
 
@@ -29,7 +29,7 @@ val exProtobufJava = ExclusionRule(organization = "com.google.protobuf", name = 
 val log4j1 = ExclusionRule(organization = "log4j", name = "log4j")
 
 libraryDependencies ++= Seq(
-  "com.google.cloud.imf" %% "mainframe-util" % "2.2.0",
+  "com.google.cloud.imf" %% "mainframe-util" % "2.2.1",
   // enable users to compile without IBM JZOS jars
   // comment this line out and place IBM jars in lib directory to test against IBM classes
   "com.google.cloud.imf" %% "jzos-shim" % "0.2" % Provided,

--- a/tools/bigquery-zos-mainframe-connector/gszutil/src/main/scala/com/google/cloud/bqsh/Bqsh.scala
+++ b/tools/bigquery-zos-mainframe-connector/gszutil/src/main/scala/com/google/cloud/bqsh/Bqsh.scala
@@ -161,6 +161,18 @@ object Bqsh extends Logging {
           }
         } else if (cmd.name == "gszutil") {
           runCommand(GsZUtil, cmd.args, zos, cmd.env)
+        } else if (cmd.name == "gcloud") {
+          sub match {
+            case "pubsub" =>
+              subArgs.toList match {
+                case "topics" :: "publish" :: runArgs =>
+                  runCommand(Publish, runArgs, zos, cmd.env)
+                case _ =>
+                  Result.Failure(s"invalid command '${args.mkString(" ")}'")
+              }
+            case _ =>
+              Result.Failure(s"invalid command '${args.mkString(" ")}'")
+          }
         } else if (cmd.name == "scp") {
           runCommand(Scp, cmd.args, zos, cmd.env)
         } else if (cmd.name == "jclutil") {

--- a/tools/bigquery-zos-mainframe-connector/gszutil/src/main/scala/com/google/cloud/bqsh/PublishConfig.scala
+++ b/tools/bigquery-zos-mainframe-connector/gszutil/src/main/scala/com/google/cloud/bqsh/PublishConfig.scala
@@ -15,7 +15,15 @@
  */
 package com.google.cloud.bqsh
 
+import com.google.cloud.imf.gzos.MVSStorage.{DSN, MVSDataset}
+
 case class PublishConfig(topic: String = "",
                          message: String = "",
                          attributes: Map[String,String] = Map.empty,
-                         orderingKey: String = "")
+                         orderingKey: String = "",
+                         messageDsn: String = "",
+                         messageDD: String = "",
+                         convert: Boolean = false,
+                         encoding: String = "") {
+  def messageDSN: DSN = MVSDataset(messageDsn)
+}

--- a/tools/bigquery-zos-mainframe-connector/gszutil/src/main/scala/com/google/cloud/bqsh/PublishConfig.scala
+++ b/tools/bigquery-zos-mainframe-connector/gszutil/src/main/scala/com/google/cloud/bqsh/PublishConfig.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2022 Google LLC All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bqsh
+
+case class PublishConfig(topic: String = "",
+                         message: String = "",
+                         attributes: Map[String,String] = Map.empty,
+                         orderingKey: String = "")

--- a/tools/bigquery-zos-mainframe-connector/gszutil/src/main/scala/com/google/cloud/bqsh/PublishOptionParser.scala
+++ b/tools/bigquery-zos-mainframe-connector/gszutil/src/main/scala/com/google/cloud/bqsh/PublishOptionParser.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 Google LLC All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bqsh
+
+import scopt.OptionParser
+
+object PublishOptionParser extends OptionParser[PublishConfig]("publish") with ArgParser[PublishConfig]{
+  override def parse(args: Seq[String], env: Map[String, String]): Option[PublishConfig] =
+    parse(args, PublishConfig())
+
+  head("publish", Bqsh.UserAgent)
+
+  help("help")
+    .text("prints this usage text")
+
+  arg[String]("topic")
+    .required()
+    .text("ID of the topic or fully qualified identifier for the topic.")
+    .action((x, c) => c.copy(topic = x))
+
+  opt[String]('m', "message")
+    .text(
+      """The body of the message to publish to the given topic name. Information on message formatting and size limits can be found at: https://cloud.google.com/pubsub/docs/publisher#publish""")
+    .action((x, c) => c.copy(message = x))
+
+  opt[Map[String, String]]('a', "attribute")
+    .text(
+      """Comma-separated list of attributes. Each ATTRIBUTE has the form name="value". You can specify up to 100 attributes.""")
+    .action((x, c) => c.copy(attributes = x))
+
+  opt[String]('k', "orderingKey")
+    .text(
+      """The key for ordering delivery to subscribers. All messages with the same ordering key are sent to subscribers in the order that Pub/Sub receives them.""")
+    .action((x, c) => c.copy(orderingKey = x))
+
+}

--- a/tools/bigquery-zos-mainframe-connector/gszutil/src/main/scala/com/google/cloud/bqsh/PublishOptionParser.scala
+++ b/tools/bigquery-zos-mainframe-connector/gszutil/src/main/scala/com/google/cloud/bqsh/PublishOptionParser.scala
@@ -46,4 +46,24 @@ object PublishOptionParser extends OptionParser[PublishConfig]("publish") with A
       """The key for ordering delivery to subscribers. All messages with the same ordering key are sent to subscribers in the order that Pub/Sub receives them.""")
     .action((x, c) => c.copy(orderingKey = x))
 
+  opt[String]("messageDSN")
+    .text(
+      """Read message contents from DSN.""")
+    .action((x, c) => c.copy(messageDsn = x))
+
+  opt[String]("messageDD")
+    .text(
+      """Read message contents from DD.""")
+    .action((x, c) => c.copy(messageDD = x))
+
+  opt[String]("encoding")
+    .text(
+      """Character encoding of input dataset. Takes precedence over ENCODING environment variable. Default: CP037""")
+    .action((x, c) => c.copy(encoding = x))
+
+  opt[Unit]("convert")
+    .text(
+      """When specified, input data is converted to ASCII/UTF8.""")
+    .action((x, c) => c.copy(convert = true))
+
 }

--- a/tools/bigquery-zos-mainframe-connector/gszutil/src/main/scala/com/google/cloud/bqsh/cmd/Publish.scala
+++ b/tools/bigquery-zos-mainframe-connector/gszutil/src/main/scala/com/google/cloud/bqsh/cmd/Publish.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 Google LLC All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bqsh.cmd
+
+import com.google.api.client.json.jackson2.JacksonFactory
+import com.google.api.services.pubsub.model.{PublishRequest, PubsubMessage}
+import com.google.cloud.bqsh.{ArgParser, Command, PublishConfig, PublishOptionParser}
+import com.google.cloud.imf.gzos.MVS
+import com.google.cloud.imf.util.{Logging, Services}
+
+import java.nio.charset.StandardCharsets
+import java.util.Base64
+import scala.jdk.CollectionConverters.{MapHasAsJava, SeqHasAsJava}
+
+object Publish extends Command[PublishConfig] with Logging {
+  override val name: String = "publish"
+  override val parser: ArgParser[PublishConfig] = PublishOptionParser
+
+  override def run(config: PublishConfig, zos: MVS, env: Map[String, String]): Result = {
+    val pubsub = Services.pubsub(Services.pubsubCredentials())
+
+    val message = new PubsubMessage()
+      .setData(new String(Base64.getEncoder.encode(config.message.getBytes(StandardCharsets.UTF_8))))
+      .setAttributes(config.attributes.asJava)
+
+    if (config.orderingKey.nonEmpty)
+      message.setOrderingKey(config.orderingKey)
+
+    val content = new PublishRequest()
+      .setMessages((message::Nil).asJava)
+    val response = pubsub.projects().topics().publish(config.topic, content).execute()
+    System.out.println("PublishResponse:")
+    System.out.println(JacksonFactory.getDefaultInstance.toPrettyString(response))
+    Result.Success
+  }
+}

--- a/tools/bigquery-zos-mainframe-connector/gszutil/src/main/scala/com/google/cloud/imf/gzos/Util.scala
+++ b/tools/bigquery-zos-mainframe-connector/gszutil/src/main/scala/com/google/cloud/imf/gzos/Util.scala
@@ -15,7 +15,7 @@
  */
 package com.google.cloud.imf.gzos
 
-import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, IOException}
 import java.nio.ByteBuffer
 import java.nio.channels.{Channels, ReadableByteChannel, WritableByteChannel}
 import java.nio.charset.Charset
@@ -108,9 +108,13 @@ object Util extends Logging {
     }
   }
 
-  def transfer(rc: ReadableByteChannel, wc: WritableByteChannel, chunkSize: Int = 4096): Unit = {
+  def transfer(rc: ReadableByteChannel, wc: WritableByteChannel, chunkSize: Int = 4096, limit: Int = 10000000): Unit = {
     val buf = ByteBuffer.allocate(chunkSize)
+    var bytesRead = 0
     while (rc.read(buf) > -1) {
+      bytesRead += buf.position()
+      if (bytesRead > limit)
+        throw new IOException(s"read limit of $limit bytes exceeded")
       buf.flip()
       wc.write(buf)
       buf.clear()
@@ -134,7 +138,14 @@ object Util extends Logging {
     Resources.toByteArray(Resources.getResource(x).toURI.toURL)
   }
 
-  def readAllBytes(in: ReadableByteChannel): Array[Byte] = {
+  /** Read all bytes from a dataset.
+    * This is meant to be used on small datasets only.
+    *
+    * @param in ReadableByteChannel, typically an instance of ZRecordReaderT
+    * @param limit if dataset exceeds this limit, an IOException will be thrown
+    * @return Array[Byte] from dataset.
+    */
+  def readAllBytes(in: ReadableByteChannel, limit: Int = 10000000): Array[Byte] = {
     val chunkSize = in match {
       case x: ZRecordReaderT =>
         x.blkSize
@@ -143,7 +154,7 @@ object Util extends Logging {
     }
     val os = new ByteArrayOutputStream()
     val out = Channels.newChannel(os)
-    transfer(in, out, chunkSize)
+    transfer(in, out, chunkSize, limit)
     os.toByteArray
   }
 

--- a/tools/bigquery-zos-mainframe-connector/mainframe-util/build.sbt
+++ b/tools/bigquery-zos-mainframe-connector/mainframe-util/build.sbt
@@ -15,7 +15,7 @@
  */
 organization := "com.google.cloud.imf"
 name := "mainframe-util"
-version := "2.2.0"
+version := "2.2.1"
 
 scalaVersion := "2.13.8"
 
@@ -27,6 +27,7 @@ libraryDependencies ++= Seq(
   "com.google.cloud" % "google-cloud-bigquery" % "2.5.1",
   "com.google.cloud" % "google-cloud-bigquerystorage" % "2.7.0",
   "com.google.cloud" % "google-cloud-storage" % "2.2.2",
+  "com.google.apis" % "google-api-services-pubsub" % "v1-rev20221020-2.0.0",
   ("com.google.apis" % "google-api-services-logging" % "v2-rev656-1.25.0").excludeAll(exGapiClient),
   "org.apache.avro" % "avro" % "1.7.7",
 

--- a/tools/bigquery-zos-mainframe-connector/mainframe-util/src/main/scala/com/google/cloud/imf/util/Services.scala
+++ b/tools/bigquery-zos-mainframe-connector/mainframe-util/src/main/scala/com/google/cloud/imf/util/Services.scala
@@ -6,6 +6,7 @@ import com.google.api.gax.retrying.RetrySettings
 import com.google.api.gax.rpc.{FixedHeaderProvider, HeaderProvider}
 import com.google.api.services.bigquery.BigqueryScopes
 import com.google.api.services.logging.v2.{Logging, LoggingScopes}
+import com.google.api.services.pubsub.{Pubsub, PubsubScopes}
 import com.google.api.services.storage.StorageScopes
 import com.google.auth.Credentials
 import com.google.auth.http.HttpCredentialsAdapter
@@ -118,6 +119,15 @@ object Services {
 
   def logging(credentials: Credentials): Logging =
     new Logging.Builder(CCATransportFactory.create,
+      GsonFactory.getDefaultInstance,
+      new HttpCredentialsAdapter(credentials))
+      .setApplicationName(UserAgent).build
+
+  def pubsubCredentials(): GoogleCredentials =
+    GoogleCredentials.getApplicationDefault.createScoped(PubsubScopes.PUBSUB)
+
+  def pubsub(credentials: Credentials): Pubsub =
+    new Pubsub.Builder(CCATransportFactory.create,
       GsonFactory.getDefaultInstance,
       new HttpCredentialsAdapter(credentials))
       .setApplicationName(UserAgent).build


### PR DESCRIPTION
This PR adds the `pubsub topics publish` command, enabling users to send text pubsub messages from z/OS job steps.