### PR TITLE
Adding code for IAP IDP Connect

### DIFF
--- a/examples/iap-idp-connect/README.md
+++ b/examples/iap-idp-connect/README.md
@@ -1,0 +1,51 @@
+# iap-idp-connect
+
+## Introduction
+
+This service programmatically connects IAP (Identity Aware Proxy) to IdP (Identity Platform) in Google Cloud Platform.
+By This program, you connect Identity providers (including multi-tenants) with IAP (Identity Aware Proxy) backend services
+For example, you connect SAML integrations defined under identity platform for tenant A with backend-service-1 in IAP.
+Additionally:
+* You can also configure the sign-in page created automatically or custom developed by developers by providing the sign_in_url.
+* You can also provide the api key attached to the sign-in page
+
+
+## Pre-requisite and setting up dependencies
+
+* Install python 3, pip 3 (Make sure Python version is 3.10)
+* Setup application dependencies:
+
+  * Use your user account
+    - Run `gcloud auth application-default login`
+  * Use service account (preferred)
+    - set environment variable `export GOOGLE_APPLICATION_CREDENTIALS=path/to/your/service_accont_key_file.json`.
+    - You can follow [this](https://developers.google.com/workspace/guides/create-credentials#create_credentials_for_a_service_account) to get the key file. 
+  * Run the following commands
+    * `gcloud init`
+    * `sh ./setup_dependencies.sh <PROJECT_ID> <MEMBER>`
+       
+        - PROJECT_ID:  is your project id
+        - MEMBER: is serviceAccount:<service account email> or user:<your user id>
+    * Run `pip3 install -r requirements.txt` to install all the python dependencies
+    
+  
+## Running the application
+
+Now since you have everything setup you run the program by the following command
+
+`python3 connect.py --project <project_id> --sign_in_url <sign_in_url>`
+
+
+You can add additional parameters
+
+
+* `--project` (required) 'Provide the project id'
+* `--sign_in_url` (required) 'Provide the sign in url for the custom login url page or the one created by GCP'
+* `--tenant_ids` (optional) 'Provide the tenant ids you want the backend services to'
+* `--backend_services` (optional) 'Provide the backend service names for which you want the IAP resource to be updated'
+* `--api_key` (optional) 'Provide the api key for the sign_in url'
+
+
+
+
+

--- a/examples/iap-idp-connect/connect.py
+++ b/examples/iap-idp-connect/connect.py
@@ -1,0 +1,330 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import sys
+import argparse
+import firebase_admin
+import google.auth
+from google.cloud import compute_v1, iap_v1, api_keys_v2
+from firebase_admin import tenant_mgt
+from exceptions.connector_exception import ConnectorException
+from utils.validator import validate_comma_separated_string
+
+"""
+
+    This method updates the IAP setting that is connecting IAP with IDP
+
+    Args:
+        credentials: credential for backend service client
+        project_id:  project_id for which we want to get the backend services for
+        backend: backend service to connect
+        api_key_arg: api key string for the sign in url
+        tenant_ids: list of tenants to be enabled that connect for
+    Returns:
+    Raises:
+        ConnectorException if the update IAP settings call fails
+
+"""
+
+
+def update_iap_settings(
+        credentials, project_id, sign_in_url, backend, api_key_arg, tenant_ids
+):
+    # Initialize the IAP Admin client
+    client = iap_v1.IdentityAwareProxyAdminServiceClient(credentials=credentials)
+
+    # Prepare the backend service resource name
+    backend_service_resource_name = (
+        f"projects/{project_id}/iap_web/compute/services/{backend}"
+    )
+    sign_in_url = f"{sign_in_url}?apiKey={api_key_arg}"
+    # Prepare the IAP settings update
+    request = {
+        "iap_settings": {
+            "name": backend_service_resource_name,
+            "access_settings": {
+                "gcip_settings": {
+                    "tenant_ids": tenant_ids,
+                    "login_page_uri": sign_in_url,
+                }
+            },
+        }
+    }
+
+    # Update the IAP settings for the backend service
+    response = None
+    try:
+        response = client.update_iap_settings(request=request)
+    except Exception as e:
+        raise ConnectorException(e)
+
+    print(
+        f"IAP settings updated successfully for backend: {backend} with response: {response}"
+    )
+    return response
+
+
+"""
+
+    This method gets firebase api key string if not provided explicitly
+
+    Args:
+        credentials: credential for api key client
+        project_id:  project_id for which we want to get the api keys for
+   
+    Returns:
+        get the api key string
+    Raises:
+        ConnectorException if firebase api key is not found
+"""
+
+
+def get_firebase_api_key_string(credentials, project_id):
+    client = api_keys_v2.ApiKeysClient(credentials=credentials)
+    # Initialize request argument(s)
+    request = api_keys_v2.ListKeysRequest(
+        parent=f"projects/{project_id}/locations/global",
+    )
+
+    # Make the request
+    page_result = client.list_keys(request=request)
+    # print(page_result)
+    firebase_substring = "Browser key (auto created by Firebase)"
+    # Handle the response
+    for response in page_result:
+        print(response)
+        if "display_name" in response and firebase_substring in response.display_name:
+            print("getting the key string value")
+            # Initialize request argument(s)
+            request = api_keys_v2.GetKeyStringRequest(name=response.name)
+
+            # Make the request
+            response = client.get_key_string(request=request)
+
+            # Handle the response
+            print(f"Key String is {response}")
+            return response.key_string
+    """
+        If we come here that means we don't have a firebase api key string generated from cloud run deploy or deployment 
+        on Firebase SDK and we dont have a api key provided explicitly. In such cases, we will raise the exception 
+        telling the user to provide one
+    """
+    raise ConnectorException(
+        "Could not find firebase api key, please provide the api key attached to sign in page"
+    )
+
+
+"""
+
+    This method gets all the backend services in the project
+
+    Args:
+        credentials: credential for backend service client
+        project_id:  project_id for which we want to get the backend services for
+   
+    Returns:
+        all the backend services in the project
+    Raises:
+
+"""
+
+
+def get_all_backend_service_names(credentials, project_id):
+    # Getting the backend service names
+    client = compute_v1.BackendServicesClient(credentials=credentials)
+
+    backend_service_list = client.list(project=project_id)
+
+    # Get the backend list
+    backend_service_names = []
+
+    for backend_service in backend_service_list:
+        print(f"Adding Backend Service name: {backend_service}")
+        backend_service_names.append(backend_service.name)
+
+    print(f"All Backend Names={backend_service_names}")
+    return backend_service_names
+
+
+"""
+
+    This method gets all the tenant ids in the project
+
+    Args:
+   
+    Returns:
+        all the tenant ids in the project
+    Raises:
+
+"""
+
+
+def get_all_tenant_ids():
+    valid_tenant_ids = []
+    firebase_admin.initialize_app()
+    for tenant in tenant_mgt.list_tenants().iterate_all():
+        valid_tenant_ids.append(tenant.tenant_id)
+    print(f"Valid Tenant Ids={valid_tenant_ids}")
+    return valid_tenant_ids
+
+
+"""
+
+    This method checks if all backend services in backend_services are part of the all_services and return the result 
+    as well as the list of unmatched backend services
+
+    Args:
+        all_services: list of all valid backend services in the project
+        backend_services:  list of the backend services to be plugged
+   
+    Returns:
+        is backend_services subset of all_services, list of unmatched backend services
+    Raises:
+
+"""
+
+
+def validate_backend_services(all_services, backend_services):
+    return set(all_services).issuperset(set(backend_services)), list(
+        set(backend_services) - set(all_services)
+    )
+
+
+"""
+
+    This method checks if all tenant ids in backend_tenant_ids are part of the valid tenant ids and return the result 
+    as well as the list of unmatched tenant_ids
+
+    Args:
+        all_tenant_ids: list of all valid tenant ids in the project
+        tenant_ids:  list of the tenant ids to be plugged
+   
+    Returns:
+        is tenant_ids subset of all_tenant_ids, list of unmatched tenant ids
+    Raises:
+
+"""
+
+
+def validate_tenant_ids(all_tenant_ids, tenant_ids):
+    return set(all_tenant_ids).issuperset(set(tenant_ids)), list(
+        set(tenant_ids) - set(all_tenant_ids)
+    )
+
+
+def run(
+        credentials,
+        project_id,
+        sign_in_url,
+        tenant_ids_arg,
+        backend_services_arg,
+        api_key_arg,
+):
+    backend_service_names = get_all_backend_service_names(credentials, project_id)
+    if backend_services_arg is not None:
+        backend_services_arg = backend_services_arg.split(",")
+        is_valid, unmatched_backend_list = validate_backend_services(
+            backend_service_names, backend_services_arg
+        )
+        if not is_valid:
+            raise ConnectorException(
+                f"Please provide the valid backends. These are the invalid backend"
+                f" {unmatched_backend_list}"
+            )
+        backend_service_names = backend_services_arg
+
+    tenant_ids = get_all_tenant_ids()
+
+    if tenant_ids_arg is not None:
+        tenant_ids_arg = tenant_ids_arg.split(",")
+        is_valid, unmatched_tenant_ids = validate_tenant_ids(tenant_ids, tenant_ids_arg)
+        if not is_valid:
+            raise ConnectorException(
+                f"Please provide the valid tenant ids. These are the invalid tenants"
+                f" {unmatched_tenant_ids}"
+            )
+        tenant_ids = tenant_ids_arg
+
+    for backend in backend_service_names:
+        if api_key_arg is None:
+            api_key_arg = get_firebase_api_key_string(credentials, project_id)
+        print(f"Processing backend {backend}")
+        update_iap_settings(
+            credentials, project_id, sign_in_url, backend, api_key_arg, tenant_ids
+        )
+
+
+def main(argv):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--project", required=True, help="Provide the project id")
+    parser.add_argument(
+        "--sign_in_url",
+        required=True,
+        help="Provide the sign in url for the custom login url page "
+             "or the one created by GCP",
+    )
+    parser.add_argument(
+        "--tenant_ids",
+        required=False,
+        help="Provide the tenant ids you want the backend services to "
+             "be updated with",
+        default=None,
+    )
+    parser.add_argument(
+        "--backend_services",
+        required=False,
+        help="Provide the backend service names for which you "
+             "want the IAP resource to be updated",
+        default=None,
+    )
+    parser.add_argument(
+        "--api_key",
+        required=False,
+        help="Provide the api key for the sign_in url",
+        default=None,
+    )
+
+    args = parser.parse_args(argv)
+
+    if args.tenant_ids is not None and not validate_comma_separated_string(
+            args.tenant_ids
+    ):
+        raise ConnectorException(
+            f"Validation failed for input_string {args.tenant_ids} to follow comma separated regex"
+        )
+
+    if args.backend_services is not None and not validate_comma_separated_string(
+            args.backend_services
+    ):
+        raise ConnectorException(
+            f"Validation failed for input_string {args.backend_services} to follow "
+            f"comma separated regex"
+        )
+    """
+    TODO Write validate function
+    """
+    # Get the default credentials for the current
+    # environment.https://google-auth.readthedocs.io/en/master/reference/google.auth.html
+    credentials, _ = google.auth.default()
+    run(
+        credentials,
+        args.project,
+        args.sign_in_url,
+        args.tenant_ids,
+        args.backend_services,
+        args.api_key,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/examples/iap-idp-connect/connect_test.py
+++ b/examples/iap-idp-connect/connect_test.py
@@ -1,0 +1,199 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from connect import (
+    update_iap_settings,
+    get_firebase_api_key_string,
+    validate_backend_services,
+    validate_tenant_ids,
+)
+from exceptions.connector_exception import ConnectorException
+import pytest
+from google.cloud import api_keys_v2
+from unittest.mock import patch, Mock
+
+
+# Define a test case
+def test_validate_tenant_ids():
+    # Mock the function's external dependencies using patch
+    with patch("connect.set") as mock_set:
+        # Mock the behavior of set() for the input data
+        mock_set.return_value.issuperset.return_value = True
+        mock_set.return_value.__sub__.return_value = set()
+
+        # Input data
+        all_tenant_ids = [1, 2, 3, 4, 5]
+        tenant_ids_to_check = [3, 4, 6]
+
+        # Call the function
+        is_valid, missing_tenants = validate_tenant_ids(
+            all_tenant_ids, tenant_ids_to_check
+        )
+
+    # Assertions
+    assert is_valid is True
+    assert missing_tenants == []
+
+
+def test_validate_backend_services():
+    # Mock the function's external dependencies using patch
+    with patch("connect.set") as mock_set:
+        # Mock the behavior of set() for the input data
+        mock_set.return_value.issuperset.return_value = True
+        mock_set.return_value.__sub__.return_value = set()
+
+        # Input data
+        all_tenant_ids = [1, 2, 3, 4, 5]
+        tenant_ids_to_check = [3, 4, 6]
+
+        # Call the function
+        is_valid, missing_tenants = validate_backend_services(
+            all_tenant_ids, tenant_ids_to_check
+        )
+
+    # Assertions
+    assert is_valid is True
+    assert missing_tenants == []
+
+
+# Define a test case
+# Define a test case
+def test_update_iap_settings_positive():
+    # Mock the IdentityAwareProxyAdminServiceClient and its methods
+    mock_client = Mock()
+    mock_update_iap_settings = Mock()
+    mock_client.update_iap_settings = mock_update_iap_settings
+
+    # Mock the credentials and other function arguments
+    credentials = Mock()
+    project_id = "your-project-id"
+    sign_in_url = "https://example.com/signin"
+    backend = "your-backend-service"
+    api_key_arg = "your-api-key"
+    tenant_ids = ["tenant1", "tenant2"]
+    # Assertions
+    expected_backend_service_resource_name = (
+        f"projects/{project_id}/iap_web/compute/services/{backend}"
+    )
+    expected_sign_in_url = f"{sign_in_url}?apiKey={api_key_arg}"
+    expected_request = {
+        "iap_settings": {
+            "name": expected_backend_service_resource_name,
+            "access_settings": {
+                "gcip_settings": {
+                    "tenant_ids": tenant_ids,
+                    "login_page_uri": expected_sign_in_url,
+                }
+            },
+        }
+    }
+
+    mock_update_iap_settings.return_value = expected_request
+    # Call the function with mocks
+    with patch(
+        "connect.iap_v1.IdentityAwareProxyAdminServiceClient", return_value=mock_client
+    ):
+        response = update_iap_settings(
+            credentials, project_id, sign_in_url, backend, api_key_arg, tenant_ids
+        )
+
+    mock_update_iap_settings.assert_called_once_with(request=expected_request)
+    assert (
+        response["iap_settings"]["name"]
+        == "projects/your-project-id/iap_web/compute/services/your-backend-service"
+    )
+    assert response["iap_settings"]["access_settings"] == {
+        "gcip_settings": {
+            "tenant_ids": tenant_ids,
+            "login_page_uri": expected_sign_in_url,
+        }
+    }
+
+
+def test_update_iap_settings_negative():
+    # Prepare some dummy input values
+    credentials = None  # Replace with valid credentials if necessary
+    project_id = "my-project"
+    sign_in_url = "https://example.com/signin"
+    backend = "my-backend"
+    api_key_arg = "my-api-key"
+    tenant_ids = ["tenant1", "tenant2"]
+
+    # Simulate a scenario where an exception is raised when calling update_iap_settings
+    with pytest.raises(ConnectorException):
+        update_iap_settings(
+            credentials, project_id, sign_in_url, backend, api_key_arg, tenant_ids
+        )
+
+
+def create_pager(display_name="Browser key (auto created by Firebase)"):
+    # Your sample data
+    key = api_keys_v2.types.Key(
+        name="projects/dummy/locations/global/keys/dummy", display_name=display_name
+    )
+    response = api_keys_v2.types.ListKeysResponse(keys=[key])
+    pager = api_keys_v2.services.api_keys.pagers.ListKeysPager(
+        response=response, method=None, request=None
+    )
+    return pager
+
+
+def test_get_firebase_api_key_string_positive():
+    # Mock the IdentityAwareProxyAdminServiceClient and its methods
+    mock_key_client = Mock()
+    mock_get_key_string = Mock()
+    mock_key_client.get_key_string = mock_get_key_string
+
+    mock_list = Mock()
+    mock_key_client.list_keys = mock_list
+
+    # Mock the credentials and other function arguments
+    credentials = Mock()
+    project_id = "your-project-id"
+
+    mock_list.return_value = create_pager()
+    mock_get_key_string.return_value = api_keys_v2.types.GetKeyStringResponse(
+        key_string="dummy"
+    )
+
+    # Call the function with mocks
+    with patch("connect.api_keys_v2.ApiKeysClient", return_value=mock_key_client):
+        response = get_firebase_api_key_string(credentials, project_id)
+
+    print(response)
+    assert response == "dummy"
+
+
+def test_get_firebase_api_key_string_negative():
+    # Mock the IdentityAwareProxyAdminServiceClient and its methods
+    mock_key_client = Mock()
+    mock_get_key_string = Mock()
+    mock_key_client.get_key_string = mock_get_key_string
+
+    mock_list = Mock()
+    mock_key_client.list_keys = mock_list
+
+    # Mock the credentials and other function arguments
+    credentials = Mock()
+    project_id = "your-project-id"
+
+    mock_list.return_value = create_pager(display_name="dummy")
+    mock_get_key_string.return_value = api_keys_v2.types.GetKeyStringResponse(
+        key_string="dummy"
+    )
+
+    # Call the function with mocks
+    with patch("connect.api_keys_v2.ApiKeysClient", return_value=mock_key_client):
+        with pytest.raises(ConnectorException):
+            get_firebase_api_key_string(credentials, project_id)

--- a/examples/iap-idp-connect/exceptions/connector_exception.py
+++ b/examples/iap-idp-connect/exceptions/connector_exception.py
@@ -1,0 +1,18 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class ConnectorException(Exception):
+    def __init__(self, message):
+        # Call the base class constructor with the parameters it needs
+        super().__init__(message)

--- a/examples/iap-idp-connect/requirements.txt
+++ b/examples/iap-idp-connect/requirements.txt
@@ -1,0 +1,7 @@
+google-cloud-compute
+google-auth
+firebase-admin
+google-cloud-iap
+google-cloud-api-keys
+pytest
+pylint[spelling]

--- a/examples/iap-idp-connect/setup_dependencies.sh
+++ b/examples/iap-idp-connect/setup_dependencies.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Check if both parameters are provided
+if [ -z "$1" ] || [ -z "$2" ]; then
+  echo "Usage: $0 <PROJECT_ID> <MEMBER>"
+  exit 1
+fi
+
+PROJECT_ID="$1"
+MEMBER="$2"
+
+# Enable Compute Engine API and assign roles
+gcloud services enable compute.googleapis.com
+gcloud projects add-iam-policy-binding "$PROJECT_ID" --member="$MEMBER" --role="roles/compute.networkAdmin"
+
+# Enable Identity Toolkit API and assign roles
+gcloud services enable identitytoolkit.googleapis.com
+gcloud projects add-iam-policy-binding "$PROJECT_ID" --member="$MEMBER" --role="roles/identitytoolkit.viewer"
+
+# Enable Cloud Identity-Aware Proxy (IAP) API and assign roles
+gcloud services enable iap.googleapis.com
+gcloud projects add-iam-policy-binding "$PROJECT_ID" --member="$MEMBER" --role="roles/iap.viewer"
+gcloud projects add-iam-policy-binding "$PROJECT_ID" --member="$MEMBER" --role="roles/iap.settingsEditor"
+
+# Enable API Keys API and assign roles
+gcloud services enable apikeys.googleapis.com
+gcloud projects add-iam-policy-binding "$PROJECT_ID" --member="$MEMBER" --role="roles/apikeys.admin"
+
+# Enable Firebase Management API and assign roles
+gcloud services enable firebase.googleapis.com
+gcloud projects add-iam-policy-binding "$PROJECT_ID" --member="$MEMBER" --role="roles/firebase.viewer"

--- a/examples/iap-idp-connect/utils/validator.py
+++ b/examples/iap-idp-connect/utils/validator.py
@@ -1,0 +1,31 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import re
+
+
+def validate_comma_separated_string(input_string):
+    # Define a regular expression pattern for valid format
+    pattern = r"^\s*\w+\s*(,\s*\w+\s*)*$"
+
+    # Use re.match() to check if the string matches the pattern
+    if re.match(pattern, input_string):
+        print(
+            f"Successfully validated input_string {input_string} follows comma separated regex"
+        )
+        return True
+    else:
+        print(
+            f"Validation failed for input_string {input_string} to follow comma separated regex"
+        )
+        return False


### PR DESCRIPTION
This service programmatically connects IAP (Identity Aware Proxy) to IdP (Identity Platform) in Google Cloud Platform.
By This program, you connect Identity providers (including multi-tenants) with IAP (Identity Aware Proxy) backend services
For example, you connect SAML integrations defined under identity platform for tenant A with backend-service-1 in IAP.
Additionally:

You can also configure the sign-in page created automatically or custom developed by developers by providing the sign_in_url.
You can also provide the api key attached to the sign-in page
This functionality doesn't exist as of now with terraform. So creating this as a re-usable asset.