### PR TITLE
Update Migration Assessment tooling to not include converted code in output

### DIFF
--- a/tools/cloud-composer-migration-complexity-assessment/dags/migration_assessment.py
+++ b/tools/cloud-composer-migration-complexity-assessment/dags/migration_assessment.py
@@ -320,6 +320,7 @@ with models.DAG(
     cp {root_dir}/airflow-v1-to-v2-migration/migration_rules/rules.csv v1-to-v2-report/rules.csv
     python3 {root_dir}/airflow-v1-to-v2-migration/run_mig.py --input_dag_folder={root_dir} --output_dag_folder=v1-to-v2-report --rules_file={root_dir}/airflow-v1-to-v2-migration/migration_rules/rules.csv
     gsutil cp -r v1-to-v2-report gs://{gcs_bucket}/{root_path}/
+    gsutil rm gs://{gcs_bucket}/{root_path}/v1-to-v2-report/*.py
      """.format(
         root_dir=AIRFLOW_HOME_DIR, gcs_bucket=GCS_BUCKET, root_path=GCS_ROOT_PATH
     )


### PR DESCRIPTION
We would like the migration assessment tool to be utilized for scoping and informational purposes, therefore we will prevent uploading converted code to the output bucket.