### PR TITLE
Update shellcheck to look for external bash file binding

### DIFF
--- a/helpers/check_format.sh
+++ b/helpers/check_format.sh
@@ -50,7 +50,7 @@ validate_bash() {
     then
         for FILE_TO_CHECK in $FILES_TO_CHECK
         do
-            if ! shellcheck "$FILE_TO_CHECK";
+            if ! shellcheck -x "$FILE_TO_CHECK";
             then
                 FILES_TO_LINT+="$FILE_TO_CHECK "
             fi


### PR DESCRIPTION
Updating tests for shell files by adding external source file check flag to shellcheck command. In accordance to this documentation: https://www.shellcheck.net/wiki/SC1091
