### PR TITLE
Improving error message in case the  Cloud Billing API is not enabled

### DIFF
--- a/examples/billboard/billboard.py
+++ b/examples/billboard/billboard.py
@@ -297,7 +297,7 @@ def main(argv):
         project_billing_info = billing.CloudBillingClient(
         ).get_project_billing_info(name=project_id_temp)
     except PermissionDenied:
-        print("Permission Denied, check project level permission.")
+        print("Permission Denied, check project level permission or if the Cloud Billing API is enabled")
         return sys.exit(1)
 
     billing_account_name = project_billing_info.billing_account_name.split(


### PR DESCRIPTION
Changed the error message from:

        print("Permission Denied, check project level permission.")
        
to:

        print("Permission Denied, check project level permission or if the Cloud Billing API is enabled")
        
as the pervious one is not indicating the issue may be related to the Cloud Billing API to be disable. 