### PR TITLE
fix: use full resource name for spiffe proxy audience claim

### DIFF
--- a/tools/spiffe-gcp-proxy/main.go
+++ b/tools/spiffe-gcp-proxy/main.go
@@ -259,7 +259,7 @@ func main() {
 		flag.PrintDefaults()
 		os.Exit(1)
 	}
-	audience = fmt.Sprintf("https://iam.googleapis.com/projects/%s/locations/global/workloadIdentityPools/%s/providers/%s", *projectNumber, *poolId, *providerId)
+	audience = fmt.Sprintf("//iam.googleapis.com/projects/%s/locations/global/workloadIdentityPools/%s/providers/%s", *projectNumber, *poolId, *providerId)
 
 	http.HandleFunc("/computeMetadata/v1/instance/service-accounts/default/token", getToken)
 	http.HandleFunc(fmt.Sprintf("/computeMetadata/v1/instance/service-accounts/%s/token", *serviceAccount), getToken)


### PR DESCRIPTION
Tried out the spiffe proxy setup and the requests getting rejected with a HTTP 403 from the sts googleapis token endpoint with the statement that the audience needs to be a [full resource name](https://cloud.google.com/iam/docs/full-resource-names).

This also coincides with the [documentation](https://cloud.google.com/iam/docs/reference/sts/rest/v1/TopLevel/token) for the Security Token Service API.

Removing the `https:` prefix for the audience made it work.
