### PR TITLE
ZetaSQL Toolkit library - Version 0.2.1

### DIFF
--- a/tools/zetasql-helper/zetasql-toolkit-core/pom.xml
+++ b/tools/zetasql-helper/zetasql-toolkit-core/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.google.zetasql.toolkit</groupId>
     <artifactId>zetasql-toolkit-core</artifactId>
-    <version>0.2.0</version>
+    <version>0.2.1</version>
 
     <properties>
         <zetasql.toolkit.version>${project.version}</zetasql.toolkit.version>

--- a/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/CatalogWrapper.java
+++ b/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/CatalogWrapper.java
@@ -16,8 +16,6 @@
 
 package com.google.zetasql.toolkit.catalog;
 
-import com.google.zetasql.Analyzer;
-import com.google.zetasql.AnalyzerOptions;
 import com.google.zetasql.SimpleCatalog;
 import com.google.zetasql.SimpleTable;
 import com.google.zetasql.resolvedast.ResolvedCreateStatementEnums.CreateMode;
@@ -26,8 +24,6 @@ import com.google.zetasql.toolkit.catalog.bigquery.FunctionInfo;
 import com.google.zetasql.toolkit.catalog.bigquery.ProcedureInfo;
 import com.google.zetasql.toolkit.catalog.bigquery.TVFInfo;
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * Interface for an object that wraps a ZetaSQL SimpleCatalog and allows adding resources to it by
@@ -207,24 +203,6 @@ public interface CatalogWrapper {
    */
   default void addProcedure(String procedure) {
     this.addProcedures(List.of(procedure));
-  }
-
-  /**
-   * Adds all the tables used in the provided query to this catalog.
-   *
-   * <p>Uses Analyzer.extractTableNamesFromScript to extract the table names and later uses
-   * this.addTables to add them.
-   *
-   * @param query The SQL query from which to get the tables that should be added to the catalog
-   * @param options The ZetaSQL AnalyzerOptions to use when extracting the table names from the
-   *     query
-   */
-  default void addAllTablesUsedInQuery(String query, AnalyzerOptions options) {
-    Set<String> tables =
-        Analyzer.extractTableNamesFromScript(query, options).stream()
-            .map(tablePath -> String.join(".", tablePath))
-            .collect(Collectors.toSet());
-    this.addTables(List.copyOf(tables));
   }
 
   /**

--- a/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/bigquery/BigQueryCatalog.java
+++ b/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/bigquery/BigQueryCatalog.java
@@ -461,6 +461,25 @@ public class BigQueryCatalog implements CatalogWrapper {
   }
 
   /**
+   * Adds all the tables used in the provided query to this catalog.
+   *
+   * <p>Uses Analyzer.extractTableNamesFromScript to extract the table names and later uses
+   * this.addTables to add them.
+   *
+   * @param query The SQL query from which to get the tables that should be added to the catalog
+   * @param options The ZetaSQL AnalyzerOptions to use when extracting the table names from the
+   *     query
+   */
+  public void addAllTablesUsedInQuery(String query, AnalyzerOptions options) {
+    Set<String> tables =
+        Analyzer.extractTableNamesFromScript(query, options).stream()
+            .map(tablePath -> String.join(".", tablePath))
+            .filter(BigQueryReference::isQualified) // Remove non-qualified tables
+            .collect(Collectors.toSet());
+    this.addTables(List.copyOf(tables));
+  }
+
+  /**
    * {@inheritDoc}
    *
    * <p>Function references should be in the format "project.dataset.function" or "dataset.function"

--- a/tools/zetasql-helper/zetasql-toolkit-examples/pom.xml
+++ b/tools/zetasql-helper/zetasql-toolkit-examples/pom.xml
@@ -12,7 +12,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <zetasql.toolkit.version>0.2.0</zetasql.toolkit.version>
+        <zetasql.toolkit.version>0.2.1</zetasql.toolkit.version>
         <google.cloud.jib.version>3.3.1</google.cloud.jib.version>
         <container.mainClass/>
     </properties>


### PR DESCRIPTION
Evolves the ZetaSQL Toolkit library to version 0.2.1

Changelog:
* fix: Support `BigQueryCatalog.addAllTablesUsedInQuery` for scripts that create temporary tables and views