### PR TITLE
Print the message of PermissionDenied exception

### DIFF
--- a/examples/billboard/billboard.py
+++ b/examples/billboard/billboard.py
@@ -296,8 +296,9 @@ def main(argv):
     try:
         project_billing_info = billing.CloudBillingClient(
         ).get_project_billing_info(name=project_id_temp)
-    except PermissionDenied:
+    except PermissionDenied as pde:
         print("Permission Denied, check project level permission.")
+        print(pde.message)
         return sys.exit(1)
 
     billing_account_name = project_billing_info.billing_account_name.split(


### PR DESCRIPTION
If the Billing API is not enabled on the project, the PermissionDenied exception is thrown but the user has no clue they need to enable the API rather then checking their permissions.
