### PR TITLE
Added Terraform code to create HA VPN Tunnels between GCP and Azure

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,6 +414,8 @@ Platform usage.
     gcp_resources using the D3.js javascript library.
 *   [GCP AWS HA VPN Connection terraform ](tools/gcp-aws-ha-vpn) - Terraform
     script to setup HA VPN between GCP and AWS.
+*   [GCP Azure HA VPN Connection Terraform](tools/gcp-azure-ha-vpn) - Terraform
+    code to setup HA VPN between GCP and Microsoft Azure.
 *   [GCP Organization Hierarchy Viewer](tools/gcp-org-hierarchy-viewer) - A CLI
     utility for visualizing your organization hierarchy in the terminal.
 *   [GCPViz](tools/gcpviz) - a visualization tool that takes input from

--- a/tools/gcp-azure-ha-vpn/README.md
+++ b/tools/gcp-azure-ha-vpn/README.md
@@ -48,6 +48,8 @@ This configuration creates the following resources:
 
 The GCP and Azure VPN gateways are connected with two VPN tunnels to provide an active-active HA configuration. BGP is used for dynamic routing between GCP and Azure.
 
+![ha-vpn-google-cloud-to-azure](https://user-images.githubusercontent.com/7136208/233800865-043c13d0-df3f-4adc-b9aa-156766e55cb4.svg)
+
 ## Prerequisites
 
 1. [Install Terraform](https://learn.hashicorp.com/tutorials/terraform/install-cli) (v1.3+ is required).

--- a/tools/gcp-azure-ha-vpn/README.md
+++ b/tools/gcp-azure-ha-vpn/README.md
@@ -75,7 +75,6 @@ Update `terraform.tfvars` file in the same directory as the Terraform configurat
 | gcp_project_id          | The GCP project ID                      | Yes      |         |
 | gcp_region              | The GCP region                          | Yes      |         |
 | gcp_vpc_name            | The GCP VPC name                        | Yes      |         |
-| gcp_subnet_name         | The GCP subnet name                     | Yes      |         |
 | gcp_router_name         | The GCP VPN router name                 | Yes      |         |
 | gcp_bgp_asn             | The GCP VPC Router ASN                  | Yes      |  65534  |
 | shared_secret           | The shared secret for the VPN connection| Yes      |         |

--- a/tools/gcp-azure-ha-vpn/README.md
+++ b/tools/gcp-azure-ha-vpn/README.md
@@ -1,0 +1,125 @@
+# GCP-Azure HA VPN with BGP Terraform Configuration
+
+This repository contains Terraform configuration to set up High Availability (HA) VPN tunnels with BGP dynamic routing between Google Cloud Platform (GCP) and Microsoft Azure.
+
+**Disclaimer:** This interoperability Terraform configuration is designed to be minimal and straightforward, requiring minimal user input and automatically assigning public IPs. However, customers should validate its functionality by conducting their own tests.
+
+## Before you begin
+
+1. Go through the steps to create [GCP to Azure HA VPN Setup](https://cloud.google.com/network-connectivity/docs/vpn/tutorials/create-ha-vpn-connections-google-cloud-azure).
+2. Review information about how [dynamic routing works in Google Cloud](https://cloud.google.com/network-connectivity/docs/vpn/concepts/choosing-networks-routing#dynamic-routing).
+3. Review information about how [BGP works in Microsoft Azure](https://docs.microsoft.com/en-us/azure/vpn-gateway/vpn-gateway-bgp-overview).
+
+## Table of Contents
+
+1. [Terminology](#terminology)
+2. [Topology](#topology)
+3. [Prerequisites](#prerequisites)
+4. [Assumptions](#assumptions)
+5. [Authentication](#authentication)
+6. [Configuration](#configuration)
+7. [Usage](#usage)
+8. [Outputs](#outputs)
+9. [Contributing](#contributing)
+
+## Terminology
+
+- **HA VPN**: High Availability VPN is a GCP VPN offering that provides an SLA-backed managed VPN service.
+- **BGP**: Border Gateway Protocol is a standardized exterior gateway protocol designed to exchange routing and reachability information among autonomous systems (AS) on the internet.
+- **VPN Gateway**: A virtual network gateway that sends encrypted traffic between your virtual network and your on-premises location across a public connection.
+- **VPN Tunnel**: A secure, encrypted communication channel between two VPN gateways.
+- **Cloud Router**: A GCP service that dynamically exchanges routes between your VPC and on-premises networks or other VPC networks.
+- **Local Network Gateway**: A resource in Azure that represents your on-premises network and is used to configure the VPN connection.
+
+## Topology
+
+GCP HA VPN Supports multiple [topologies](https://cloud.google.com/network-connectivity/docs/vpn/concepts/topologies). This topology using with `REDUNDANCY_TYPE` of `TWO_IPS_REDUNDANCY`.
+
+This configuration creates the following resources:
+
+- GCP:
+  - VPN Gateway
+  - Two VPN tunnels for active-active configuration
+  - Cloud Router with BGP enabled
+- Azure:
+  - VPN Gateway with two public IP addresses for active-active configuration
+  - Two VPN connections
+  - Two Local Network Gateway with BGP enabled
+
+The GCP and Azure VPN gateways are connected with two VPN tunnels to provide an active-active HA configuration. BGP is used for dynamic routing between GCP and Azure.
+
+## Prerequisites
+
+1. [Install Terraform](https://learn.hashicorp.com/tutorials/terraform/install-cli) (v1.3+ is required).
+2. [Install Google Cloud SDK](https://cloud.google.com/sdk/docs/install) (optional, for authentication purposes).
+3. [Install Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli) (optional, for authentication purposes).
+
+## Assumptions
+
+1. Required roles are assigned to respective user (who will run the Terraform code) on GCP and Azure.
+2. VPC in GCP and VNET in Azure is already created.
+3. **GatewaySubnet** in Azure VNET is already created.
+4. Traffic is allowed on Azure NSG for Virtual Network Gateway.
+5. Traffic is allowed on GCP Firewall for VPN.
+
+## Authentication
+
+Use CLI or other methods to log in to GCP(gcloud) and Microsoft Azure(az cli).
+
+## Configuration
+
+Update `terraform.tfvars` file in the same directory as the Terraform configuration files with the following variables:
+
+| Variable                | Description                             | Required | Default |
+|-------------------------|-----------------------------------------|----------|---------|
+| gcp_project_id          | The GCP project ID                      | Yes      |         |
+| gcp_region              | The GCP region                          | Yes      |         |
+| gcp_vpc_name            | The GCP VPC name                        | Yes      |         |
+| gcp_subnet_name         | The GCP subnet name                     | Yes      |         |
+| gcp_router_name         | The GCP VPN router name                 | Yes      |         |
+| gcp_bgp_asn             | The GCP VPC Router ASN                  | Yes      |  65534  |
+| shared_secret           | The shared secret for the VPN connection| Yes      |         |
+| azure_subscription_id   | The Azure subscription ID               | Yes      |         |
+| azure_vnet_name         | The Azure VNET Name                     | Yes      |         |
+| azure_region            | The Azure region                        | Yes      |         |
+| azure_resource_group    | The Azure resource group                | Yes      |         |
+| azure_bgp_asn           | The Azure BGP ASN                       | Yes      |  65515  |
+| azure_vpn_sku           | The Azure VPN Sku                       | Yes      |  VpnGw1 |
+
+Replace the values as per your need.
+
+## Usage
+
+1. Initialize Terraform:
+
+    ```bash
+    terraform init
+    ```
+
+2. Plan and apply the Terraform configuration:
+
+    ```bash
+    terraform plan
+    terraform apply
+    ```
+
+3. After the infrastructure is created, Terraform will output the GCP VPN Gateway IP, GCP VPN Tunnel Peer IPs, Azure VPN Gateway Public IPs, and Azure VPN Tunnel Peer IPs.
+
+4. To clean up the resources, run:
+
+    ```bash
+    terraform destroy
+    ```
+
+## Outputs
+
+The following output variables are defined in `output.tf`:
+
+- GCP VPN Gateway IP
+- GCP VPN Tunnel Peer IPs
+- Azure VPN Gateway Public IPs
+- Azure VPN Tunnel Peer IPs
+
+## Contributing
+
+If you have suggestions or improvements, feel free to submit a pull request or create an issue.

--- a/tools/gcp-azure-ha-vpn/azure.tf
+++ b/tools/gcp-azure-ha-vpn/azure.tf
@@ -1,0 +1,145 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+# Azure existing virtual network and subnet
+data "azurerm_virtual_network" "azure_vnet" {
+  name                = var.azure_vnet_name
+  resource_group_name = var.azure_resource_group
+}
+
+data "azurerm_subnet" "azure_gw_subnet" {
+  name                 = "GatewaySubnet"
+  resource_group_name  = var.azure_resource_group
+  virtual_network_name = data.azurerm_virtual_network.azure_vnet.name
+}
+
+# Azure Public IP addresses
+resource "azurerm_public_ip" "azure_vpn_gateway_public_ip_1" {
+  name                = "azure-vpn-gateway-public-ip-1"
+  location            = var.azure_region
+  resource_group_name = var.azure_resource_group
+  allocation_method   = "Static"
+  sku                 = "Standard"
+}
+
+resource "azurerm_public_ip" "azure_vpn_gateway_public_ip_2" {
+  name                = "azure-vpn-gateway-public-ip-2"
+  location            = var.azure_region
+  resource_group_name = var.azure_resource_group
+  allocation_method   = "Static"
+  sku                 = "Standard"
+}
+
+# Azure VPN Gateway and connections
+resource "azurerm_virtual_network_gateway" "azure_vpn_gateway" {
+  name                = "azure-vpn-gateway"
+  location            = var.azure_region
+  resource_group_name = var.azure_resource_group
+
+  type     = "Vpn"
+  vpn_type = "RouteBased"
+
+  active_active = true
+  enable_bgp    = true
+  sku           = var.azure_vpn_sku
+
+  ip_configuration {
+    name                          = "vnetGatewayConfig1"
+    private_ip_address_allocation = "Dynamic"
+    subnet_id                     = data.azurerm_subnet.azure_gw_subnet.id
+    public_ip_address_id          = azurerm_public_ip.azure_vpn_gateway_public_ip_1.id
+  }
+
+  ip_configuration {
+    name                          = "vnetGatewayConfig2"
+    private_ip_address_allocation = "Dynamic"
+    subnet_id                     = data.azurerm_subnet.azure_gw_subnet.id
+    public_ip_address_id          = azurerm_public_ip.azure_vpn_gateway_public_ip_2.id
+  }
+
+  bgp_settings {
+    asn         = var.azure_bgp_asn
+    peer_weight = 100
+
+    peering_addresses {
+      ip_configuration_name = "vnetGatewayConfig1"
+      apipa_addresses       = ["169.254.21.1"]
+    }
+
+    peering_addresses {
+      ip_configuration_name = "vnetGatewayConfig2"
+      apipa_addresses       = ["169.254.22.1"]
+    }
+
+  }
+
+}
+
+resource "azurerm_local_network_gateway" "gcp_gw1" {
+  name                = "gcp-local-network-gateway-1"
+  location            = var.azure_region
+  resource_group_name = var.azure_resource_group
+
+  gateway_address = google_compute_ha_vpn_gateway.target_gateway.vpn_interfaces[0].ip_address
+  address_space   = [var.gcp_subnet_ip_cidr_range]
+
+  bgp_settings {
+    asn                 = var.gcp_bgp_asn
+    bgp_peering_address = google_compute_router_peer.router1_peer1.ip_address
+  }
+}
+
+resource "azurerm_local_network_gateway" "gcp_gw2" {
+  name                = "gcp-local-network-gateway-2"
+  location            = var.azure_region
+  resource_group_name = var.azure_resource_group
+
+  gateway_address = google_compute_ha_vpn_gateway.target_gateway.vpn_interfaces[1].ip_address
+  address_space   = [var.gcp_subnet_ip_cidr_range]
+
+  bgp_settings {
+    asn                 = var.gcp_bgp_asn
+    bgp_peering_address = google_compute_router_peer.router1_peer2.ip_address
+  }
+}
+
+resource "azurerm_virtual_network_gateway_connection" "vpn_connection1" {
+  name                = "azure-to-gcp-vpn-connection-1"
+  location            = var.azure_region
+  resource_group_name = var.azure_resource_group
+
+  type = "IPsec"
+
+  virtual_network_gateway_id = azurerm_virtual_network_gateway.azure_vpn_gateway.id
+  local_network_gateway_id   = azurerm_local_network_gateway.gcp_gw1.id
+  shared_key                 = var.shared_secret
+
+  enable_bgp = true
+}
+
+resource "azurerm_virtual_network_gateway_connection" "vpn_connection2" {
+  name                = "azure-to-gcp-vpn-connection-2"
+  location            = var.azure_region
+  resource_group_name = var.azure_resource_group
+
+  type = "IPsec"
+
+  virtual_network_gateway_id = azurerm_virtual_network_gateway.azure_vpn_gateway.id
+  local_network_gateway_id   = azurerm_local_network_gateway.gcp_gw2.id
+  shared_key                 = var.shared_secret
+
+  enable_bgp = true
+}

--- a/tools/gcp-azure-ha-vpn/azure.tf
+++ b/tools/gcp-azure-ha-vpn/azure.tf
@@ -94,7 +94,6 @@ resource "azurerm_local_network_gateway" "gcp_gw1" {
   resource_group_name = var.azure_resource_group
 
   gateway_address = google_compute_ha_vpn_gateway.target_gateway.vpn_interfaces[0].ip_address
-  address_space   = [var.gcp_subnet_ip_cidr_range]
 
   bgp_settings {
     asn                 = var.gcp_bgp_asn
@@ -108,7 +107,6 @@ resource "azurerm_local_network_gateway" "gcp_gw2" {
   resource_group_name = var.azure_resource_group
 
   gateway_address = google_compute_ha_vpn_gateway.target_gateway.vpn_interfaces[1].ip_address
-  address_space   = [var.gcp_subnet_ip_cidr_range]
 
   bgp_settings {
     asn                 = var.gcp_bgp_asn

--- a/tools/gcp-azure-ha-vpn/gcp.tf
+++ b/tools/gcp-azure-ha-vpn/gcp.tf
@@ -1,0 +1,108 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+# GCP existing network
+data "google_compute_network" "gcp_vpn_network" {
+  name = var.gcp_vpc_name
+}
+
+resource "google_compute_router" "vpn_router" {
+  name    = "vpn-router"
+  network = var.gcp_vpc_name
+
+  bgp {
+    asn               = var.gcp_bgp_asn
+    advertise_mode    = "CUSTOM"
+    advertised_groups = ["ALL_SUBNETS"]
+  }
+}
+
+# GCP HA VPN gateway
+resource "google_compute_ha_vpn_gateway" "target_gateway" {
+  name    = "vpn-gcp-azure"
+  network = var.gcp_vpc_name
+}
+
+resource "google_compute_external_vpn_gateway" "azure_gateway" {
+  name            = "azure-gateway"
+  redundancy_type = "TWO_IPS_REDUNDANCY"
+  description     = "VPN gateway on Azure side"
+
+  interface {
+    id         = 0
+    ip_address = azurerm_public_ip.azure_vpn_gateway_public_ip_1.ip_address
+  }
+
+  interface {
+    id         = 1
+    ip_address = azurerm_public_ip.azure_vpn_gateway_public_ip_2.ip_address
+  }
+}
+
+# GCP HA VPN Tunnels
+resource "google_compute_vpn_tunnel" "tunnel_1" {
+  name                            = "ha-azure-vpn-tunnel-1"
+  vpn_gateway                     = google_compute_ha_vpn_gateway.target_gateway.self_link
+  shared_secret                   = var.shared_secret
+  peer_external_gateway           = google_compute_external_vpn_gateway.azure_gateway.self_link
+  peer_external_gateway_interface = 0
+  router                          = google_compute_router.vpn_router.name
+  ike_version                     = 2
+  vpn_gateway_interface           = 0
+}
+
+resource "google_compute_vpn_tunnel" "tunnel_2" {
+  name                            = "ha-azure-vpn-tunnel-2"
+  vpn_gateway                     = google_compute_ha_vpn_gateway.target_gateway.self_link
+  shared_secret                   = var.shared_secret
+  peer_external_gateway           = google_compute_external_vpn_gateway.azure_gateway.self_link
+  peer_external_gateway_interface = 1
+  router                          = google_compute_router.vpn_router.name
+  ike_version                     = 2
+  vpn_gateway_interface           = 1
+}
+
+resource "google_compute_router_interface" "router1_interface1" {
+  name       = "interface-1"
+  router     = google_compute_router.vpn_router.name
+  ip_range   = "169.254.21.2/30"
+  vpn_tunnel = google_compute_vpn_tunnel.tunnel_1.name
+}
+
+resource "google_compute_router_peer" "router1_peer1" {
+  name                      = "peer-1"
+  router                    = google_compute_router.vpn_router.name
+  peer_ip_address           = "169.254.21.1"
+  peer_asn                  = "65515"
+  advertised_route_priority = 100
+  interface                 = google_compute_router_interface.router1_interface1.name
+}
+
+resource "google_compute_router_interface" "router1_interface2" {
+  name       = "interface-2"
+  router     = google_compute_router.vpn_router.name
+  ip_range   = "169.254.22.2/30"
+  vpn_tunnel = google_compute_vpn_tunnel.tunnel_2.name
+}
+
+resource "google_compute_router_peer" "router1_peer2" {
+  name                      = "peer-2"
+  router                    = google_compute_router.vpn_router.name
+  peer_ip_address           = "169.254.22.1"
+  peer_asn                  = "65515"
+  advertised_route_priority = 100
+  interface                 = google_compute_router_interface.router1_interface2.name
+}

--- a/tools/gcp-azure-ha-vpn/outputs.tf
+++ b/tools/gcp-azure-ha-vpn/outputs.tf
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "gcp_vpn_gateway_ip1" {
+  value       = google_compute_ha_vpn_gateway.target_gateway.vpn_interfaces.0.ip_address
+  description = "GCP VPN Gateway IP address for the first VPN tunnel."
+}
+
+output "gcp_vpn_gateway_ip2" {
+  value       = google_compute_ha_vpn_gateway.target_gateway.vpn_interfaces.1.ip_address
+  description = "GCP VPN Gateway IP address for the second VPN tunnel."
+}
+
+output "gcp_peer_ip1" {
+  value       = google_compute_router_peer.router1_peer1.ip_address
+  description = "GCP BGP peer IP address for the first VPN tunnel."
+}
+
+output "gcp_peer_ip2" {
+  value       = google_compute_router_peer.router1_peer2.ip_address
+  description = "GCP BGP peer IP address for the second VPN tunnel."
+}
+
+output "azure_peer_ip1" {
+  value       = azurerm_virtual_network_gateway.azure_vpn_gateway.bgp_settings.0.peering_addresses[0].apipa_addresses[0]
+  description = "Azure BGP peer IP address for the first VPN tunnel."
+}
+
+output "azure_peer_ip2" {
+  value       = azurerm_virtual_network_gateway.azure_vpn_gateway.bgp_settings.0.peering_addresses[1].apipa_addresses[0]
+  description = "Azure BGP peer IP address for the second VPN tunnel."
+}
+
+output "azure_vpn_gateway_ip1" {
+  value       = azurerm_public_ip.azure_vpn_gateway_public_ip_1.ip_address
+  description = "Azure VPN Gateway Public IP address for the first VPN tunnel."
+}
+
+output "azure_vpn_gateway_ip2" {
+  value       = azurerm_public_ip.azure_vpn_gateway_public_ip_2.ip_address
+  description = "Azure VPN Gateway Public IP address for the second VPN tunnel."
+}

--- a/tools/gcp-azure-ha-vpn/provider.tf
+++ b/tools/gcp-azure-ha-vpn/provider.tf
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+# Required Terraform providers
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 4.60.0"
+    }
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 3.50.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+
+  subscription_id = var.azure_subscription_id
+}
+
+provider "google" {
+  region  = var.gcp_region
+  project = var.gcp_project_id
+}

--- a/tools/gcp-azure-ha-vpn/terraform.tfvars
+++ b/tools/gcp-azure-ha-vpn/terraform.tfvars
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+# GCP variables
+gcp_project_id           = "<GCP_PROJECT_ID>"
+gcp_region               = "<GCP_REGION>"
+gcp_vpc_name             = "<GCP_VPC_NAME>"
+gcp_router_name          = "<GCP_ROUTER_NAME>"
+gcp_subnet_ip_cidr_range = "<GCP_SUBNET_IP_CIDR_RANGE>"
+
+# Shared secret for VPN Tunnels
+shared_secret = "<SHARED_SECRET>"
+
+# Azure variables
+azure_resource_group  = "<AZURE_RESOURCE_GROUP>"
+azure_region          = "<AZURE_REGION>"
+azure_vnet_name       = "<AZURE_VNET_NAME>"
+azure_subscription_id = "<AZURE_SUBSCRIPTION_ID>"

--- a/tools/gcp-azure-ha-vpn/terraform.tfvars
+++ b/tools/gcp-azure-ha-vpn/terraform.tfvars
@@ -19,7 +19,6 @@ gcp_project_id           = "<GCP_PROJECT_ID>"
 gcp_region               = "<GCP_REGION>"
 gcp_vpc_name             = "<GCP_VPC_NAME>"
 gcp_router_name          = "<GCP_ROUTER_NAME>"
-gcp_subnet_ip_cidr_range = "<GCP_SUBNET_IP_CIDR_RANGE>"
 
 # Shared secret for VPN Tunnels
 shared_secret = "<SHARED_SECRET>"

--- a/tools/gcp-azure-ha-vpn/variables.tf
+++ b/tools/gcp-azure-ha-vpn/variables.tf
@@ -50,11 +50,6 @@ variable "azure_subscription_id" {
 }
 
 # GCP variables
-variable "gcp_subnet_ip_cidr_range" {
-  description = "GCP Subnet IP CIDR Range"
-  type        = string
-}
-
 variable "gcp_project_id" {
   description = "The GCP project ID."
   type        = string

--- a/tools/gcp-azure-ha-vpn/variables.tf
+++ b/tools/gcp-azure-ha-vpn/variables.tf
@@ -1,0 +1,89 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+# Azure variables
+variable "azure_resource_group" {
+  description = "Azure Resource Group"
+  type        = string
+}
+
+variable "azure_region" {
+  description = "Azure Region"
+  type        = string
+}
+
+variable "azure_vnet_name" {
+  description = "Azure Virtual Network Name"
+  type        = string
+}
+
+variable "azure_bgp_asn" {
+  description = "The Azure BGP ASN"
+  type        = string
+  default     = "65515"
+}
+
+variable "azure_vpn_sku" {
+  type        = string
+  default     = "VpnGw1"
+  description = "The Azure VPN Sku/Size"
+}
+
+variable "azure_subscription_id" {
+  type        = string
+  description = "The Azure Subscription ID"
+
+}
+
+# GCP variables
+variable "gcp_subnet_ip_cidr_range" {
+  description = "GCP Subnet IP CIDR Range"
+  type        = string
+}
+
+variable "gcp_project_id" {
+  description = "The GCP project ID."
+  type        = string
+}
+
+variable "gcp_region" {
+  description = "The GCP region."
+  type        = string
+}
+
+variable "gcp_vpc_name" {
+  description = "The GCP VPC name."
+  type        = string
+}
+
+variable "gcp_router_name" {
+  description = "The GCP VPN router name."
+  type        = string
+}
+
+variable "gcp_bgp_asn" {
+  description = "The GCP VPC Router ASN"
+  type        = string
+  default     = "65534"
+}
+
+# Shared secret
+variable "shared_secret" {
+  description = "The shared secret for the VPN connection."
+  type        = string
+  sensitive   = true
+}


### PR DESCRIPTION
This pull request adds a Terraform code for creating an HA VPN setup between Google Cloud Platform (GCP) and Microsoft Azure. The code is designed to be minimal in nature with less user input and auto public IP. The Terraform code creates resources such as VPC networks, subnets, routers, VPN gateways, and tunnels in both GCP and Azure.

The Azure and GCP configurations are split into separate files, namely azure.tf and gcp.tf, respectively. These files contain variables that are used to create resources specific to each cloud platform.

This pull request also includes a variables.tf file that defines the required variables for the Terraform code, a terraform.tfvars file that contains the values of the variables, an output.tf file that outputs the GCP and Azure Peer IPs and Gateway IPs, and a README.md file that provides instructions for creating the HA VPN setup and information about dynamic routing in Google Cloud and BGP in Microsoft Azure.