### PR TITLE
ZetaSQL Toolkit library - Version 0.2.0

### DIFF
--- a/tools/zetasql-helper/zetasql-toolkit-core/README.md
+++ b/tools/zetasql-helper/zetasql-toolkit-core/README.md
@@ -167,6 +167,33 @@ QueryStmt
 
 See a list of comprehensive usage examples [here](../zetasql-toolkit-examples).
 
+## Pushing to Artifact Registry
+
+The ZetaSQL toolkit package is not hosted on maven central for the moment. 
+It can, however, easily be built and hosted on [Artifact Registry](https://cloud.google.com/artifact-registry/docs/java).
+
+To build and push the package to Artifact Registry:
+
+1. Configure the project id, repository name and location
+    ``` bash
+   export PROJECT_ID=...
+   export REPOSITORY_NAME=...
+   export LOCATION=...
+   ```
+2. Create an Artifact Registry Maven Repository if necessary
+   ``` bash
+   gcloud artifacts repositories create $REPOSITORY_NAME \
+     --repository-format=maven \
+     --location=$LOCATION
+   ```
+3. [Configure Authentication](https://cloud.google.com/artifact-registry/docs/java/authentication)
+4. Build and push the package
+   ``` bash
+   mvn deploy \
+     -DskipTests \
+     -Dartifactregistry.repository=artifactregistry://$LOCATION-maven.pkg.dev/$PROJECT_ID/$REPOSITORY_NAME
+   ```
+
 ## Support Disclaimer
 
 This is not an officially supported Google product.

--- a/tools/zetasql-helper/zetasql-toolkit-core/pom.xml
+++ b/tools/zetasql-helper/zetasql-toolkit-core/pom.xml
@@ -6,10 +6,10 @@
 
     <groupId>com.google.zetasql.toolkit</groupId>
     <artifactId>zetasql-toolkit-core</artifactId>
-    <version>${revision}</version>
+    <version>0.1.3</version>
 
     <properties>
-        <revision>0.1.3-SNAPSHOT</revision>
+        <zetasql.toolkit.version>${project.version}</zetasql.toolkit.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -122,6 +122,22 @@
                             <goal>antlr4</goal>
                         </goals>
                         <id>antlr</id>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>properties-maven-plugin</artifactId>
+                <version>1.1.0</version>
+                <executions>
+                    <execution>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>write-project-properties</goal>
+                        </goals>
+                        <configuration>
+                            <outputFile>${project.build.outputDirectory}/zetasql-toolkit-core.properties</outputFile>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/tools/zetasql-helper/zetasql-toolkit-core/pom.xml
+++ b/tools/zetasql-helper/zetasql-toolkit-core/pom.xml
@@ -6,13 +6,13 @@
 
     <groupId>com.google.zetasql.toolkit</groupId>
     <artifactId>zetasql-toolkit-core</artifactId>
-    <version>0.1-SNAPSHOT</version>
+    <version>0.1.1-SNAPSHOT</version>
 
     <properties>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <zetasql.version>2022.08.1</zetasql.version>
+        <zetasql.version>2023.03.2</zetasql.version>
         <antlr4.version>4.12.0</antlr4.version>
         <google.cloud.libraries.version>25.4.0</google.cloud.libraries.version>
         <google.cloud.jib.version>3.3.1</google.cloud.jib.version>

--- a/tools/zetasql-helper/zetasql-toolkit-core/pom.xml
+++ b/tools/zetasql-helper/zetasql-toolkit-core/pom.xml
@@ -14,7 +14,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <zetasql.version>2023.03.2</zetasql.version>
         <antlr4.version>4.12.0</antlr4.version>
-        <google.cloud.libraries.version>25.4.0</google.cloud.libraries.version>
+        <google.cloud.libraries.version>26.11.0</google.cloud.libraries.version>
         <google.cloud.jib.version>3.3.1</google.cloud.jib.version>
         <junit.version>5.9.2</junit.version>
         <mockito.version>5.2.0</mockito.version>
@@ -26,6 +26,12 @@
             <groupId>com.google.zetasql</groupId>
             <artifactId>zetasql-client</artifactId>
             <version>${zetasql.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-javalite</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.google.zetasql/zetasql-types -->
         <dependency>
@@ -49,6 +55,12 @@
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-bigquery</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-buffer</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.google.cloud/google-cloud-spanner -->
         <dependency>

--- a/tools/zetasql-helper/zetasql-toolkit-core/pom.xml
+++ b/tools/zetasql-helper/zetasql-toolkit-core/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.google.zetasql.toolkit</groupId>
     <artifactId>zetasql-toolkit-core</artifactId>
-    <version>0.1.3</version>
+    <version>0.2.0</version>
 
     <properties>
         <zetasql.toolkit.version>${project.version}</zetasql.toolkit.version>

--- a/tools/zetasql-helper/zetasql-toolkit-core/pom.xml
+++ b/tools/zetasql-helper/zetasql-toolkit-core/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.google.zetasql.toolkit</groupId>
     <artifactId>zetasql-toolkit-core</artifactId>
-    <version>0.1.1-SNAPSHOT</version>
+    <version>0.1.2</version>
 
     <properties>
         <maven.compiler.source>11</maven.compiler.source>
@@ -18,6 +18,7 @@
         <google.cloud.jib.version>3.3.1</google.cloud.jib.version>
         <junit.version>5.9.2</junit.version>
         <mockito.version>5.2.0</mockito.version>
+        <artifactregistry.repository/>
     </properties>
 
     <dependencies>
@@ -132,6 +133,24 @@
                 </configuration>
             </plugin>
         </plugins>
+        <extensions>
+            <extension>
+                <groupId>com.google.cloud.artifactregistry</groupId>
+                <artifactId>artifactregistry-maven-wagon</artifactId>
+                <version>2.2.0</version>
+            </extension>
+        </extensions>
     </build>
+
+    <distributionManagement>
+        <repository>
+            <id>artifact-registry</id>
+            <url>${artifactregistry.repository}</url>
+        </repository>
+        <snapshotRepository>
+            <id>artifact-registry</id>
+            <url>${artifactregistry.repository}</url>
+        </snapshotRepository>
+    </distributionManagement>
 
 </project>

--- a/tools/zetasql-helper/zetasql-toolkit-core/pom.xml
+++ b/tools/zetasql-helper/zetasql-toolkit-core/pom.xml
@@ -6,9 +6,10 @@
 
     <groupId>com.google.zetasql.toolkit</groupId>
     <artifactId>zetasql-toolkit-core</artifactId>
-    <version>0.1.2</version>
+    <version>${revision}</version>
 
     <properties>
+        <revision>0.1.3-SNAPSHOT</revision>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/AnalyzerExtensions.java
+++ b/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/AnalyzerExtensions.java
@@ -1,0 +1,264 @@
+/*
+ * Copyright 2023 Google LLC All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.zetasql.toolkit;
+
+import com.google.common.collect.ImmutableList;
+import com.google.zetasql.LanguageOptions;
+import com.google.zetasql.ParseResumeLocation;
+import com.google.zetasql.Parser;
+import com.google.zetasql.parser.ASTNode;
+import com.google.zetasql.parser.ASTNodes.ASTCallStatement;
+import com.google.zetasql.parser.ASTNodes.ASTFunctionCall;
+import com.google.zetasql.parser.ASTNodes.ASTIdentifier;
+import com.google.zetasql.parser.ASTNodes.ASTScript;
+import com.google.zetasql.parser.ASTNodes.ASTStatement;
+import com.google.zetasql.parser.ASTNodes.ASTTVF;
+import com.google.zetasql.parser.ParseTreeVisitor;
+import java.util.List;
+import org.antlr.v4.runtime.misc.OrderedHashSet;
+
+/** Implements extensions to ZetaSQL's built-in {@link com.google.zetasql.Analyzer} */
+public class AnalyzerExtensions {
+
+  /**
+   * Extracts the name paths for all functions called in a SQL statement
+   *
+   * @param sql The SQL statement from which to extract called functions
+   * @param options The {@link LanguageOptions} to use when parsing the provided statement
+   * @return The list of name paths for all functions called in the statement. If a function is
+   *     called multiple times with different quoting (e.g. `catalog.function()` vs
+   *     catalog.function()), it will be returned multiple times.
+   */
+  public static List<List<String>> extractFunctionNamesFromStatement(
+      String sql, LanguageOptions options) {
+    ASTStatement statement = Parser.parseStatement(sql, options);
+    return extractFunctionNamesFromASTNode(statement);
+  }
+
+  /**
+   * Extracts the name paths for all functions called in a SQL script
+   *
+   * @param sql The SQL script from which to extract called functions
+   * @param options The {@link LanguageOptions} to use when parsing the provided script
+   * @return The list of name paths for all functions called in the script. If a function is called
+   *     multiple times with different quoting (e.g. `catalog.function()` vs catalog.function()), it
+   *     will be returned multiple times.
+   */
+  public static List<List<String>> extractFunctionNamesFromScript(
+      String sql, LanguageOptions options) {
+    ASTScript script = Parser.parseScript(sql, options);
+    return extractFunctionNamesFromASTNode(script);
+  }
+
+  /**
+   * Extracts the name paths for all functions called in the next statement in the provided {@link
+   * ParseResumeLocation}.
+   *
+   * @param parseResumeLocation The ParseResumeLocation from which to extract called functions
+   * @param options The {@link LanguageOptions} to use when parsing the statement
+   * @return The list of name paths for all functions called in the statement. If a function is
+   *     called multiple times with different quoting (e.g. `catalog.function()` vs
+   *     catalog.function()), it will be returned multiple times.
+   */
+  public static List<List<String>> extractFunctionNamesFromNextStatement(
+      ParseResumeLocation parseResumeLocation, LanguageOptions options) {
+    ASTStatement statement = Parser.parseNextStatement(parseResumeLocation, options);
+    return extractFunctionNamesFromASTNode(statement);
+  }
+
+  /**
+   * Extracts the name paths for all functions called in the provided parse tree
+   *
+   * @param node The root of the parse tree from which to extract functions called
+   * @return The list of name paths for all functions called in the tree. If a function is called
+   *     multiple times with different quoting (e.g. `catalog.function()` vs catalog.function()), it
+   *     will be returned multiple times.
+   */
+  private static List<List<String>> extractFunctionNamesFromASTNode(ASTNode node) {
+    OrderedHashSet<ImmutableList<String>> result = new OrderedHashSet<>();
+
+    ParseTreeVisitor extractFunctionNamesVisitor =
+        new ParseTreeVisitor() {
+
+          @Override
+          public void visit(ASTFunctionCall functionCall) {
+            ImmutableList<String> functionNamePath =
+                functionCall.getFunction().getNames().stream()
+                    .map(ASTIdentifier::getIdString)
+                    .collect(ImmutableList.toImmutableList());
+            result.add(functionNamePath);
+          }
+        };
+
+    node.accept(extractFunctionNamesVisitor);
+
+    return List.copyOf(result);
+  }
+
+  /**
+   * Extracts the name paths for all TVFs called in a SQL statement
+   *
+   * @param sql The SQL statement from which to extract called functions
+   * @param options The {@link LanguageOptions} to use when parsing the provided statement
+   * @return The list of name paths for all functions called in the statement. If a function is
+   *     called multiple times with different quoting (e.g. `catalog.function()` vs
+   *     catalog.function()), it will be returned multiple times.
+   */
+  public static List<List<String>> extractTVFNamesFromStatement(
+      String sql, LanguageOptions options) {
+    ASTStatement statement = Parser.parseStatement(sql, options);
+    return extractTVFNamesFromASTNode(statement);
+  }
+
+  /**
+   * Extracts the name paths for all TVFs called in a SQL script
+   *
+   * @param sql The SQL script from which to extract called functions
+   * @param options The {@link LanguageOptions} to use when parsing the provided script
+   * @return The list of name paths for all functions called in the script. If a function is called
+   *     multiple times with different quoting (e.g. `catalog.function()` vs catalog.function()), it
+   *     will be returned multiple times.
+   */
+  public static List<List<String>> extractTVFNamesFromScript(String sql, LanguageOptions options) {
+    ASTScript script = Parser.parseScript(sql, options);
+    return extractTVFNamesFromASTNode(script);
+  }
+
+  /**
+   * Extracts the name paths for all TVFs called in the next statement in the provided {@link
+   * ParseResumeLocation}.
+   *
+   * @param parseResumeLocation The ParseResumeLocation from which to extract called functions
+   * @param options The {@link LanguageOptions} to use when parsing the statement
+   * @return The list of name paths for all functions called in the statement. If a function is
+   *     called multiple times with different quoting (e.g. `catalog.function()` vs
+   *     catalog.function()), it will be returned multiple times.
+   */
+  public static List<List<String>> extractTVFNamesFromNextStatement(
+      ParseResumeLocation parseResumeLocation, LanguageOptions options) {
+    ASTStatement statement = Parser.parseNextStatement(parseResumeLocation, options);
+    return extractTVFNamesFromASTNode(statement);
+  }
+
+  /**
+   * Extracts the name paths for all TVFs called in the provided parse tree
+   *
+   * @param node The root of the parse tree from which to extract functions called
+   * @return The list of name paths for all functions called in the tree. If a function is called
+   *     multiple times with different quoting (e.g. `catalog.function()` vs catalog.function()), it
+   *     will be returned multiple times.
+   */
+  private static List<List<String>> extractTVFNamesFromASTNode(ASTNode node) {
+    OrderedHashSet<ImmutableList<String>> result = new OrderedHashSet<>();
+
+    ParseTreeVisitor extractFunctionNamesVisitor =
+        new ParseTreeVisitor() {
+
+          @Override
+          public void visit(ASTTVF tvfCall) {
+            ImmutableList<String> functionNamePath =
+                tvfCall.getName().getNames().stream()
+                    .map(ASTIdentifier::getIdString)
+                    .collect(ImmutableList.toImmutableList());
+            result.add(functionNamePath);
+          }
+        };
+
+    node.accept(extractFunctionNamesVisitor);
+
+    return List.copyOf(result);
+  }
+
+  /**
+   * Extracts the name paths for all procedures called in a SQL statement. It can either return one
+   * procedure or no procedures, depending on whether the provided statement is a CALL statement.
+   *
+   * @param sql The SQL statement from which to extract called procedures
+   * @param options The {@link LanguageOptions} to use when parsing the provided statement
+   * @return The list of name paths for all procedures called in the statement. If a procedure is
+   *     called multiple times with different quoting (e.g. `catalog.procedure()` vs
+   *     catalog.procedure()), it will be returned multiple times.
+   */
+  public static List<List<String>> extractProcedureNamesFromStatement(
+      String sql, LanguageOptions options) {
+    ASTStatement statement = Parser.parseStatement(sql, options);
+    return extractProcedureNamesFromASTNode(statement);
+  }
+
+  /**
+   * Extracts the name paths for all procedures called in a SQL script
+   *
+   * @param sql The SQL script from which to extract called procedures
+   * @param options The {@link LanguageOptions} to use when parsing the provided script
+   * @return The list of name paths for all procedures called in the script. If a procedure is
+   *     called multiple times with different quoting (e.g. `catalog.procedure()` vs
+   *     catalog.procedure()), it will be returned multiple times.
+   */
+  public static List<List<String>> extractProcedureNamesFromScript(
+      String sql, LanguageOptions options) {
+    ASTScript script = Parser.parseScript(sql, options);
+    return extractProcedureNamesFromASTNode(script);
+  }
+
+  /**
+   * Extracts the name paths for all procedures called in the next statement in the provided {@link
+   * ParseResumeLocation}. It can either return one procedure or no procedures, depending on whether
+   * the statement is a CALL statement.
+   *
+   * @param parseResumeLocation The ParseResumeLocation from which to extract called procedures
+   * @param options The {@link LanguageOptions} to use when parsing the statement
+   * @return The list of name paths for all procedures called in the statement. If a procedure is
+   *     called multiple times with different quoting (e.g. `catalog.procedure()` vs
+   *     catalog.procedure()), it will be returned multiple times.
+   */
+  public static List<List<String>> extractProcedureNamesFromNextStatement(
+      ParseResumeLocation parseResumeLocation, LanguageOptions options) {
+    ASTStatement statement = Parser.parseNextStatement(parseResumeLocation, options);
+    return extractProcedureNamesFromASTNode(statement);
+  }
+
+  /**
+   * Extracts the name paths for all procedures called in the provided parse tree
+   *
+   * @param node The root of the parse tree from which to extract procedures called
+   * @return The list of name paths for all procedures called in the tree. If a procedure is called
+   *     multiple times with different quoting (e.g. `catalog.procedure()` vs catalog.procedure()),
+   *     it will be returned multiple times.
+   */
+  private static List<List<String>> extractProcedureNamesFromASTNode(ASTNode node) {
+    OrderedHashSet<ImmutableList<String>> result = new OrderedHashSet<>();
+
+    ParseTreeVisitor extractProcedureNamesVisitor =
+        new ParseTreeVisitor() {
+
+          @Override
+          public void visit(ASTCallStatement procedureCall) {
+            ImmutableList<String> functionNamePath =
+                procedureCall.getProcedureName().getNames().stream()
+                    .map(ASTIdentifier::getIdString)
+                    .collect(ImmutableList.toImmutableList());
+            result.add(functionNamePath);
+          }
+        };
+
+    node.accept(extractProcedureNamesVisitor);
+
+    return List.copyOf(result);
+  }
+
+  private AnalyzerExtensions() {}
+}

--- a/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/CatalogUpdaterVisitor.java
+++ b/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/CatalogUpdaterVisitor.java
@@ -25,6 +25,7 @@ import com.google.zetasql.resolvedast.ResolvedCreateStatementEnums.CreateScope;
 import com.google.zetasql.resolvedast.ResolvedNodes.*;
 import com.google.zetasql.toolkit.catalog.CatalogOperations;
 import com.google.zetasql.toolkit.catalog.CatalogWrapper;
+import com.google.zetasql.toolkit.catalog.bigquery.FunctionInfo;
 import com.google.zetasql.toolkit.catalog.bigquery.ProcedureInfo;
 import com.google.zetasql.toolkit.catalog.bigquery.TVFInfo;
 import java.util.List;
@@ -185,12 +186,13 @@ class CatalogUpdaterVisitor extends Visitor {
    */
   @Override
   public void visit(ResolvedCreateFunctionStmt createFunctionStmt) {
-    Function function =
-        new Function(
-            createFunctionStmt.getNamePath(),
-            "UDF",
-            Mode.SCALAR,
-            List.of(createFunctionStmt.getSignature()));
+    FunctionInfo function =
+        FunctionInfo.newBuilder()
+            .setNamePath(createFunctionStmt.getNamePath())
+            .setGroup("UDF")
+            .setMode(Mode.SCALAR)
+            .setSignatures(List.of(createFunctionStmt.getSignature()))
+            .build();
 
     CreateMode createMode = createFunctionStmt.getCreateMode();
     CreateScope createScope = createFunctionStmt.getCreateScope();

--- a/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/CatalogUpdaterVisitor.java
+++ b/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/CatalogUpdaterVisitor.java
@@ -216,10 +216,11 @@ class CatalogUpdaterVisitor extends Visitor {
             .collect(Collectors.toList());
 
     TVFInfo tvfInfo =
-        new TVFInfo(
-            createTableFunctionStmt.getNamePath(),
-            createTableFunctionStmt.getSignature(),
-            TVFRelation.createColumnBased(outputSchemaColumns));
+        TVFInfo.newBuilder()
+            .setNamePath(createTableFunctionStmt.getNamePath())
+            .setSignature(createTableFunctionStmt.getSignature())
+            .setOutputSchema(TVFRelation.createColumnBased(outputSchemaColumns))
+            .build();
 
     CreateMode createMode = createTableFunctionStmt.getCreateMode();
 

--- a/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/ZetaSQLToolkitAnalyzer.java
+++ b/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/ZetaSQLToolkitAnalyzer.java
@@ -142,7 +142,7 @@ public class ZetaSQLToolkitAnalyzer {
 
         ResolvedStatement statement =
             Analyzer.analyzeNextStatement(
-                parseResumeLocation, analyzerOptions, catalog.getZetaSQLCatalog());
+                parseResumeLocation, analyzerOptions, catalogForAnalysis.getZetaSQLCatalog());
 
         this.previous = Optional.of(statement);
 

--- a/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/CatalogOperations.java
+++ b/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/CatalogOperations.java
@@ -16,6 +16,7 @@
 
 package com.google.zetasql.toolkit.catalog;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.zetasql.*;
 import com.google.zetasql.SimpleCatalogProtos.SimpleCatalogProto;
@@ -381,6 +382,8 @@ public class CatalogOperations {
       List<List<String>> functionPaths,
       TVFInfo tvfInfo,
       CreateMode createMode) {
+    Preconditions.checkArgument(
+        tvfInfo.getOutputSchema().isPresent(), "Cannot create a a TVF without an output schema");
 
     if (createMode.equals(CreateMode.CREATE_OR_REPLACE)) {
       deleteTVFFromCatalog(rootCatalog, functionPaths);
@@ -397,7 +400,9 @@ public class CatalogOperations {
 
       TableValuedFunction tvf =
           new FixedOutputSchemaTVF(
-              ImmutableList.of(functionName), tvfInfo.getSignature(), tvfInfo.getOutputSchema());
+              ImmutableList.of(functionName),
+              tvfInfo.getSignature(),
+              tvfInfo.getOutputSchema().get());
 
       if (!tvfExists(catalogForCreation, tvf)) {
         catalogForCreation.addTableValuedFunction(tvf);

--- a/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/CatalogWrapper.java
+++ b/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/CatalogWrapper.java
@@ -16,9 +16,13 @@
 
 package com.google.zetasql.toolkit.catalog;
 
-import com.google.zetasql.*;
+import com.google.zetasql.Analyzer;
+import com.google.zetasql.AnalyzerOptions;
+import com.google.zetasql.SimpleCatalog;
+import com.google.zetasql.SimpleTable;
 import com.google.zetasql.resolvedast.ResolvedCreateStatementEnums.CreateMode;
 import com.google.zetasql.resolvedast.ResolvedCreateStatementEnums.CreateScope;
+import com.google.zetasql.toolkit.catalog.bigquery.FunctionInfo;
 import com.google.zetasql.toolkit.catalog.bigquery.ProcedureInfo;
 import com.google.zetasql.toolkit.catalog.bigquery.TVFInfo;
 import java.util.List;
@@ -49,7 +53,7 @@ public interface CatalogWrapper {
    * @param createMode The CreateMode for creating the function
    * @param createScope The CreateScope for creating the function
    */
-  void register(Function function, CreateMode createMode, CreateScope createScope);
+  void register(FunctionInfo function, CreateMode createMode, CreateScope createScope);
 
   /**
    * Registers a TVF in this catalog.

--- a/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/basic/BasicCatalogWrapper.java
+++ b/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/basic/BasicCatalogWrapper.java
@@ -16,7 +16,6 @@
 
 package com.google.zetasql.toolkit.catalog.basic;
 
-import com.google.zetasql.Function;
 import com.google.zetasql.SimpleCatalog;
 import com.google.zetasql.SimpleTable;
 import com.google.zetasql.ZetaSQLBuiltinFunctionOptions;
@@ -24,6 +23,7 @@ import com.google.zetasql.resolvedast.ResolvedCreateStatementEnums.CreateMode;
 import com.google.zetasql.resolvedast.ResolvedCreateStatementEnums.CreateScope;
 import com.google.zetasql.toolkit.catalog.CatalogOperations;
 import com.google.zetasql.toolkit.catalog.CatalogWrapper;
+import com.google.zetasql.toolkit.catalog.bigquery.FunctionInfo;
 import com.google.zetasql.toolkit.catalog.bigquery.ProcedureInfo;
 import com.google.zetasql.toolkit.catalog.bigquery.TVFInfo;
 import com.google.zetasql.toolkit.catalog.exceptions.CatalogException;
@@ -65,7 +65,7 @@ public class BasicCatalogWrapper implements CatalogWrapper {
   }
 
   @Override
-  public void register(Function function, CreateMode createMode, CreateScope createScope) {
+  public void register(FunctionInfo function, CreateMode createMode, CreateScope createScope) {
     CatalogOperations.createFunctionInCatalog(
         this.catalog, List.of(function.getNamePath()), function, createMode);
   }

--- a/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/basic/BasicCatalogWrapper.java
+++ b/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/basic/BasicCatalogWrapper.java
@@ -42,7 +42,7 @@ public class BasicCatalogWrapper implements CatalogWrapper {
 
   public BasicCatalogWrapper() {
     this.catalog = new SimpleCatalog("catalog");
-    this.catalog.addZetaSQLFunctions(new ZetaSQLBuiltinFunctionOptions());
+    this.catalog.addZetaSQLFunctionsAndTypes(new ZetaSQLBuiltinFunctionOptions());
   }
 
   public BasicCatalogWrapper(SimpleCatalog initialCatalog) {

--- a/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/bigquery/BigQueryAPIResourceProvider.java
+++ b/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/bigquery/BigQueryAPIResourceProvider.java
@@ -23,6 +23,7 @@ import com.google.zetasql.*;
 import com.google.zetasql.FunctionArgumentType.FunctionArgumentTypeOptions;
 import com.google.zetasql.StructType.StructField;
 import com.google.zetasql.ZetaSQLFunctions.FunctionEnums.Mode;
+import com.google.zetasql.ZetaSQLFunctions.FunctionEnums.NamedArgumentKind;
 import com.google.zetasql.ZetaSQLFunctions.FunctionEnums.ProcedureArgumentMode;
 import com.google.zetasql.ZetaSQLFunctions.SignatureArgumentKind;
 import com.google.zetasql.ZetaSQLType.TypeKind;
@@ -339,7 +340,7 @@ public class BigQueryAPIResourceProvider implements BigQueryResourceProvider {
 
     FunctionArgumentTypeOptions options =
         FunctionArgumentTypeOptions.builder()
-            .setArgumentName(argument.getName())
+            .setArgumentName(argument.getName(), NamedArgumentKind.POSITIONAL_ONLY)
             .setProcedureArgumentMode(procedureArgumentMode)
             .build();
 

--- a/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/bigquery/BigQueryAPIRoutineLanguage.java
+++ b/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/bigquery/BigQueryAPIRoutineLanguage.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 Google LLC All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.zetasql.toolkit.catalog.bigquery;
+
+public enum BigQueryAPIRoutineLanguage {
+  LANGUAGE_UNSPECIFIED,
+  SQL,
+  JAVASCRIPT,
+  PYTHON,
+  JAVA,
+  SCALA;
+
+  public static BigQueryAPIRoutineLanguage valueOfOrUnspecified(String name) {
+    try {
+      return BigQueryAPIRoutineLanguage.valueOf(name);
+    } catch (NullPointerException | IllegalArgumentException err) {
+      return LANGUAGE_UNSPECIFIED;
+    }
+  }
+}

--- a/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/bigquery/BigQueryBuiltIns.java
+++ b/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/bigquery/BigQueryBuiltIns.java
@@ -26,6 +26,7 @@ import com.google.zetasql.Type;
 import com.google.zetasql.TypeFactory;
 import com.google.zetasql.ZetaSQLFunctions.FunctionEnums.ArgumentCardinality;
 import com.google.zetasql.ZetaSQLFunctions.FunctionEnums.Mode;
+import com.google.zetasql.ZetaSQLFunctions.FunctionEnums.NamedArgumentKind;
 import com.google.zetasql.ZetaSQLFunctions.SignatureArgumentKind;
 import com.google.zetasql.ZetaSQLType;
 import com.google.zetasql.ZetaSQLType.TypeKind;
@@ -69,19 +70,20 @@ class BigQueryBuiltIns {
                           new FunctionArgumentType(
                               TypeFactory.createSimpleType(TypeKind.TYPE_STRING),
                               FunctionArgumentTypeOptions.builder()
-                                  .setArgumentName("expression")
+                                  .setArgumentName("expression", NamedArgumentKind.POSITIONAL_ONLY)
                                   .build(),
                               1),
                           new FunctionArgumentType(
                               SignatureArgumentKind.ARG_TYPE_ANY_1,
                               FunctionArgumentTypeOptions.builder()
-                                  .setArgumentName("search_value_literal")
+                                  .setArgumentName(
+                                      "search_value_literal", NamedArgumentKind.POSITIONAL_ONLY)
                                   .build(),
                               1),
                           new FunctionArgumentType(
                               TypeFactory.createSimpleType(TypeKind.TYPE_STRING),
                               FunctionArgumentTypeOptions.builder()
-                                  .setArgumentName("json_scope")
+                                  .setArgumentName("json_scope", NamedArgumentKind.POSITIONAL_ONLY)
                                   .setCardinality(ArgumentCardinality.OPTIONAL)
                                   .build(),
                               1)),
@@ -98,26 +100,27 @@ class BigQueryBuiltIns {
                           new FunctionArgumentType(
                               SignatureArgumentKind.ARG_TYPE_ANY_1,
                               FunctionArgumentTypeOptions.builder()
-                                  .setArgumentName("search_data")
+                                  .setArgumentName("search_data", NamedArgumentKind.POSITIONAL_ONLY)
                                   .build(),
                               1),
                           new FunctionArgumentType(
                               TypeFactory.createSimpleType(TypeKind.TYPE_STRING),
                               FunctionArgumentTypeOptions.builder()
-                                  .setArgumentName("search_query")
+                                  .setArgumentName(
+                                      "search_query", NamedArgumentKind.POSITIONAL_ONLY)
                                   .build(),
                               1),
                           new FunctionArgumentType(
                               TypeFactory.createSimpleType(TypeKind.TYPE_STRING),
                               FunctionArgumentTypeOptions.builder()
-                                  .setArgumentName("json_scope")
+                                  .setArgumentName("json_scope", NamedArgumentKind.POSITIONAL_ONLY)
                                   .setCardinality(ArgumentCardinality.OPTIONAL)
                                   .build(),
                               1),
                           new FunctionArgumentType(
                               TypeFactory.createSimpleType(TypeKind.TYPE_STRING),
                               FunctionArgumentTypeOptions.builder()
-                                  .setArgumentName("analyzer")
+                                  .setArgumentName("analyzer", NamedArgumentKind.POSITIONAL_ONLY)
                                   .setCardinality(ArgumentCardinality.OPTIONAL)
                                   .build(),
                               1)),
@@ -134,7 +137,7 @@ class BigQueryBuiltIns {
                       new FunctionArgumentType(
                           TypeFactory.createSimpleType(TypeKind.TYPE_STRING),
                           FunctionArgumentTypeOptions.builder()
-                              .setArgumentName("session_id")
+                              .setArgumentName("session_id", NamedArgumentKind.POSITIONAL_ONLY)
                               .setCardinality(ArgumentCardinality.OPTIONAL)
                               .build(),
                           1)),
@@ -148,7 +151,7 @@ class BigQueryBuiltIns {
                       new FunctionArgumentType(
                           TypeFactory.createSimpleType(TypeKind.TYPE_STRING),
                           FunctionArgumentTypeOptions.builder()
-                              .setArgumentName("job")
+                              .setArgumentName("job", NamedArgumentKind.POSITIONAL_ONLY)
                               .setCardinality(ArgumentCardinality.REQUIRED)
                               .build(),
                           1)),
@@ -162,7 +165,7 @@ class BigQueryBuiltIns {
                       new FunctionArgumentType(
                           TypeFactory.createSimpleType(TypeKind.TYPE_STRING),
                           FunctionArgumentTypeOptions.builder()
-                              .setArgumentName("table_name")
+                              .setArgumentName("table_name", NamedArgumentKind.POSITIONAL_ONLY)
                               .setCardinality(ArgumentCardinality.REQUIRED)
                               .build(),
                           1)),
@@ -176,7 +179,7 @@ class BigQueryBuiltIns {
                       new FunctionArgumentType(
                           TypeFactory.createSimpleType(TypeKind.TYPE_STRING),
                           FunctionArgumentTypeOptions.builder()
-                              .setArgumentName("view_name")
+                              .setArgumentName("view_name", NamedArgumentKind.POSITIONAL_ONLY)
                               .setCardinality(ArgumentCardinality.REQUIRED)
                               .build(),
                           1)),

--- a/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/bigquery/BigQueryCatalog.java
+++ b/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/bigquery/BigQueryCatalog.java
@@ -276,8 +276,8 @@ public class BigQueryCatalog implements CatalogWrapper {
   /**
    * {@inheritDoc}
    *
-   * <p>Multiple copies of the registered {@link Function} will be created in the Catalog to comply
-   * with BigQuery name resolution semantics.
+   * <p>Multiple copies of the registered {@link FunctionInfo} will be created in the Catalog to
+   * comply with BigQuery name resolution semantics.
    *
    * @see #buildCatalogPathsForResource(BigQueryReference)
    * @throws BigQueryCreateError if a pre-create validation fails
@@ -285,7 +285,7 @@ public class BigQueryCatalog implements CatalogWrapper {
    *     CREATE_OR_REPLACE
    */
   @Override
-  public void register(Function function, CreateMode createMode, CreateScope createScope) {
+  public void register(FunctionInfo function, CreateMode createMode, CreateScope createScope) {
     List<String> functionNamePath = function.getNamePath();
     String fullName = String.join(".", functionNamePath);
 

--- a/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/bigquery/BigQueryCatalog.java
+++ b/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/bigquery/BigQueryCatalog.java
@@ -84,7 +84,7 @@ public class BigQueryCatalog implements CatalogWrapper {
     this.defaultProjectId = defaultProjectId;
     this.bigQueryResourceProvider = bigQueryResourceProvider;
     this.catalog = new SimpleCatalog("catalog");
-    this.catalog.addZetaSQLFunctions(
+    this.catalog.addZetaSQLFunctionsAndTypes(
         new ZetaSQLBuiltinFunctionOptions(BigQueryLanguageOptions.get()));
     BigQueryBuiltIns.addToCatalog(this.catalog);
   }

--- a/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/bigquery/BigQueryReference.java
+++ b/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/bigquery/BigQueryReference.java
@@ -18,6 +18,7 @@ package com.google.zetasql.toolkit.catalog.bigquery;
 
 import com.google.cloud.bigquery.RoutineId;
 import com.google.cloud.bigquery.TableId;
+import com.google.common.base.CharMatcher;
 import com.google.common.collect.ImmutableList;
 import com.google.zetasql.toolkit.catalog.bigquery.exceptions.InvalidBigQueryReference;
 import java.util.Arrays;
@@ -77,6 +78,16 @@ class BigQueryReference {
     }
 
     return new BigQueryReference(elements.get(0), elements.get(1), elements.get(2));
+  }
+
+  /**
+   * Returns whether the provided BigQuery reference string is qualified
+   *
+   * @param referenceString The reference string to check (e.g. dataset.table)
+   * @return Whether the reference is qualified
+   */
+  public static boolean isQualified(String referenceString) {
+    return CharMatcher.is('.').countIn(referenceString) > 0;
   }
 
   public String getProjectId() {

--- a/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/bigquery/BigQueryResourceProvider.java
+++ b/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/bigquery/BigQueryResourceProvider.java
@@ -16,7 +16,6 @@
 
 package com.google.zetasql.toolkit.catalog.bigquery;
 
-import com.google.zetasql.Function;
 import com.google.zetasql.SimpleTable;
 import java.util.List;
 
@@ -58,26 +57,26 @@ public interface BigQueryResourceProvider {
    *     project, the default project is used.
    * @param functionReferences The list of function references. Each reference should be in the
    *     format "project.dataset.function" or "dataset.function".
-   * @return The list of Functions representing the requested BigQuery functions.
+   * @return The list of {@link FunctionInfo} representing the requested BigQuery functions.
    */
-  List<Function> getFunctions(String projectId, List<String> functionReferences);
+  List<FunctionInfo> getFunctions(String projectId, List<String> functionReferences);
 
   /**
    * Gets all BigQuery functions in a given dataset and returns them as {@link Function}s
    *
    * @param projectId The projectId the dataset belongs to
    * @param datasetName The name of the dataset from which to get the functions
-   * @return The list of Functions representing the functions in the dataset
+   * @return The list of {@link FunctionInfo} representing the functions in the dataset
    */
-  List<Function> getAllFunctionsInDataset(String projectId, String datasetName);
+  List<FunctionInfo> getAllFunctionsInDataset(String projectId, String datasetName);
 
   /**
    * Gets all BigQuery functions in a given project and returns them as {@link Function}s
    *
    * @param projectId The projectId from which to get the functions
-   * @return The list of Functions representing the functions in the project
+   * @return The list of {@link FunctionInfo} representing the functions in the project
    */
-  List<Function> getAllFunctionsInProject(String projectId);
+  List<FunctionInfo> getAllFunctionsInProject(String projectId);
 
   /**
    * Gets a set of BigQuery TVFs and returns them as {@link TVFInfo}s
@@ -86,7 +85,7 @@ public interface BigQueryResourceProvider {
    *     project, the default project is used.
    * @param functionReferences The list of function references. Each reference should be in the
    *     format "project.dataset.function" or "dataset.function".
-   * @return The list of TVFInfo representing the requested BigQuery functions.
+   * @return The list of {@link TVFInfo} representing the requested BigQuery functions.
    */
   List<TVFInfo> getTVFs(String projectId, List<String> functionReferences);
 
@@ -95,7 +94,7 @@ public interface BigQueryResourceProvider {
    *
    * @param projectId The projectId the dataset belongs to
    * @param datasetName The name of the dataset from which to get the functions
-   * @return The list of TVFInfo representing the TVFs in the dataset
+   * @return The list of {@link TVFInfo} representing the TVFs in the dataset
    */
   List<TVFInfo> getAllTVFsInDataset(String projectId, String datasetName);
 
@@ -103,7 +102,7 @@ public interface BigQueryResourceProvider {
    * Gets all BigQuery TVFs in a given project and returns them as {@link TVFInfo}s
    *
    * @param projectId The projectId from which to get the TVFs
-   * @return The list of TVFInfo representing the TVFs in the project
+   * @return The list of {@link TVFInfo} representing the TVFs in the project
    */
   List<TVFInfo> getAllTVFsInProject(String projectId);
 
@@ -114,7 +113,7 @@ public interface BigQueryResourceProvider {
    *     project, the default project is used.
    * @param procedureReferences The list of procedure references. Each reference should be in the
    *     format "project.dataset.procedure" or "dataset.procedure".
-   * @return The list of ProcedureInfo representing the requested BigQuery procedures.
+   * @return The list of {@link ProcedureInfo} representing the requested BigQuery procedures.
    */
   List<ProcedureInfo> getProcedures(String projectId, List<String> procedureReferences);
 
@@ -123,7 +122,7 @@ public interface BigQueryResourceProvider {
    *
    * @param projectId The projectId the dataset belongs to
    * @param datasetName The name of the dataset from which to get the procedures
-   * @return The list of ProcedureInfo representing the procedures in the dataset
+   * @return The list of {@link ProcedureInfo} representing the procedures in the dataset
    */
   List<ProcedureInfo> getAllProceduresInDataset(String projectId, String datasetName);
 
@@ -131,7 +130,7 @@ public interface BigQueryResourceProvider {
    * Gets all BigQuery procedures in a given project and returns them as {@link ProcedureInfo}s
    *
    * @param projectId The projectId from which to get the procedures
-   * @return The list of ProcedureInfo representing the procedures in the project
+   * @return The list of {@link ProcedureInfo} representing the procedures in the project
    */
   List<ProcedureInfo> getAllProceduresInProject(String projectId);
 }

--- a/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/bigquery/BigQueryRoutineLanguage.java
+++ b/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/bigquery/BigQueryRoutineLanguage.java
@@ -16,7 +16,7 @@
 
 package com.google.zetasql.toolkit.catalog.bigquery;
 
-public enum BigQueryAPIRoutineLanguage {
+public enum BigQueryRoutineLanguage {
   LANGUAGE_UNSPECIFIED,
   SQL,
   JAVASCRIPT,
@@ -24,9 +24,9 @@ public enum BigQueryAPIRoutineLanguage {
   JAVA,
   SCALA;
 
-  public static BigQueryAPIRoutineLanguage valueOfOrUnspecified(String name) {
+  public static BigQueryRoutineLanguage valueOfOrUnspecified(String name) {
     try {
-      return BigQueryAPIRoutineLanguage.valueOf(name);
+      return BigQueryRoutineLanguage.valueOf(name);
     } catch (NullPointerException | IllegalArgumentException err) {
       return LANGUAGE_UNSPECIFIED;
     }

--- a/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/bigquery/FunctionInfo.java
+++ b/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/bigquery/FunctionInfo.java
@@ -35,19 +35,13 @@ public class FunctionInfo {
 
   private final Optional<String> body;
 
-  private FunctionInfo(
-      List<String> namePath,
-      String group,
-      Mode mode,
-      List<FunctionSignature> signatures,
-      Optional<BigQueryRoutineLanguage> language,
-      Optional<String> body) {
-    this.namePath = namePath;
-    this.group = group;
-    this.mode = mode;
-    this.signatures = signatures;
-    this.language = language;
-    this.body = body;
+  private FunctionInfo(Builder builder) {
+    this.namePath = builder.getNamePath();
+    this.group = builder.getGroup();
+    this.mode = builder.getMode();
+    this.signatures = builder.getSignatures();
+    this.language = builder.getLanguage();
+    this.body = builder.getBody();
   }
 
   public List<String> getNamePath() {
@@ -161,7 +155,7 @@ public class FunctionInfo {
     }
 
     public FunctionInfo build() {
-      return new FunctionInfo(namePath, group, mode, signatures, language, body);
+      return new FunctionInfo(this);
     }
   }
 }

--- a/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/bigquery/FunctionInfo.java
+++ b/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/bigquery/FunctionInfo.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2023 Google LLC All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.zetasql.toolkit.catalog.bigquery;
+
+import com.google.zetasql.FunctionSignature;
+import com.google.zetasql.ZetaSQLFunctions.FunctionEnums.Mode;
+
+import java.util.List;
+import java.util.Optional;
+
+public class FunctionInfo {
+
+  private final List<String> namePath;
+
+  private final String group;
+
+  private final Mode mode;
+
+  private final List<FunctionSignature> signatures;
+
+  private final Optional<BigQueryAPIRoutineLanguage> language;
+
+  private final Optional<String> body;
+
+  private FunctionInfo(
+      List<String> namePath,
+      String group,
+      Mode mode,
+      List<FunctionSignature> signatures,
+      Optional<BigQueryAPIRoutineLanguage> language,
+      Optional<String> body) {
+    this.namePath = namePath;
+    this.group = group;
+    this.mode = mode;
+    this.signatures = signatures;
+    this.language = language;
+    this.body = body;
+  }
+
+  public List<String> getNamePath() {
+    return namePath;
+  }
+
+  public String getGroup() {
+    return group;
+  }
+
+  public Mode getMode() {
+    return mode;
+  }
+
+  public List<FunctionSignature> getSignatures() {
+    return signatures;
+  }
+
+  public Optional<BigQueryAPIRoutineLanguage> getLanguage() {
+    return language;
+  }
+
+  public Optional<String> getBody() {
+    return this.body;
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private List<String> namePath;
+    private String group;
+    private Mode mode;
+    private List<FunctionSignature> signatures;
+    private Optional<BigQueryAPIRoutineLanguage> language;
+    private Optional<String> body;
+
+    public Builder setNamePath(List<String> namePath) {
+      this.namePath = namePath;
+      return this;
+    }
+
+    public Builder setGroup(String group) {
+      this.group = group;
+      return this;
+    }
+
+    public Builder setMode(Mode mode) {
+      this.mode = mode;
+      return this;
+    }
+
+    public Builder setSignatures(List<FunctionSignature> signatures) {
+      this.signatures = signatures;
+      return this;
+    }
+
+    public Builder setLanguage(BigQueryAPIRoutineLanguage language) {
+      this.language = Optional.ofNullable(language);
+      return this;
+    }
+
+    public Builder setBody(String body) {
+      this.body = Optional.ofNullable(body);
+      return this;
+    }
+
+    public FunctionInfo build() {
+      return new FunctionInfo(namePath, group, mode, signatures, language, body);
+    }
+  }
+}

--- a/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/bigquery/FunctionInfo.java
+++ b/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/bigquery/FunctionInfo.java
@@ -18,7 +18,6 @@ package com.google.zetasql.toolkit.catalog.bigquery;
 
 import com.google.zetasql.FunctionSignature;
 import com.google.zetasql.ZetaSQLFunctions.FunctionEnums.Mode;
-
 import java.util.List;
 import java.util.Optional;
 
@@ -32,7 +31,7 @@ public class FunctionInfo {
 
   private final List<FunctionSignature> signatures;
 
-  private final Optional<BigQueryAPIRoutineLanguage> language;
+  private final Optional<BigQueryRoutineLanguage> language;
 
   private final Optional<String> body;
 
@@ -41,7 +40,7 @@ public class FunctionInfo {
       String group,
       Mode mode,
       List<FunctionSignature> signatures,
-      Optional<BigQueryAPIRoutineLanguage> language,
+      Optional<BigQueryRoutineLanguage> language,
       Optional<String> body) {
     this.namePath = namePath;
     this.group = group;
@@ -67,12 +66,22 @@ public class FunctionInfo {
     return signatures;
   }
 
-  public Optional<BigQueryAPIRoutineLanguage> getLanguage() {
+  public Optional<BigQueryRoutineLanguage> getLanguage() {
     return language;
   }
 
   public Optional<String> getBody() {
     return this.body;
+  }
+
+  public Builder toBuilder() {
+    return newBuilder()
+        .setNamePath(this.namePath)
+        .setGroup(this.group)
+        .setMode(this.mode)
+        .setSignatures(this.signatures)
+        .setLanguage(this.language)
+        .setBody(this.body);
   }
 
   public static Builder newBuilder() {
@@ -84,7 +93,7 @@ public class FunctionInfo {
     private String group;
     private Mode mode;
     private List<FunctionSignature> signatures;
-    private Optional<BigQueryAPIRoutineLanguage> language;
+    private Optional<BigQueryRoutineLanguage> language;
     private Optional<String> body;
 
     public Builder setNamePath(List<String> namePath) {
@@ -107,14 +116,48 @@ public class FunctionInfo {
       return this;
     }
 
-    public Builder setLanguage(BigQueryAPIRoutineLanguage language) {
+    public Builder setLanguage(BigQueryRoutineLanguage language) {
       this.language = Optional.ofNullable(language);
+      return this;
+    }
+
+    public Builder setLanguage(Optional<BigQueryRoutineLanguage> language) {
+      this.language = language;
       return this;
     }
 
     public Builder setBody(String body) {
       this.body = Optional.ofNullable(body);
       return this;
+    }
+
+    public Builder setBody(Optional<String> body) {
+      this.body = body;
+      return this;
+    }
+
+    public List<String> getNamePath() {
+      return namePath;
+    }
+
+    public String getGroup() {
+      return group;
+    }
+
+    public Mode getMode() {
+      return mode;
+    }
+
+    public List<FunctionSignature> getSignatures() {
+      return signatures;
+    }
+
+    public Optional<BigQueryRoutineLanguage> getLanguage() {
+      return language;
+    }
+
+    public Optional<String> getBody() {
+      return body;
     }
 
     public FunctionInfo build() {

--- a/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/bigquery/FunctionReturnTypeResolver.java
+++ b/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/bigquery/FunctionReturnTypeResolver.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2023 Google LLC All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.zetasql.toolkit.catalog.bigquery;
+
+import com.google.zetasql.Analyzer;
+import com.google.zetasql.AnalyzerOptions;
+import com.google.zetasql.FunctionArgumentType;
+import com.google.zetasql.FunctionArgumentType.FunctionArgumentTypeOptions;
+import com.google.zetasql.FunctionSignature;
+import com.google.zetasql.LanguageOptions;
+import com.google.zetasql.SimpleCatalog;
+import com.google.zetasql.SqlException;
+import com.google.zetasql.Type;
+import com.google.zetasql.ZetaSQLFunctions.SignatureArgumentKind;
+import com.google.zetasql.ZetaSQLType.TypeKind;
+import com.google.zetasql.resolvedast.ResolvedNodes.ResolvedExpr;
+import com.google.zetasql.toolkit.catalog.bigquery.exceptions.CouldNotInferFunctionReturnType;
+import com.google.zetasql.toolkit.catalog.bigquery.exceptions.MissingFunctionReturnType;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Allows resolving the return types of {@link FunctionSignature}s for BigQuery.
+ *
+ * <p>Resolving implies inferring the function return type based on the function body in case the
+ * signature does not have a valid return type. Signatures set to return an unknown type (having
+ * {@link TypeKind#TYPE_UNKNOWN} as their return type) or an arbitrary type (having {@link
+ * SignatureArgumentKind#ARG_TYPE_ARBITRARY} as their return kind) require inference.
+ */
+class FunctionReturnTypeResolver {
+
+  /**
+   * Infer the return type of a function if necessary.
+   *
+   * @param signature The signature for which to infer the return type
+   * @param body The body of the function in question
+   * @param languageOptions The {@link LanguageOptions} to use when performing inference
+   * @param catalog The {@link SimpleCatalog} to use when performing inference
+   * @return The {@link FunctionArgumentType} that the provided signature should use. Will be the
+   *     same as the original if no inference was necessary.
+   * @throws CouldNotInferFunctionReturnType if inference fails for any reason
+   */
+  private static FunctionArgumentType inferFunctionReturnType(
+      FunctionSignature signature,
+      String body,
+      LanguageOptions languageOptions,
+      SimpleCatalog catalog) {
+    FunctionArgumentType originalReturn = signature.getResultType();
+
+    boolean returnIsArbitrary =
+        originalReturn.getKind().equals(SignatureArgumentKind.ARG_TYPE_ARBITRARY);
+    boolean returnIsFixed = originalReturn.getKind().equals(SignatureArgumentKind.ARG_TYPE_FIXED);
+    boolean returnTypeIsNull = originalReturn.getType() == null;
+    boolean returnIsUnknown = returnIsFixed && returnTypeIsNull;
+    boolean shouldInferReturnType = returnIsArbitrary || returnIsUnknown;
+
+    if (!shouldInferReturnType) {
+      return originalReturn;
+    }
+
+    AnalyzerOptions analyzerOptions = new AnalyzerOptions();
+    analyzerOptions.setLanguageOptions(languageOptions);
+
+    for (FunctionArgumentType argument : signature.getFunctionArgumentList()) {
+      if (!argument.isConcrete()) {
+        throw new CouldNotInferFunctionReturnType(
+            signature, "Cannot infer the return type of a function with templated arguments");
+      }
+
+      analyzerOptions.addExpressionColumn(
+          argument.getOptions().getArgumentName(), argument.getType());
+    }
+
+    try {
+      ResolvedExpr analyzedExpression = Analyzer.analyzeExpression(body, analyzerOptions, catalog);
+      return new FunctionArgumentType(
+          analyzedExpression.getType(), FunctionArgumentTypeOptions.builder().build(), 1);
+    } catch (SqlException sqlException) {
+      throw new CouldNotInferFunctionReturnType(
+          signature, "Failed to infer function return type", sqlException);
+    }
+  }
+
+  /**
+   * Resolves the return type of a {@link FunctionSignature} for a given function represented by the
+   * provided {@link FunctionInfo}. If necessary, it will attempt to infer the return type using the
+   * function body.
+   *
+   * <p>It will attempt to infer the return type of signatures set to return an unknown type (having
+   * {@link TypeKind#TYPE_UNKNOWN} as their return type) or an arbitrary type (having {@link
+   * SignatureArgumentKind#ARG_TYPE_ARBITRARY} as their return kind). Other signatures will be
+   * unchanged.
+   *
+   * <p>Attempting to infer the return type for the signature is done by analyzing the function body
+   * using {@link Analyzer#analyzeExpression(String, AnalyzerOptions, SimpleCatalog)}.
+   *
+   * @param signature The signature for which to infer the return type.
+   * @param function The FunctionInfo representing the function. The function language must be SQL
+   *     and the function body must be available; otherwise, resolution will fail for functions that
+   *     need inference.
+   * @param languageOptions The {@link LanguageOptions} to use when performing inference.
+   * @param catalog The catalog to use when analyzing the function body in case inferring the return
+   *     type if needed.
+   * @return An updated {@link FunctionSignature} with the return type resolved. Will be the
+   *     original signature if no inference was necessary.
+   * @throws MissingFunctionReturnType if the signature does not include a proper return type and it
+   *     could not be inferred.
+   */
+  private static FunctionSignature resolveReturnTypeForFunctionSignature(
+      FunctionSignature signature,
+      FunctionInfo function,
+      LanguageOptions languageOptions,
+      SimpleCatalog catalog) {
+    Type returnType = signature.getResultType().getType();
+
+    if (returnType != null) {
+      // The return type is already known, no need to infer it
+      return signature;
+    }
+
+    // The return type in unknown, try to infer it
+    BigQueryRoutineLanguage language =
+        function.getLanguage().orElse(BigQueryRoutineLanguage.LANGUAGE_UNSPECIFIED);
+
+    if (!language.equals(BigQueryRoutineLanguage.SQL)) {
+      throw new MissingFunctionReturnType(function.getNamePath());
+    }
+
+    String body =
+        function.getBody().orElseThrow(() -> new MissingFunctionReturnType(function.getNamePath()));
+
+    try {
+      FunctionArgumentType inferredReturnType =
+          FunctionReturnTypeResolver.inferFunctionReturnType(
+              signature, body, languageOptions, catalog);
+      return new FunctionSignature(
+          inferredReturnType, signature.getFunctionArgumentList(), signature.getContextId());
+    } catch (CouldNotInferFunctionReturnType err) {
+      throw new MissingFunctionReturnType(function.getNamePath(), err);
+    }
+  }
+
+  /**
+   * Resolves the return types of the {@link FunctionSignature}s of a given function represented by
+   * the provided {@link FunctionInfo}. If necessary, it will attempt to infer the return type using
+   * the function body.
+   *
+   * <p>It will attempt to infer the return type of signatures set to return an unknown type (having
+   * {@link TypeKind#TYPE_UNKNOWN} as their return type) or an arbitrary type (having {@link
+   * SignatureArgumentKind#ARG_TYPE_ARBITRARY} as their return kind). Other signatures will be
+   * unchanged.
+   *
+   * <p>Attempting to infer the return type for the signature is done by analyzing the function body
+   * using {@link Analyzer#analyzeExpression(String, AnalyzerOptions, SimpleCatalog)}.
+   *
+   * @param functionInfo The FunctionInfo representing the function. The function language must be
+   *     SQL and the function body must be available; otherwise, resolution will fail for functions
+   *     that need inference.
+   * @param languageOptions The {@link LanguageOptions} to use when performing inference.
+   * @param catalog The catalog to use when analyzing the function body in case inferring the return
+   *     type if needed.
+   * @return An updated {@link FunctionInfo} with the return types resolved. Any signature where
+   *     inference wasn't necessary will remain unchanged.
+   * @throws MissingFunctionReturnType if any signature does not include a proper return type and it
+   *     could not be inferred.
+   */
+  public static FunctionInfo resolveFunctionReturnTypesIfNeeded(
+      FunctionInfo functionInfo, LanguageOptions languageOptions, SimpleCatalog catalog) {
+    List<FunctionSignature> newSignatures =
+        functionInfo.getSignatures().stream()
+            .map(
+                signature ->
+                    resolveReturnTypeForFunctionSignature(
+                        signature, functionInfo, languageOptions, catalog))
+            .collect(Collectors.toList());
+
+    return functionInfo.toBuilder().setSignatures(newSignatures).build();
+  }
+}

--- a/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/bigquery/exceptions/CouldNotInferFunctionReturnType.java
+++ b/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/bigquery/exceptions/CouldNotInferFunctionReturnType.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 Google LLC All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.zetasql.toolkit.catalog.bigquery.exceptions;
+
+import com.google.zetasql.FunctionSignature;
+
+public class CouldNotInferFunctionReturnType extends BigQueryCatalogException {
+
+  private final FunctionSignature signature;
+
+  public CouldNotInferFunctionReturnType(FunctionSignature signature, String message) {
+    super(message);
+    this.signature = signature;
+  }
+
+  public CouldNotInferFunctionReturnType(
+      FunctionSignature signature, String message, Throwable cause) {
+    super(message, cause);
+    this.signature = signature;
+  }
+
+  public FunctionSignature getSignature() {
+    return signature;
+  }
+}

--- a/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/bigquery/exceptions/MissingFunctionResultType.java
+++ b/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/bigquery/exceptions/MissingFunctionResultType.java
@@ -18,23 +18,23 @@ package com.google.zetasql.toolkit.catalog.bigquery.exceptions;
 
 import java.util.List;
 
-public class MissingFunctionReturnType extends BigQueryCatalogException {
+public class MissingFunctionResultType extends BigQueryCatalogException {
 
   private final String routineReference;
 
-  public MissingFunctionReturnType(List<String> routineNamePath) {
+  public MissingFunctionResultType(List<String> routineNamePath) {
     this(String.join(".", routineNamePath));
   }
 
-  public MissingFunctionReturnType(List<String> routineNamePath, Throwable cause) {
+  public MissingFunctionResultType(List<String> routineNamePath, Throwable cause) {
     this(String.join(".", routineNamePath), cause);
   }
 
-  public MissingFunctionReturnType(String routineReference) {
+  public MissingFunctionResultType(String routineReference) {
     this(routineReference, null);
   }
 
-  public MissingFunctionReturnType(String routineReference, Throwable cause) {
+  public MissingFunctionResultType(String routineReference, Throwable cause) {
     super(
         String.format(
             "BigQuery routine %s is missing an explicit return type and it could not be inferred. "

--- a/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/bigquery/exceptions/MissingFunctionReturnType.java
+++ b/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/bigquery/exceptions/MissingFunctionReturnType.java
@@ -16,16 +16,31 @@
 
 package com.google.zetasql.toolkit.catalog.bigquery.exceptions;
 
-public class MissingRoutineReturnType extends BigQueryCatalogException {
+import java.util.List;
+
+public class MissingFunctionReturnType extends BigQueryCatalogException {
 
   private final String routineReference;
 
-  public MissingRoutineReturnType(String routineReference) {
+  public MissingFunctionReturnType(List<String> routineNamePath) {
+    this(String.join(".", routineNamePath));
+  }
+
+  public MissingFunctionReturnType(List<String> routineNamePath, Throwable cause) {
+    this(String.join(".", routineNamePath), cause);
+  }
+
+  public MissingFunctionReturnType(String routineReference) {
+    this(routineReference, null);
+  }
+
+  public MissingFunctionReturnType(String routineReference, Throwable cause) {
     super(
         String.format(
-            "BigQuery routine %s is missing an explicit return type. UDFs and Table Valued Functions "
-                + "should be define with a RETURNS clause.",
-            routineReference));
+            "BigQuery routine %s is missing an explicit return type and it could not be inferred. "
+                + "Consider adding an explicit RETURNS clause to it.",
+            routineReference),
+        cause);
     this.routineReference = routineReference;
   }
 

--- a/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/spanner/SpannerCatalog.java
+++ b/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/spanner/SpannerCatalog.java
@@ -61,7 +61,7 @@ public class SpannerCatalog implements CatalogWrapper {
     this.database = database;
     this.spannerResourceProvider = spannerResourceProvider;
     this.catalog = new SimpleCatalog("catalog");
-    this.catalog.addZetaSQLFunctions(
+    this.catalog.addZetaSQLFunctionsAndTypes(
         new ZetaSQLBuiltinFunctionOptions(SpannerLanguageOptions.get()));
     SpannerBuiltIns.addToCatalog(this.catalog);
   }

--- a/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/spanner/SpannerCatalog.java
+++ b/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/spanner/SpannerCatalog.java
@@ -18,7 +18,6 @@ package com.google.zetasql.toolkit.catalog.spanner;
 
 import com.google.cloud.spanner.DatabaseClient;
 import com.google.cloud.spanner.Spanner;
-import com.google.zetasql.Function;
 import com.google.zetasql.SimpleCatalog;
 import com.google.zetasql.SimpleTable;
 import com.google.zetasql.ZetaSQLBuiltinFunctionOptions;
@@ -26,6 +25,7 @@ import com.google.zetasql.resolvedast.ResolvedCreateStatementEnums.CreateMode;
 import com.google.zetasql.resolvedast.ResolvedCreateStatementEnums.CreateScope;
 import com.google.zetasql.toolkit.catalog.CatalogOperations;
 import com.google.zetasql.toolkit.catalog.CatalogWrapper;
+import com.google.zetasql.toolkit.catalog.bigquery.FunctionInfo;
 import com.google.zetasql.toolkit.catalog.bigquery.ProcedureInfo;
 import com.google.zetasql.toolkit.catalog.bigquery.TVFInfo;
 import com.google.zetasql.toolkit.catalog.exceptions.CatalogResourceAlreadyExists;
@@ -149,7 +149,7 @@ public class SpannerCatalog implements CatalogWrapper {
   }
 
   @Override
-  public void register(Function function, CreateMode createMode, CreateScope createScope) {
+  public void register(FunctionInfo function, CreateMode createMode, CreateScope createScope) {
     throw new UnsupportedOperationException(
         "Cloud Spanner does not support user-defined functions");
   }

--- a/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/usage/UsageTracker.java
+++ b/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/usage/UsageTracker.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 Google LLC All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.zetasql.toolkit.usage;
 
 public interface UsageTracker {

--- a/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/usage/UsageTrackerImpl.java
+++ b/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/usage/UsageTrackerImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 Google LLC All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.zetasql.toolkit.usage;
 
 import com.google.cloud.bigquery.BigQuery;

--- a/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/usage/UsageTracking.java
+++ b/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/usage/UsageTracking.java
@@ -7,7 +7,7 @@ import com.google.common.collect.ImmutableMap;
 public class UsageTracking {
 
   private static final String USER_AGENT_HEADER = "user-agent";
-  private static final String USER_AGENT_VALUE = "google-pso-tool/zetasql-toolkit/0.1.0";
+  private static final String USER_AGENT_VALUE = "google-pso-tool/zetasql-toolkit/0.1.1";
 
   public static final HeaderProvider HEADER_PROVIDER =
       FixedHeaderProvider.create(ImmutableMap.of(USER_AGENT_HEADER, USER_AGENT_VALUE));

--- a/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/usage/UsageTracking.java
+++ b/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/usage/UsageTracking.java
@@ -19,11 +19,29 @@ package com.google.zetasql.toolkit.usage;
 import com.google.api.gax.rpc.FixedHeaderProvider;
 import com.google.api.gax.rpc.HeaderProvider;
 import com.google.common.collect.ImmutableMap;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
 
 public class UsageTracking {
-
   private static final String USER_AGENT_HEADER = "user-agent";
-  private static final String USER_AGENT_VALUE = "google-pso-tool/zetasql-toolkit/0.1.3-SNAPSHOT";
+  private static final String USER_AGENT_VALUE;
+
+  static {
+    String revision = "UNSET";
+
+    InputStream propertiesInputStream =
+        UsageTracking.class.getResourceAsStream("/zetasql-toolkit-core.properties");
+
+    try (propertiesInputStream) {
+      Properties properties = new Properties();
+      properties.load(propertiesInputStream);
+      revision = properties.getProperty("zetasql.toolkit.version", "UNSET");
+    } catch (IOException ignored) {
+    }
+
+    USER_AGENT_VALUE = String.format("google-pso-tool/zetasql-toolkit/%s", revision);
+  }
 
   public static final HeaderProvider HEADER_PROVIDER =
       FixedHeaderProvider.create(ImmutableMap.of(USER_AGENT_HEADER, USER_AGENT_VALUE));

--- a/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/usage/UsageTracking.java
+++ b/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/usage/UsageTracking.java
@@ -23,7 +23,7 @@ import com.google.common.collect.ImmutableMap;
 public class UsageTracking {
 
   private static final String USER_AGENT_HEADER = "user-agent";
-  private static final String USER_AGENT_VALUE = "google-pso-tool/zetasql-toolkit/0.1.1";
+  private static final String USER_AGENT_VALUE = "google-pso-tool/zetasql-toolkit/0.1.3-SNAPSHOT";
 
   public static final HeaderProvider HEADER_PROVIDER =
       FixedHeaderProvider.create(ImmutableMap.of(USER_AGENT_HEADER, USER_AGENT_VALUE));

--- a/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/usage/UsageTracking.java
+++ b/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/usage/UsageTracking.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 Google LLC All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.zetasql.toolkit.usage;
 
 import com.google.api.gax.rpc.FixedHeaderProvider;

--- a/tools/zetasql-helper/zetasql-toolkit-core/src/test/java/com/google/zetasql/toolkit/AnalyzerExtensionsTest.java
+++ b/tools/zetasql-helper/zetasql-toolkit-core/src/test/java/com/google/zetasql/toolkit/AnalyzerExtensionsTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2023 Google LLC All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.zetasql.toolkit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.google.zetasql.LanguageOptions;
+import com.google.zetasql.ParseResumeLocation;
+import com.google.zetasql.toolkit.options.BigQueryLanguageOptions;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class AnalyzerExtensionsTest {
+
+  private static final LanguageOptions languageOptions = BigQueryLanguageOptions.get();
+
+  @Test
+  void testExtractFunctionNamesFromStatement() {
+    String query = "SELECT f1(), c.f2(), `c.f3`();";
+
+    List<List<String>> expected = List.of(List.of("f1"), List.of("c", "f2"), List.of("c.f3"));
+
+    List<List<String>> extractedFunctions =
+        AnalyzerExtensions.extractFunctionNamesFromStatement(query, languageOptions);
+
+    assertIterableEquals(expected, extractedFunctions);
+  }
+
+  @Test
+  void testExtractFunctionNamesFromScript() {
+    String script = "INSERT INTO t(column) VALUES (f1(1));\n" + "SELECT c.f2(column) FROM t;\n";
+
+    List<List<String>> expected = List.of(List.of("f1"), List.of("c", "f2"));
+
+    List<List<String>> extractedFunctions =
+        AnalyzerExtensions.extractFunctionNamesFromScript(script, languageOptions);
+
+    assertIterableEquals(expected, extractedFunctions);
+  }
+
+  @Test
+  void testExtractFunctionNamesFromNextStatement() {
+    String script = "INSERT INTO t(column) VALUES (f1(1));\n" + "SELECT c.f2(column) FROM t;\n";
+
+    ParseResumeLocation parseResumeLocation = new ParseResumeLocation(script);
+
+    List<List<String>> expected = List.of(List.of("f1"));
+
+    List<List<String>> extractedFunctions =
+        AnalyzerExtensions.extractFunctionNamesFromNextStatement(
+            parseResumeLocation, languageOptions);
+
+    assertIterableEquals(expected, extractedFunctions);
+  }
+
+  @Test
+  void testExtractTVFNamesFromStatement() {
+    String query = "SELECT * FROM f1(), c.f2(), `c.f3`();";
+
+    List<List<String>> expected = List.of(List.of("f1"), List.of("c", "f2"), List.of("c.f3"));
+
+    List<List<String>> extractedFunctions =
+        AnalyzerExtensions.extractTVFNamesFromStatement(query, languageOptions);
+
+    assertIterableEquals(expected, extractedFunctions);
+  }
+
+  @Test
+  void testExtractTVFNamesFromScript() {
+    String script =
+        "INSERT INTO t(column) SELECT column FROM f1(1);\n" + "SELECT * FROM c.f2(column);\n";
+
+    List<List<String>> expected = List.of(List.of("f1"), List.of("c", "f2"));
+
+    List<List<String>> extractedFunctions =
+        AnalyzerExtensions.extractTVFNamesFromScript(script, languageOptions);
+
+    assertIterableEquals(expected, extractedFunctions);
+  }
+
+  @Test
+  void testExtractTVFNamesFromNextStatement() {
+    String script =
+        "INSERT INTO t(column) SELECT column FROM f1(1);\n" + "SELECT * FROM c.f2(column);\n";
+
+    ParseResumeLocation parseResumeLocation = new ParseResumeLocation(script);
+
+    List<List<String>> expected = List.of(List.of("f1"));
+
+    List<List<String>> extractedFunctions =
+        AnalyzerExtensions.extractTVFNamesFromNextStatement(parseResumeLocation, languageOptions);
+
+    assertIterableEquals(expected, extractedFunctions);
+  }
+
+  @Test
+  void testExtractProcedureNamesFromStatement() {
+    String query = "CALL p1();";
+
+    List<List<String>> expected = List.of(List.of("p1"));
+
+    List<List<String>> extractedProcedures =
+        AnalyzerExtensions.extractProcedureNamesFromStatement(query, languageOptions);
+
+    assertIterableEquals(expected, extractedProcedures);
+  }
+
+  @Test
+  void testExtractProcedureNamesFromScript() {
+    String script = "CALL c.p1(); CALL `c.p2`();";
+
+    List<List<String>> expected = List.of(List.of("c", "p1"), List.of("c.p2"));
+
+    List<List<String>> extractedProcedures =
+        AnalyzerExtensions.extractProcedureNamesFromScript(script, languageOptions);
+
+    assertIterableEquals(expected, extractedProcedures);
+  }
+
+  @Test
+  void testExtractProcedureNamesFromNextStatement() {
+    String query = "CALL p1();";
+
+    ParseResumeLocation parseResumeLocation = new ParseResumeLocation(query);
+
+    List<List<String>> expected = List.of(List.of("p1"));
+
+    List<List<String>> extractedProcedures =
+        AnalyzerExtensions.extractProcedureNamesFromNextStatement(
+            parseResumeLocation, languageOptions);
+
+    assertIterableEquals(expected, extractedProcedures);
+  }
+}

--- a/tools/zetasql-helper/zetasql-toolkit-core/src/test/java/com/google/zetasql/toolkit/CatalogUpdaterVisitorTest.java
+++ b/tools/zetasql-helper/zetasql-toolkit-core/src/test/java/com/google/zetasql/toolkit/CatalogUpdaterVisitorTest.java
@@ -33,6 +33,7 @@ import com.google.zetasql.resolvedast.ResolvedDropStmtEnums;
 import com.google.zetasql.resolvedast.ResolvedNodes.*;
 import com.google.zetasql.toolkit.catalog.CatalogTestUtils;
 import com.google.zetasql.toolkit.catalog.CatalogWrapper;
+import com.google.zetasql.toolkit.catalog.bigquery.FunctionInfo;
 import com.google.zetasql.toolkit.catalog.bigquery.TVFInfo;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -245,21 +246,22 @@ public class CatalogUpdaterVisitorTest {
 
     resolvedCreateFunctionStmt.accept(visitor);
 
-    ArgumentCaptor<Function> createdFunctionCaptor = ArgumentCaptor.forClass(Function.class);
+    ArgumentCaptor<FunctionInfo> createdFunctionCaptor =
+        ArgumentCaptor.forClass(FunctionInfo.class);
     verify(catalog).register(createdFunctionCaptor.capture(), any(), any());
 
-    Function createdFunction = createdFunctionCaptor.getValue();
+    FunctionInfo createdFunction = createdFunctionCaptor.getValue();
 
     assertAll(
         () -> assertIterableEquals(expectedFunction.getNamePath(), createdFunction.getNamePath()),
         () -> assertEquals(expectedFunction.getGroup(), createdFunction.getGroup()),
         () -> assertEquals(expectedFunction.getMode(), createdFunction.getMode()),
-        () -> assertEquals(1, createdFunction.getSignatureList().size()),
+        () -> assertEquals(1, createdFunction.getSignatures().size()),
         () ->
             assertTrue(
                 CatalogTestUtils.functionSignatureEquals(
                     expectedFunction.getSignatureList().get(0),
-                    createdFunction.getSignatureList().get(0))));
+                    createdFunction.getSignatures().get(0))));
   }
 
   @Test

--- a/tools/zetasql-helper/zetasql-toolkit-core/src/test/java/com/google/zetasql/toolkit/CatalogUpdaterVisitorTest.java
+++ b/tools/zetasql-helper/zetasql-toolkit-core/src/test/java/com/google/zetasql/toolkit/CatalogUpdaterVisitorTest.java
@@ -276,7 +276,12 @@ public class CatalogUpdaterVisitorTest {
         TVFRelation.createColumnBased(
             List.of(Column.create("output", TypeFactory.createSimpleType(TypeKind.TYPE_STRING))));
 
-    TVFInfo expectedFunction = new TVFInfo(ImmutableList.of("tvf"), signature, tvfOutputSchema);
+    TVFInfo expectedFunction =
+        TVFInfo.newBuilder()
+            .setNamePath(ImmutableList.of("tvf"))
+            .setSignature(signature)
+            .setOutputSchema(tvfOutputSchema)
+            .build();
 
     ResolvedCreateTableFunctionStmt resolvedCreateTableFunctionStmt =
         ResolvedCreateTableFunctionStmt.builder()

--- a/tools/zetasql-helper/zetasql-toolkit-core/src/test/java/com/google/zetasql/toolkit/catalog/CatalogOperationsTest.java
+++ b/tools/zetasql-helper/zetasql-toolkit-core/src/test/java/com/google/zetasql/toolkit/catalog/CatalogOperationsTest.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.zetasql.*;
 import com.google.zetasql.ZetaSQLType.TypeKind;
 import com.google.zetasql.resolvedast.ResolvedCreateStatementEnums.CreateMode;
+import com.google.zetasql.toolkit.catalog.bigquery.FunctionInfo;
 import com.google.zetasql.toolkit.catalog.bigquery.ProcedureInfo;
 import com.google.zetasql.toolkit.catalog.bigquery.TVFInfo;
 import com.google.zetasql.toolkit.catalog.exceptions.CatalogResourceAlreadyExists;
@@ -268,16 +269,19 @@ class CatalogOperationsTest {
 
   @Test
   void testCreateFunctionInCatalog() {
-    Function newFunction =
-        new Function(
-            List.of("newFunction"),
-            "UDF",
-            ZetaSQLFunctions.FunctionEnums.Mode.SCALAR,
-            List.of(
-                new FunctionSignature(
-                    new FunctionArgumentType(TypeFactory.createSimpleType(TypeKind.TYPE_STRING)),
-                    List.of(),
-                    -1)));
+    FunctionInfo newFunction =
+        FunctionInfo.newBuilder()
+            .setNamePath(List.of("newFunction"))
+            .setGroup("UDF")
+            .setMode(ZetaSQLFunctions.FunctionEnums.Mode.SCALAR)
+            .setSignatures(
+                List.of(
+                    new FunctionSignature(
+                        new FunctionArgumentType(
+                            TypeFactory.createSimpleType(TypeKind.TYPE_STRING)),
+                        List.of(),
+                        -1)))
+            .build();
 
     List<String> newFunctionPath1 = List.of("newFunction");
     List<String> newFunctionPath2 = List.of("qualified", "newFunction");

--- a/tools/zetasql-helper/zetasql-toolkit-core/src/test/java/com/google/zetasql/toolkit/catalog/CatalogOperationsTest.java
+++ b/tools/zetasql-helper/zetasql-toolkit-core/src/test/java/com/google/zetasql/toolkit/catalog/CatalogOperationsTest.java
@@ -340,13 +340,18 @@ class CatalogOperationsTest {
   @Test
   void testCreateTVFInCatalog() {
     TVFInfo newTVF =
-        new TVFInfo(
-            ImmutableList.of("newTVF"),
-            new FunctionSignature(
-                new FunctionArgumentType(ZetaSQLFunctions.SignatureArgumentKind.ARG_TYPE_RELATION),
-                List.of(),
-                -1),
-            TVFRelation.createValueTableBased(TypeFactory.createSimpleType(TypeKind.TYPE_STRING)));
+        TVFInfo.newBuilder()
+            .setNamePath(ImmutableList.of("newTVF"))
+            .setSignature(
+                new FunctionSignature(
+                    new FunctionArgumentType(
+                        ZetaSQLFunctions.SignatureArgumentKind.ARG_TYPE_RELATION),
+                    List.of(),
+                    -1))
+            .setOutputSchema(
+                TVFRelation.createValueTableBased(
+                    TypeFactory.createSimpleType(TypeKind.TYPE_STRING)))
+            .build();
 
     List<String> newFunctionPath1 = List.of("newTVF");
     List<String> newFunctionPath2 = List.of("qualified", "newTVF");

--- a/tools/zetasql-helper/zetasql-toolkit-core/src/test/java/com/google/zetasql/toolkit/catalog/bigquery/BigQueryAPIResourceProviderTest.java
+++ b/tools/zetasql-helper/zetasql-toolkit-core/src/test/java/com/google/zetasql/toolkit/catalog/bigquery/BigQueryAPIResourceProviderTest.java
@@ -16,6 +16,7 @@
 
 package com.google.zetasql.toolkit.catalog.bigquery;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
@@ -312,7 +313,9 @@ public class BigQueryAPIResourceProviderTest {
     assertTrue(
         CatalogTestUtils.functionSignatureEquals(
             expectedSignatureForMockTVF, functions.get(0).getSignature()));
-    assertEquals(expectedOutputSchemaForMockTVF, functions.get(0).getOutputSchema());
+
+    TVFRelation outputSchema = assertDoesNotThrow(() -> functions.get(0).getOutputSchema().get());
+    assertEquals(expectedOutputSchemaForMockTVF, outputSchema);
   }
 
   Routine createMockProcedure() {

--- a/tools/zetasql-helper/zetasql-toolkit-core/src/test/java/com/google/zetasql/toolkit/catalog/bigquery/BigQueryAPIResourceProviderTest.java
+++ b/tools/zetasql-helper/zetasql-toolkit-core/src/test/java/com/google/zetasql/toolkit/catalog/bigquery/BigQueryAPIResourceProviderTest.java
@@ -234,13 +234,13 @@ public class BigQueryAPIResourceProviderTest {
 
     FunctionSignature expectedSignatureForMockUDF = expectedSignatureForMockUDF();
 
-    List<Function> functions =
+    List<FunctionInfo> functions =
         bigqueryResourceProvider.getFunctions("project", List.of("reference"));
 
     assertEquals(1, functions.size());
     assertTrue(
         CatalogTestUtils.functionSignatureEquals(
-            expectedSignatureForMockUDF, functions.get(0).getSignatureList().get(0)));
+            expectedSignatureForMockUDF, functions.get(0).getSignatures().get(0)));
   }
 
   Routine createMockTVF() {

--- a/tools/zetasql-helper/zetasql-toolkit-core/src/test/java/com/google/zetasql/toolkit/catalog/bigquery/BigQueryAPIResourceProviderTest.java
+++ b/tools/zetasql-helper/zetasql-toolkit-core/src/test/java/com/google/zetasql/toolkit/catalog/bigquery/BigQueryAPIResourceProviderTest.java
@@ -27,6 +27,7 @@ import com.google.zetasql.*;
 import com.google.zetasql.FunctionArgumentType.FunctionArgumentTypeOptions;
 import com.google.zetasql.StructType.StructField;
 import com.google.zetasql.TVFRelation.Column;
+import com.google.zetasql.ZetaSQLFunctions.FunctionEnums.NamedArgumentKind;
 import com.google.zetasql.ZetaSQLFunctions.FunctionEnums.ProcedureArgumentMode;
 import com.google.zetasql.ZetaSQLFunctions.SignatureArgumentKind;
 import com.google.zetasql.ZetaSQLType.TypeKind;
@@ -217,7 +218,7 @@ public class BigQueryAPIResourceProviderTest {
         new FunctionArgumentType(
             TypeFactory.createSimpleType(TypeKind.TYPE_INT64),
             FunctionArgumentTypeOptions.builder()
-                .setArgumentName("x")
+                .setArgumentName("x", NamedArgumentKind.POSITIONAL_ONLY)
                 .setProcedureArgumentMode(ProcedureArgumentMode.NOT_SET)
                 .build(),
             1);
@@ -288,7 +289,7 @@ public class BigQueryAPIResourceProviderTest {
         new FunctionArgumentType(
             TypeFactory.createSimpleType(TypeKind.TYPE_INT64),
             FunctionArgumentTypeOptions.builder()
-                .setArgumentName("x")
+                .setArgumentName("x", NamedArgumentKind.POSITIONAL_ONLY)
                 .setProcedureArgumentMode(ProcedureArgumentMode.NOT_SET)
                 .build(),
             1);
@@ -339,7 +340,7 @@ public class BigQueryAPIResourceProviderTest {
         new FunctionArgumentType(
             TypeFactory.createSimpleType(TypeKind.TYPE_INT64),
             FunctionArgumentTypeOptions.builder()
-                .setArgumentName("x")
+                .setArgumentName("x", NamedArgumentKind.POSITIONAL_ONLY)
                 .setProcedureArgumentMode(ProcedureArgumentMode.NOT_SET)
                 .build(),
             1);

--- a/tools/zetasql-helper/zetasql-toolkit-core/src/test/java/com/google/zetasql/toolkit/catalog/bigquery/BigQueryCatalogTest.java
+++ b/tools/zetasql-helper/zetasql-toolkit-core/src/test/java/com/google/zetasql/toolkit/catalog/bigquery/BigQueryCatalogTest.java
@@ -67,11 +67,14 @@ public class BigQueryCatalogTest {
           .build();
 
   TVFInfo exampleTVF =
-      new TVFInfo(
-          ImmutableList.of(testProjectId, "dataset", "exampletvf"),
-          new FunctionSignature(
-              new FunctionArgumentType(SignatureArgumentKind.ARG_TYPE_RELATION), List.of(), -1),
-          TVFRelation.createValueTableBased(TypeFactory.createSimpleType(TypeKind.TYPE_STRING)));
+      TVFInfo.newBuilder()
+          .setNamePath(ImmutableList.of(testProjectId, "dataset", "exampletvf"))
+          .setSignature(
+              new FunctionSignature(
+                  new FunctionArgumentType(SignatureArgumentKind.ARG_TYPE_RELATION), List.of(), -1))
+          .setOutputSchema(
+              TVFRelation.createValueTableBased(TypeFactory.createSimpleType(TypeKind.TYPE_STRING)))
+          .build();
 
   ProcedureInfo exampleProcedure =
       new ProcedureInfo(

--- a/tools/zetasql-helper/zetasql-toolkit-core/src/test/java/com/google/zetasql/toolkit/catalog/bigquery/BigQueryCatalogTest.java
+++ b/tools/zetasql-helper/zetasql-toolkit-core/src/test/java/com/google/zetasql/toolkit/catalog/bigquery/BigQueryCatalogTest.java
@@ -53,16 +53,18 @@ public class BigQueryCatalogTest {
 
   SimpleTable replacementTableInDefaultProject;
 
-  Function exampleFunction =
-      new Function(
-          List.of(testProjectId, "dataset", "examplefunction"),
-          "UDF",
-          Mode.SCALAR,
-          List.of(
-              new FunctionSignature(
-                  new FunctionArgumentType(TypeFactory.createSimpleType(TypeKind.TYPE_STRING)),
-                  List.of(),
-                  -1)));
+  FunctionInfo exampleFunction =
+      FunctionInfo.newBuilder()
+          .setNamePath(List.of(testProjectId, "dataset", "examplefunction"))
+          .setGroup("UDF")
+          .setMode(Mode.SCALAR)
+          .setSignatures(
+              List.of(
+                  new FunctionSignature(
+                      new FunctionArgumentType(TypeFactory.createSimpleType(TypeKind.TYPE_STRING)),
+                      List.of(),
+                      -1)))
+          .build();
 
   TVFInfo exampleTVF =
       new TVFInfo(
@@ -373,12 +375,48 @@ public class BigQueryCatalogTest {
   }
 
   @Test
-  void testCopy() {
-    BigQueryCatalog copy = this.bigQueryCatalog.copy();
+  void testRegisterFunction() {
+    this.bigQueryCatalog.register(
+        exampleFunction, CreateMode.CREATE_DEFAULT, CreateScope.CREATE_DEFAULT_SCOPE);
 
-    assertAll(
-        () -> assertNotSame(this.bigQueryCatalog, copy),
-        () -> assertNotSame(this.bigQueryCatalog.getZetaSQLCatalog(), copy.getZetaSQLCatalog()));
+    SimpleCatalog underlyingCatalog = this.bigQueryCatalog.getZetaSQLCatalog();
+    assertDoesNotThrow(
+        () -> underlyingCatalog.findFunction(exampleFunction.getNamePath()),
+        String.format(
+            "Expected function to exist at path %s",
+            String.join(".", exampleFunction.getNamePath())));
+  }
+
+  @Test
+  void testInferFunctionReturnType() {
+    FunctionInfo functionWithUnknownReturnType =
+        FunctionInfo.newBuilder()
+            .setNamePath(List.of(testProjectId, "dataset", "function"))
+            .setGroup("UDF")
+            .setMode(Mode.SCALAR)
+            .setSignatures(
+                List.of(
+                    new FunctionSignature(
+                        new FunctionArgumentType(
+                            TypeFactory.createSimpleType(TypeKind.TYPE_UNKNOWN)),
+                        List.of(),
+                        -1)))
+            .setLanguage(BigQueryRoutineLanguage.SQL)
+            .setBody("5.6 + 5")
+            .build();
+
+    this.bigQueryCatalog.register(
+        functionWithUnknownReturnType, CreateMode.CREATE_DEFAULT, CreateScope.CREATE_DEFAULT_SCOPE);
+
+    SimpleCatalog underlyingCatalog = this.bigQueryCatalog.getZetaSQLCatalog();
+    Function foundFunction =
+        assertDoesNotThrow(
+            () -> underlyingCatalog.findFunction(functionWithUnknownReturnType.getNamePath()),
+            String.format(
+                "Expected function to exist at path %s",
+                String.join(".", functionWithUnknownReturnType.getNamePath())));
+
+    assertTrue(foundFunction.getSignatureList().get(0).getResultType().getType().isFloatingPoint());
   }
 
   @Test
@@ -391,6 +429,15 @@ public class BigQueryCatalogTest {
         () -> underlyingCatalog.findProcedure(exampleProcedure.getNamePath()),
         String.format(
             "Expected procedure to exist at path %s",
-            String.join(".", exampleFunction.getNamePath())));
+            String.join(".", exampleProcedure.getNamePath())));
+  }
+
+  @Test
+  void testCopy() {
+    BigQueryCatalog copy = this.bigQueryCatalog.copy();
+
+    assertAll(
+        () -> assertNotSame(this.bigQueryCatalog, copy),
+        () -> assertNotSame(this.bigQueryCatalog.getZetaSQLCatalog(), copy.getZetaSQLCatalog()));
   }
 }

--- a/tools/zetasql-helper/zetasql-toolkit-core/src/test/java/com/google/zetasql/toolkit/catalog/bigquery/FunctionReturnTypeResolverTest.java
+++ b/tools/zetasql-helper/zetasql-toolkit-core/src/test/java/com/google/zetasql/toolkit/catalog/bigquery/FunctionReturnTypeResolverTest.java
@@ -1,0 +1,98 @@
+package com.google.zetasql.toolkit.catalog.bigquery;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.google.common.collect.ImmutableList;
+import com.google.zetasql.FunctionArgumentType;
+import com.google.zetasql.FunctionSignature;
+import com.google.zetasql.LanguageOptions;
+import com.google.zetasql.SimpleCatalog;
+import com.google.zetasql.TVFRelation;
+import com.google.zetasql.Type;
+import com.google.zetasql.TypeFactory;
+import com.google.zetasql.ZetaSQLBuiltinFunctionOptions;
+import com.google.zetasql.ZetaSQLFunctions.FunctionEnums.Mode;
+import com.google.zetasql.ZetaSQLFunctions.SignatureArgumentKind;
+import com.google.zetasql.ZetaSQLType.TypeKind;
+import com.google.zetasql.toolkit.options.BigQueryLanguageOptions;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class FunctionReturnTypeResolverTest {
+
+  private LanguageOptions languageOptions = BigQueryLanguageOptions.get();
+
+  private SimpleCatalog catalog = new SimpleCatalog("catalog");
+
+  @BeforeEach
+  void init() {
+    catalog.addZetaSQLFunctionsAndTypes(new ZetaSQLBuiltinFunctionOptions(languageOptions));
+  }
+
+  @Test
+  void testInferFunctionReturnType() {
+    FunctionInfo functionInfo =
+        FunctionInfo.newBuilder()
+            .setNamePath(List.of("f"))
+            .setGroup("UDF")
+            .setMode(Mode.SCALAR)
+            .setSignatures(
+                List.of(
+                    new FunctionSignature(
+                        new FunctionArgumentType(
+                            TypeFactory.createSimpleType(TypeKind.TYPE_UNKNOWN)),
+                        List.of(),
+                        -1)))
+            .setLanguage(BigQueryRoutineLanguage.SQL)
+            .setBody("CAST(FLOOR(5.5) AS INT64) + 1")
+            .build();
+
+    FunctionInfo resolvedFunctionInfo =
+        FunctionResultTypeResolver.resolveFunctionReturnTypes(
+            functionInfo, languageOptions, catalog);
+
+    FunctionSignature resolvedSignature =
+        assertDoesNotThrow(
+            () -> resolvedFunctionInfo.getSignatures().get(0),
+            "Expected result type to have been set after resolution");
+
+    Type resolvedResultType = resolvedSignature.getResultType().getType();
+
+    assertNotNull(resolvedResultType, "Expected result type to have resolved to INT");
+    assertTrue(resolvedResultType.isInteger(), "Expected result type to have resolved to INT");
+  }
+
+  @Test
+  void testInferTVFOutputSchema() {
+    TVFInfo tvfInfo =
+        TVFInfo.newBuilder()
+            .setNamePath(ImmutableList.of("tvf"))
+            .setSignature(
+                new FunctionSignature(
+                    new FunctionArgumentType(SignatureArgumentKind.ARG_TYPE_RELATION),
+                    List.of(),
+                    -1))
+            .setOutputSchema(Optional.empty())
+            .setBody("SELECT 1 AS column1, CONCAT('a', 'b') AS column2")
+            .build();
+
+    TVFInfo resolvedTVFInfo =
+        FunctionResultTypeResolver.resolveTVFOutputSchema(tvfInfo, languageOptions, catalog);
+
+    assertTrue(
+        resolvedTVFInfo.getOutputSchema().isPresent(),
+        "Expected TVF output schema to have been set after resolution");
+
+    TVFRelation inferredOutputSchema = resolvedTVFInfo.getOutputSchema().get();
+
+    // TVFRelation does not expose columns publicly, we assert using its string representation
+    String expectedOutputSchemaString = "TABLE<column1 INT64, column2 STRING>";
+
+    assertEquals(
+        expectedOutputSchemaString,
+        inferredOutputSchema.toString(),
+        "Expected inferred output schema to be " + expectedOutputSchemaString);
+  }
+}

--- a/tools/zetasql-helper/zetasql-toolkit-examples/pom.xml
+++ b/tools/zetasql-helper/zetasql-toolkit-examples/pom.xml
@@ -12,7 +12,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <zetasql.toolkit.version>0.1.2</zetasql.toolkit.version>
+        <zetasql.toolkit.version>0.1.3-SNAPSHOT</zetasql.toolkit.version>
         <google.cloud.jib.version>3.3.1</google.cloud.jib.version>
         <container.mainClass/>
     </properties>

--- a/tools/zetasql-helper/zetasql-toolkit-examples/pom.xml
+++ b/tools/zetasql-helper/zetasql-toolkit-examples/pom.xml
@@ -12,7 +12,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <zetasql.toolkit.version>0.1.3</zetasql.toolkit.version>
+        <zetasql.toolkit.version>0.2.0</zetasql.toolkit.version>
         <google.cloud.jib.version>3.3.1</google.cloud.jib.version>
         <container.mainClass/>
     </properties>

--- a/tools/zetasql-helper/zetasql-toolkit-examples/pom.xml
+++ b/tools/zetasql-helper/zetasql-toolkit-examples/pom.xml
@@ -12,7 +12,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <zetasql.toolkit.version>0.1-SNAPSHOT</zetasql.toolkit.version>
+        <zetasql.toolkit.version>0.1.1-SNAPSHOT</zetasql.toolkit.version>
         <google.cloud.jib.version>3.3.1</google.cloud.jib.version>
         <container.mainClass/>
     </properties>

--- a/tools/zetasql-helper/zetasql-toolkit-examples/pom.xml
+++ b/tools/zetasql-helper/zetasql-toolkit-examples/pom.xml
@@ -12,7 +12,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <zetasql.toolkit.version>0.1.1-SNAPSHOT</zetasql.toolkit.version>
+        <zetasql.toolkit.version>0.1.2</zetasql.toolkit.version>
         <google.cloud.jib.version>3.3.1</google.cloud.jib.version>
         <container.mainClass/>
     </properties>

--- a/tools/zetasql-helper/zetasql-toolkit-examples/pom.xml
+++ b/tools/zetasql-helper/zetasql-toolkit-examples/pom.xml
@@ -12,7 +12,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <zetasql.toolkit.version>0.1.3-SNAPSHOT</zetasql.toolkit.version>
+        <zetasql.toolkit.version>0.1.3</zetasql.toolkit.version>
         <google.cloud.jib.version>3.3.1</google.cloud.jib.version>
         <container.mainClass/>
     </properties>


### PR DESCRIPTION
Evolves the ZetaSQL Toolkit library to version 0.2.0

Changelog:
* Fixes dependency conflicts with GCP client libraries
* Adds support for inferring the return type of BigQuery functions when using a `BigQueryCatalog`
* Adds support for inferring the output schema of a BigQuery TVF when using a `BigQueryCatalog`