### PR TITLE
added terraform module for provisioning TCPX infrastructure

### DIFF
--- a/examples/gpudirect-tcpx/README.md
+++ b/examples/gpudirect-tcpx/README.md
@@ -1,0 +1,10 @@
+# GPUDirect TCPX Terraform Module
+For use with GCP A3 (H100) GPU offerings.
+
+For more information see [Google Cloud Docs](https://cloud.google.com/compute/docs/gpus/gpudirect).
+
+## Overview
+This module provisions the performance tuned networking infrastructure in terraform for optimal utilization of multiple A3 nodes. 
+
+## Usage
+Pass in a project ID and region to deploy the networks to. Use the outputs of the module in an instance template or compute instance.

--- a/examples/gpudirect-tcpx/data_plane.tf
+++ b/examples/gpudirect-tcpx/data_plane.tf
@@ -1,0 +1,50 @@
+resource "random_id" "gpu_data_plane" {
+  byte_length = 2
+}
+
+locals {
+  data_planes = {
+    "one" : "192.168.1.0/24",
+    "two" : "192.168.2.0/24",
+    "three" : "192.168.3.0/24",
+    "four" : "192.168.4.0/24"
+  }
+}
+
+resource "google_compute_network" "gpu_data_plane" {
+  for_each                = local.data_planes
+  project                 = var.project_id
+  name                    = "gpu-data-plane-${each.key}-${random_id.gpu_data_plane.hex}"
+  auto_create_subnetworks = false
+  mtu                     = 8244
+}
+
+resource "google_compute_subnetwork" "gpu_data_plane" {
+  for_each      = local.data_planes
+  project       = var.project_id
+  name          = "gpu-data-plane-${each.key}-${random_id.gpu_data_plane.hex}"
+  region        = var.region
+  network       = google_compute_network.gpu_data_plane[each.key].id
+  ip_cidr_range = each.value
+}
+
+resource "google_compute_firewall" "gpu_data_plane" {
+  for_each  = local.data_planes
+  name      = "gpu-dataplane-firewall-${each.key}"
+  project   = var.project_id
+  network   = google_compute_network.gpu_data_plane[each.key].name
+  direction = "INGRESS"
+
+
+  allow {
+    protocol = "tcp"
+    ports    = ["0-65535"]
+  }
+
+  allow {
+    protocol = "udp"
+    ports    = ["0-65535"]
+  }
+
+  source_ranges = ["192.168.0.0/16"]
+}

--- a/examples/gpudirect-tcpx/data_plane.tf
+++ b/examples/gpudirect-tcpx/data_plane.tf
@@ -1,3 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 resource "random_id" "gpu_data_plane" {
   byte_length = 2
 }

--- a/examples/gpudirect-tcpx/management_network.tf
+++ b/examples/gpudirect-tcpx/management_network.tf
@@ -1,0 +1,51 @@
+resource "random_id" "gpu_management_plane" {
+  byte_length = 2
+}
+
+resource "google_compute_network" "gpu_management_plane" {
+  project                 = var.project_id
+  name                    = "gpu-management-plane-${random_id.gpu_management_plane.hex}"
+  auto_create_subnetworks = false
+  mtu                     = 8244
+}
+
+resource "google_compute_subnetwork" "gpu_management_plane" {
+  project       = var.project_id
+  name          = "gpu-management-plane-${random_id.gpu_management_plane.hex}"
+  region        = var.region
+  network       = google_compute_network.gpu_management_plane.id
+  ip_cidr_range = "192.168.0.0/24"
+}
+
+resource "google_compute_firewall" "gpu_management_plane-allow-all" {
+  name      = "gpu-management-firewall-allow-all"
+  project   = var.project_id
+  network   = google_compute_network.gpu_management_plane.name
+  direction = "INGRESS"
+
+
+  allow {
+    protocol = "tcp"
+    ports    = ["0-65535"]
+  }
+
+  allow {
+    protocol = "udp"
+    ports    = ["0-65535"]
+  }
+
+  source_ranges = ["192.168.0.0/16"]
+}
+
+resource "google_compute_firewall" "gpu_management_plane-allow-icmp" {
+  name      = "gpu-management-firewall-allow-icmp"
+  project   = var.project_id
+  network   = google_compute_network.gpu_management_plane.name
+  direction = "INGRESS"
+
+  allow {
+    protocol = "icmp"
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+}

--- a/examples/gpudirect-tcpx/management_network.tf
+++ b/examples/gpudirect-tcpx/management_network.tf
@@ -1,3 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 resource "random_id" "gpu_management_plane" {
   byte_length = 2
 }

--- a/examples/gpudirect-tcpx/outputs.tf
+++ b/examples/gpudirect-tcpx/outputs.tf
@@ -1,3 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 locals {
   networks = {
     management = google_compute_network.gpu_management_plane

--- a/examples/gpudirect-tcpx/outputs.tf
+++ b/examples/gpudirect-tcpx/outputs.tf
@@ -1,0 +1,26 @@
+locals {
+  networks = {
+    management = google_compute_network.gpu_management_plane
+    data_plane = google_compute_network.gpu_data_plane
+  }
+  subnetworks = {
+    management = google_compute_subnetwork.gpu_management_plane
+    data_plane = google_compute_subnetwork.gpu_data_plane
+  }
+  firewall_rules = {
+    management = [google_compute_firewall.gpu_management_plane-allow-all, google_compute_firewall.gpu_management_plane-allow-icmp]
+    data_plane = [google_compute_firewall.gpu_data_plane]
+  }
+}
+
+output "networks" {
+  value = local.networks
+}
+
+output "subnetworks" {
+  value = local.subnetworks
+}
+
+output "firewall_rules" {
+  value = local.firewall_rules
+}

--- a/examples/gpudirect-tcpx/variables.tf
+++ b/examples/gpudirect-tcpx/variables.tf
@@ -1,0 +1,7 @@
+variable "project_id" {
+  type = string
+}
+
+variable "region" {
+  type = string
+}

--- a/examples/gpudirect-tcpx/variables.tf
+++ b/examples/gpudirect-tcpx/variables.tf
@@ -1,3 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 variable "project_id" {
   type = string
 }


### PR DESCRIPTION
This terraform module provisions the networking infrastructure required to utilize full inter-GPU bandwith on A3 instances. It will automatically deploy the necessary VPCs, firewall rules, and subnets.