### PR TITLE
added example to host a static website on GCS and containerized backend on MIG

### DIFF
--- a/examples/gcs-static-website-example/.gitignore
+++ b/examples/gcs-static-website-example/.gitignore
@@ -1,0 +1,9 @@
+provider.tf
+project.tf
+
+.terraform/*
+.terraform
+.terraform*
+terraform.tfstate*
+
+terraform.tfvars

--- a/examples/gcs-static-website-example/README.md
+++ b/examples/gcs-static-website-example/README.md
@@ -1,0 +1,50 @@
+# Sample web app using GCS and GCE
+
+This code deploys a sample Web UI in a GCS bucket and a sample nodeJS based backend as container on a MIG.
+
+A GCLB exposes frontend and backend under a joined domain, exposing the backend service via the /api path.
+
+## How to deploy
+
+If you are using a Service Account to deploy the Terraform script, you can add the following line to the google provider in the providers.tf file:
+
+`impersonate_service_account = "SA_EMAIL"`
+
+Terraform will automatically impersonate this service account when deploying the infrastructure. The account which gcloud is currently authenticated with needs to have the "Service Account Token Creator" role on the service account. You can find out which account is currently authenticated with gcloud running `gcloud auth list`. If you are not logged in yet, run `gcloud auth login` to login.
+
+Keep in mind that your currently authenticated user still needs permission to access the state bucket, if you are using one.
+
+## Deploy the infrastructure via Terraform
+
+Run `terraform init` and `terraform apply`. 
+
+## Create the A record for your domain
+
+From the outputs, copy the IP address of the newly created load balancer. Register a new A record with yoru domain provider. The domain must be an exact match to the one you set as variable before running the script.
+
+## Deploy the backend application
+
+Authenticate against Artifact Registry:
+
+`gcloud auth configure-docker REGION.pkg.dev`
+
+Go to the src/backend folder and build the docker image to your newly created artifact registry:
+
+`docker build -t REGION-docker.pkg.dev/PROJECT_ID/image-repo/webserver:v1 .`
+
+Push the docker image to the registry:
+
+`docker push REGION-docker.pkg.dev/PROJECT_ID/image-repo/webserver:v1`
+
+## Update the cloud-init file
+
+Go to config/cloud-init.yaml and updated the following lines with your region and project ID:
+
+`ExecStartPre=/usr/bin/docker-credential-gcr configure-docker --registries REGION-docker.pkg.dev`
+
+`ExecStart=/usr/bin/docker run --rm --name webserver -p 80:80 REGION.pkg.dev/PROJECT_ID/image-repo/webserver:v1`
+
+
+## Apply the changes
+
+Run `terraform apply` to apply the changes. Now you can reach your frontend under your-domain.com and the backend app under your-domain.com/api

--- a/examples/gcs-static-website-example/artifact-registry.tf
+++ b/examples/gcs-static-website-example/artifact-registry.tf
@@ -1,0 +1,29 @@
+#    Copyright 2023 Google LLC
+
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+
+#        http://www.apache.org/licenses/LICENSE-2.0
+
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+resource "google_artifact_registry_repository" "image-repo" {
+  location      = var.region
+  repository_id = "image-repo"
+  description   = "Docker repository"
+  format        = "DOCKER"
+  depends_on = [google_project_service.apis]
+}
+
+resource "google_artifact_registry_repository_iam_member" "member" {
+  project = google_artifact_registry_repository.image-repo.project
+  location = google_artifact_registry_repository.image-repo.location
+  repository = google_artifact_registry_repository.image-repo.name
+  role = "roles/artifactregistry.reader"
+  member = "serviceAccount:${google_service_account.gce_sa.email}"
+}

--- a/examples/gcs-static-website-example/config/cloud-init.yaml
+++ b/examples/gcs-static-website-example/config/cloud-init.yaml
@@ -1,0 +1,26 @@
+# Copyright 2023 Google.
+# This software is provided as-is, without warranty or representation for any use or purpose.
+# Your use of it is subject to your agreement with Google.
+
+#cloud-config
+
+write_files:
+- path: /etc/systemd/system/nginx.service
+  permissions: 0644
+  owner: root
+  content: |
+    [Unit]
+    Description=Start a simple nginx docker container
+    Wants=gcr-online.target
+    After=gcr-online.target
+
+    [Service]
+    Environment="HOME=/home/nginx"
+    ExecStartPre=/usr/bin/docker-credential-gcr configure-docker --registries REGION-docker.pkg.dev
+    ExecStart=/usr/bin/docker run --rm --name webserver -p 80:80 /usr/bin/docker run --rm --name webserver -p 80:80 REGION.pkg.dev/gPROJECT_ID/image-repo/webserver:v1
+    ExecStop=/usr/bin/docker stop webserver
+    ExecStopPost=/usr/bin/docker rm webserver
+
+runcmd:
+- systemctl daemon-reload
+- systemctl start nginx.service

--- a/examples/gcs-static-website-example/gcs.tf
+++ b/examples/gcs-static-website-example/gcs.tf
@@ -1,0 +1,44 @@
+#    Copyright 2023 Google LLC
+
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+
+#        http://www.apache.org/licenses/LICENSE-2.0
+
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+resource "google_storage_bucket" "static_website" {
+  project = google_project.project.project_id
+
+  name          = "static_website_example"
+  location      = var.region
+
+  website {
+    main_page_suffix = "index.html"
+    not_found_page   = "404.html"
+  }
+}
+
+resource "google_storage_bucket_object" "index_html" {
+  name   = "index.html"
+  source = "./src/static/index.html"
+  bucket = google_storage_bucket.static_website.name
+}
+
+resource "google_storage_bucket_object" "not_found_html" {
+  name   = "404.html"
+  source = "./src/static/404.html"
+  bucket = google_storage_bucket.static_website.name
+}
+
+# Make bucket public by granting allUsers READER access
+resource "google_storage_bucket_iam_member" "public_bucket" {
+  bucket = google_storage_bucket.static_website.name
+  role = "roles/storage.objectViewer"
+  member = "allUsers"
+}

--- a/examples/gcs-static-website-example/load_balancer.tf
+++ b/examples/gcs-static-website-example/load_balancer.tf
@@ -1,0 +1,119 @@
+#    Copyright 2023 Google LLC
+
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+
+#        http://www.apache.org/licenses/LICENSE-2.0
+
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+locals {
+  health_check = {
+    check_interval_sec  = 15
+    timeout_sec         = null
+    healthy_threshold   = null
+    unhealthy_threshold = null
+    request_path        = "/"
+    port                = 80
+    host                = null
+    logging             = null
+  }
+}
+
+# Create a classic load balancer with https redirect
+module "gce-lb-https" {
+  source  = "GoogleCloudPlatform/lb-http/google"
+  version = "~> 9.0"
+  name    = google_compute_network.default.name
+  project = data.google_project.project.project_id
+  firewall_networks = [google_compute_network.default.self_link]
+  url_map           = google_compute_url_map.ml-bkd-ml-mig-bckt-s-lb.self_link
+  create_url_map    = false
+  ssl               = true
+  https_redirect = true
+  managed_ssl_certificate_domains = [var.domain]
+
+  backends = {
+    api = {
+      description                     = null
+      protocol                        = "HTTP"
+      port                            = 80
+      port_name                       = "http"
+      timeout_sec                     = 10
+      connection_draining_timeout_sec = null
+      enable_cdn                      = false
+      edge_security_policy            = null
+      security_policy                 = null
+      session_affinity                = null
+      affinity_cookie_ttl_sec         = null
+      custom_request_headers          = null
+      custom_response_headers         = null
+      compression_mode                = null
+
+      health_check = local.health_check
+      log_config = {
+        enable      = true
+        sample_rate = 1.0
+      }
+
+      groups = [
+        {
+          group                        = module.webserver.instance_group # google_compute_instance_group.webserver.self_link
+          balancing_mode               = null
+          capacity_scaler              = null
+          description                  = null
+          max_connections              = null
+          max_connections_per_instance = null
+          max_connections_per_endpoint = null
+          max_rate                     = null
+          max_rate_per_instance        = null
+          max_rate_per_endpoint        = null
+          max_utilization              = null
+        }
+      ]
+
+      iap_config = {
+        enable               = false
+        oauth2_client_id     = ""
+        oauth2_client_secret = ""
+      }
+    }
+  }
+}
+
+resource "google_compute_backend_bucket" "static_website" {
+  project = data.google_project.project.project_id
+  name        = "static-website-backend-bucket"
+  description = "Contains a static website"
+  bucket_name = google_storage_bucket.static_website.name
+  enable_cdn  = true
+}
+
+resource "google_compute_url_map" "ml-bkd-ml-mig-bckt-s-lb" {
+  // note that this is the name of the load balancer
+  name            = google_compute_network.default.name
+  default_service = google_compute_backend_bucket.static_website.self_link
+
+  host_rule {
+    hosts        = ["*"]
+    path_matcher = "allpaths"
+  }
+
+  path_matcher {
+    name            = "allpaths"
+    default_service = google_compute_backend_bucket.static_website.self_link
+
+    path_rule {
+      paths = [
+        "/api",
+        "/api/*"
+      ]
+      service = module.gce-lb-https.backend_services["api"].self_link
+    }
+  }
+}

--- a/examples/gcs-static-website-example/main.tf
+++ b/examples/gcs-static-website-example/main.tf
@@ -1,0 +1,35 @@
+#    Copyright 2023 Google LLC
+
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+
+#        http://www.apache.org/licenses/LICENSE-2.0
+
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+data "google_project" "project" {
+    project_id = var.project_id
+}
+
+locals {
+  apis_to_enable = [
+    "iam.googleapis.com",
+    "storage.googleapis.com",
+    "compute.googleapis.com",
+    "artifactregistry.googleapis.com"
+  ]
+}
+
+# Enable APIs
+resource "google_project_service" "apis" {
+  for_each = toset(local.apis_to_enable)
+  service = each.key
+
+  project = google_project.project.project_id
+}
+

--- a/examples/gcs-static-website-example/mig.tf
+++ b/examples/gcs-static-website-example/mig.tf
@@ -1,0 +1,49 @@
+#    Copyright 2023 Google LLC
+
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+
+#        http://www.apache.org/licenses/LICENSE-2.0
+
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+module "gce_template" {
+  source     = "terraform-google-modules/vm/google//modules/instance_template"
+  version    = "~> 7.9"
+  network    = google_compute_network.default.self_link
+  subnetwork = google_compute_subnetwork.subnet.self_link
+  service_account = {
+    email  = google_service_account.gce_sa.email
+    scopes = ["cloud-platform"]
+  }
+  name_prefix          = "container-vm"
+  metadata = {
+    user-data = file("${path.module}/config/cloud-init.yaml")
+  }
+  source_image_family  = "cos-stable"
+  source_image_project = "cos-cloud"
+  tags = ["allow-iap-ssh", "allow-http"]
+  depends_on = [ google_project_service.apis ]
+}
+
+resource "google_service_account" "gce_sa" {
+  account_id = "gce-backend"
+}
+
+module "webserver" {
+  source            = "terraform-google-modules/vm/google//modules/mig"
+  project_id        = data.google_project.project.project_id
+  region            = var.region
+  target_size       = 1
+  hostname          = "webserver"
+  instance_template = module.gce_template.self_link
+  named_ports =[{
+    name = "http"
+    port = "80"
+  }]
+}

--- a/examples/gcs-static-website-example/network.tf
+++ b/examples/gcs-static-website-example/network.tf
@@ -1,0 +1,77 @@
+#    Copyright 2023 Google LLC
+
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+
+#        http://www.apache.org/licenses/LICENSE-2.0
+
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+resource "google_compute_network" "default" {
+  name                    = "vpc-network"
+  project = data.google_project.project.project_id
+  auto_create_subnetworks = "false"
+}
+
+resource "google_compute_subnetwork" "subnet" {
+  name                     = "subnet"
+  ip_cidr_range            = "10.125.0.0/20"
+  network                  = google_compute_network.default.self_link
+  region                   = var.region
+  private_ip_google_access = true
+}
+
+# Router and Cloud NAT are required for installing packages from repos (apache, php etc)
+module "cloud-nat" {
+  source     = "terraform-google-modules/cloud-nat/google"
+  version    = "~> 1.2"
+  project_id = data.google_project.project.project_id
+  region     = var.region
+  router     = module.cloud_router.router.name
+}
+
+module "cloud_router" {
+  source  = "terraform-google-modules/cloud-router/google"
+  version = "~> 5.0"
+  name    = "nat-router"
+  project = data.google_project.project.project_id
+  region  = var.region
+  network = google_compute_network.default.name
+}
+
+# SSH is optional, but helpful for debugging. For extra security, limit to IAP ranges only and 
+# ssh into VM via Google Cloud Console
+resource "google_compute_firewall" "allow-iap-ssh" {
+  name        = "allow-iap-ssh"
+  network     = google_compute_network.default.name
+  description = "Creates firewall rule targeting tagged instances"
+
+  allow {
+    protocol  = "tcp"
+    ports     = ["22"]
+  }
+
+  source_ranges = ["35.235.240.0/20"]
+  target_tags = ["allow-iap-ssh"]
+}
+
+
+# Allow HTTP requests from GCLB (classic) ranges only. This is also required for health checks.
+resource "google_compute_firewall" "allow-http" {
+  name        = "allow-http"
+  network     = google_compute_network.default.name
+  description = "Creates firewall rule targeting tagged instances"
+
+  allow {
+    protocol  = "tcp"
+    ports     = ["80"]
+  }
+
+  source_ranges = ["130.211.0.0/22","35.191.0.0/16"]
+  target_tags = ["allow-http"]
+}

--- a/examples/gcs-static-website-example/outputs.tf
+++ b/examples/gcs-static-website-example/outputs.tf
@@ -1,0 +1,17 @@
+#    Copyright 2023 Google LLC
+
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+
+#        http://www.apache.org/licenses/LICENSE-2.0
+
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+output "load_balancer_ip" {
+  value = module.gce-lb-https.external_ip
+}

--- a/examples/gcs-static-website-example/providers.tf
+++ b/examples/gcs-static-website-example/providers.tf
@@ -1,0 +1,17 @@
+#    Copyright 2023 Google LLC
+
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+
+#        http://www.apache.org/licenses/LICENSE-2.0
+
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+provider "google" {
+  project = var.project_id
+}

--- a/examples/gcs-static-website-example/src/backend/Dockerfile
+++ b/examples/gcs-static-website-example/src/backend/Dockerfile
@@ -1,0 +1,28 @@
+#    Copyright 2023 Google LLC
+
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+
+#        http://www.apache.org/licenses/LICENSE-2.0
+
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+FROM node:14-alpine
+
+WORKDIR /app
+
+COPY package.json ./
+COPY package-lock.json ./
+
+RUN npm install
+
+COPY . .
+
+EXPOSE 80
+
+CMD ["npm", "start"]

--- a/examples/gcs-static-website-example/src/backend/backend.js
+++ b/examples/gcs-static-website-example/src/backend/backend.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const http = require('http');
+
+const webserver = http.createServer((req, res) => {
+  res.writeHead(200, { 'Content-Type': 'text/plain' });
+  res.write(`Method: ${req.method}\n`);
+  res.write(`Path: ${req.url}\n`);
+  res.end();
+});
+
+webserver.listen(80, () => {
+  console.log('Server is running on port 80');
+});

--- a/examples/gcs-static-website-example/src/backend/package.json
+++ b/examples/gcs-static-website-example/src/backend/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "simple-webserver",
+    "main": "backend.js",
+    "scripts": {
+      "start": "node backend.js"
+    }
+  }
+  

--- a/examples/gcs-static-website-example/src/static/404.html
+++ b/examples/gcs-static-website-example/src/static/404.html
@@ -1,0 +1,15 @@
+<!-- Copyright 2023 Google.
+This software is provided as-is, without warranty or representation for any use or purpose.
+Your use of it is subject to your agreement with Google.
+-->
+<!DOCTYPE html>
+<html>
+<head>
+  <title>404 - Not found</title>
+</head>
+<body>
+
+The page you were looking for could not be found... This is a simple example, so please stick to the index file.
+
+</body>
+</html>

--- a/examples/gcs-static-website-example/src/static/index.html
+++ b/examples/gcs-static-website-example/src/static/index.html
@@ -1,0 +1,15 @@
+<!-- Copyright 2023 Google.
+This software is provided as-is, without warranty or representation for any use or purpose.
+Your use of it is subject to your agreement with Google.
+-->
+<!DOCTYPE html>
+<html>
+<head>
+  <title>GCS Static Website Hosting</title>
+</head>
+<body>
+
+Hello from Google Cloud Storage!
+
+</body>
+</html>

--- a/examples/gcs-static-website-example/variables.tf
+++ b/examples/gcs-static-website-example/variables.tf
@@ -1,0 +1,20 @@
+/* Copyright 2023 Google.
+This software is provided as-is, without warranty or representation for any use or purpose.
+Your use of it is subject to your agreement with Google.
+*/
+
+variable "region" {
+    type = string
+    description = "Region in which the Google Cloud Services should be deployed"
+}
+
+variable "project_id" {
+    type = string
+    description = "Google Cloud Project ID"
+}
+
+variable "domain" {
+    type = string
+    description = "Domain under which the load balancer should be reachable"
+  
+}


### PR DESCRIPTION
Added an example that creates a load balancer which serves a static frontend hosted on GCS and containerized NodeJS backend hosted on a MIG.