### PR TITLE
Add Cloud Composer Environment Rotator

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,9 +598,12 @@ Platform usage.
     Recommender is a database script that recommends the best numeric data type for the NUMBER data type
     when migrating from legacy databases like Oracle to Google Cloud platforms like BigQuery, AlloyDB,
     Cloud SQL for PostgreSQL, and Google Cloud Storage.
-*   [Composer DAG Load Generator](tools/cloud-composer-dag-generator) - This is an automatic 
-    DAG generator tool which can be used to create test workload on a cloud composer environmnet
-    and to test differents airflows configurations or to do fine tune using the composer/airflow metrics.
+*   [Cloud Composer Stress Testing](tools/cloud-composer-stress-testing) - A collection
+    of tools aimed at testing, benchmarking, and simulating workloads within Composer. Great for
+    integration testing and experimenting with different environment configurations. 
+*   [Cloud Composer Environment Rotator](tools/cloud-composer-environment-rotator) - Rotate Airflow
+    resources from an old composer environment to a new composer environment with minimal downtime. Ideal
+    for non in-place environment updates, downgrading environment versions, or migrating to different regions.
 *   [Gradio and Generative AI Example](examples/genai-gradio-example) - The example code allows developers 
     to create rapid Generative AI PoC applications with Gradio and Gen AI agents.
 *   [Memorystore Cluster Ops Framework](tools/memorystore-cluster-ops-framework) - This is a framework that 

--- a/tools/cloud-composer-environment-rotator/README.md
+++ b/tools/cloud-composer-environment-rotator/README.md
@@ -1,0 +1,114 @@
+# Composer-Airflow Rotation Tool
+
+## Overview
+
+This script automates the process of rotating a Composer environment to a new Cloud Composer environment. It performs the following steps:
+
+1. **Save the DAG inventory** locally and take a snapshot of the old Composer environment.
+2. **Pause all DAGs** instantly in the old Composer environment to ensure no overlap in DAG runs.
+3. **Load the snapshot** into the new Composer environment.
+
+## Use Cases
+
+While in-place updates are preferred for Composer environments (e.g., minor version updates using the Google beta-provider), there are scenarios where environment rotation is unavoidable:
+
+- Changing network configurations like tags, VPC networks, or IP ranges.
+- Updating the encryption key.
+- Resolving an unhealthy environment status that doesn't go away.
+- downgrading environment versions
+- migrating resources to a new region
+
+Safe updates that do **not** require environment rotation include:
+
+- Modifying labels.
+- Updating software configurations such as image versions, PyPI packages, and environment variables.
+- Adjusting workload configurations like the scheduler and triggerer.
+
+## Prerequisites
+
+- Ensure you have the Google Cloud SDK (`gcloud`) installed and configured.
+- Have appropriate permissions to manage Composer environments and Cloud Storage.
+- The `pause_all_dags.py` script should be available in the `dags/` directory.
+
+## Usage
+
+The script accepts the following arguments:
+
+1. `-p`: **Project ID** where Composer is deployed.
+2. `-c`: **Old Composer Environment Name**.
+3. `-l`: **Old Composer Environment Location**.
+4. `-C`: **New Composer Environment Name**.
+5. `-L`: **New Composer Environment Location**.
+6. `-g`: **GCS Location for Snapshot** (e.g., `gs://your-bucket/composer-snapshots/`).
+7. `-d`: **Old DAG Folder** (GCS path to the DAG folder of the old environment).
+
+### Example
+
+```bash
+./rotate-composer.sh \
+  -p "your-project-id" \
+  -c "old-composer-env" \
+  -l "us-central1" \
+  -C "new-composer-env" \
+  -L "us-central1" \
+  -g "gs://your-bucket/composer-snapshots/" \
+  -d "gs://your-old-dag-folder-path"
+```
+
+### Argument Details
+
+- **`-p` (Project ID):** The Google Cloud project ID where the Composer environments are deployed.
+- **`-c` (Old Composer Environment Name):** The name of the Composer environment you wish to rotate from.
+- **`-l` (Old Composer Environment Location):** The region of the old Composer environment.
+- **`-C` (New Composer Environment Name):** The name of the new Composer environment you wish to rotate to.
+- **`-L` (New Composer Environment Location):** The region of the new Composer environment.
+- **`-g` (GCS Location for Snapshot):** The Cloud Storage bucket path where the snapshot of the old environment will be stored.
+- **`-d` (Old DAG Folder):** The Cloud Storage path to the DAG folder of the old Composer environment.
+
+## Script Steps
+
+1. **Begin Rotation:**
+   - The script starts by printing a message indicating the rotation process has begun.
+
+2. **Save Airflow DAG Inventory:**
+   - Runs `gcloud composer environments run` to list all DAGs in the old environment.
+   - Saves the inventory to a local file named `${OLD_COMPOSER_ENV}_${OLD_COMPOSER_LOCATION}_inventory`.
+
+3. **Save Snapshot of Old Environment:**
+   - Uses `gcloud beta composer environments snapshots save` to create a snapshot.
+   - Stores the snapshot in the specified GCS location.
+
+4. **Upload `pause_all_dags.py` DAG:**
+   - Copies the `pause_all_dags.py` script to the old environment's DAG folder to pause all DAGs.
+
+5. **Wait for DAG Sync:**
+   - Polls the old environment to check if the `pause_all_dags` DAG is available and not paused.
+   - Continues checking every 15 seconds until the DAG is ready.
+
+6. **Trigger `pause_all_dags` DAG:**
+   - Triggers the `pause_all_dags` DAG to pause all other DAGs in the old environment.
+
+7. **Remove `pause_all_dags.py` DAG:**
+   - Removes the `pause_all_dags.py` script from the old environment's DAG folder.
+
+8. **Load Snapshot into New Environment:**
+   - Uses `gcloud beta composer environments snapshots load` to load the snapshot into the new environment.
+
+9. **Complete Rotation:**
+   - Prints a completion message indicating the rotation is complete.
+
+## Notes
+
+- The script uses `set -e` to exit immediately if a command exits with a non-zero status.
+- Ensure that the `pause_all_dags.py` script is available in the `dags/` directory from which the script is run.
+- The rotation process can take up to **30 minutes** to complete.
+- After the rotation, update any external services or configurations that point to the old Composer environment.
+
+## Troubleshooting
+
+- **Permission Errors:**
+  - Ensure you have the necessary IAM permissions for Composer and Cloud Storage operations.
+- **Environment Variables:**
+  - Double-check that all environment variables and configurations are correctly set in the new Composer environment.
+- **DAG Synchronization Issues:**
+  - If the script hangs while waiting for the `pause_all_dags` DAG to sync, verify that the DAG was correctly copied to the old environment's DAG folder.

--- a/tools/cloud-composer-environment-rotator/composer-2-small_us-central1_inventory
+++ b/tools/cloud-composer-environment-rotator/composer-2-small_us-central1_inventory
@@ -1,0 +1,16 @@
+dag_id                       | filepath                       | owner    | paused
+=============================+================================+==========+=======
+advanced_sla_reporting_dag   | advanced_sla_reporting_dag.py  | auditing | True
+airflow_monitoring           | airflow_monitoring.py          | airflow  | False
+cloudsql_dag_v0_0_10         | sql_dag_testing.py             | Google   | False
+cloudsql_dag_v0_0_8          | cloud_sql_dag.py               | Google   | False
+custom_operator_dag_v0_0_3   | abstract_cluster_create_dag.py | Google   | False
+data_transfers_dag_v0_0_1    | data_transfers_dag.py          | Google   | False
+dataproc_dynamic_xcom_v0_0_5 | dataproc_dynamic_xcom_dag.py   | Google   | False
+flink_dataproc_dag_v0_0_4    | flink_dag.py                   | Google   | True
+gcp_sensors_dag_v0_0_1       | gcp_sensors_dag.py             | Google   | True
+local_config_dag_v0_2        | local_configured_dag.py        | Google   | True
+parameterized_dag_v0_0_0     | params_dag.py                  | Google   | True
+pause_all_dags               | pause_all_dags.py              | auditing | True
+python_xcom_dag_v0_0_0       | python_xcom_dag.py             | Google   | True
+spark_to_bigtable_v0_0       | spark_to_bigtable_dag.py       | Google   | True

--- a/tools/cloud-composer-environment-rotator/dags/pause_all_dags.py
+++ b/tools/cloud-composer-environment-rotator/dags/pause_all_dags.py
@@ -1,0 +1,44 @@
+"""
+A DAG to pause all other dags.
+"""
+
+from datetime import datetime, timedelta
+from airflow import models
+from airflow.providers.postgres.operators.postgres import (
+    PostgresOperator,
+)
+
+default_args = {
+    "owner": "auditing",
+    "depends_on_past": False,
+    "email": [""],
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 1,
+    "retry_delay": timedelta(minutes=2),
+}
+
+with models.DAG(
+    "pause_all_dags",
+    tags=["airflow_db"],
+    description="Pause all dags.",
+    is_paused_upon_creation=False,
+    catchup=False,
+    start_date=datetime(2024, 1, 1),
+    dagrun_timeout=timedelta(minutes=30),
+    max_active_runs=1,
+    default_args=default_args,
+    schedule_interval=None, 
+) as dag:
+    
+    pause_all_dags = PostgresOperator(
+        task_id='pause_all_dags',
+        postgres_conn_id='airflow_db', 
+        sql="""
+            UPDATE dag
+            SET is_paused = true 
+            WHERE 
+                dag_id != 'airflow_monitoring' AND 
+                dag_id != 'pause_all_dags';
+            """
+    )

--- a/tools/cloud-composer-environment-rotator/dags/pause_all_dags.py
+++ b/tools/cloud-composer-environment-rotator/dags/pause_all_dags.py
@@ -5,8 +5,7 @@ A DAG to pause all other dags.
 from datetime import datetime, timedelta
 from airflow import models
 from airflow.providers.postgres.operators.postgres import (
-    PostgresOperator,
-)
+    PostgresOperator,)
 
 default_args = {
     "owner": "auditing",
@@ -19,26 +18,24 @@ default_args = {
 }
 
 with models.DAG(
-    "pause_all_dags",
-    tags=["airflow_db"],
-    description="Pause all dags.",
-    is_paused_upon_creation=False,
-    catchup=False,
-    start_date=datetime(2024, 1, 1),
-    dagrun_timeout=timedelta(minutes=30),
-    max_active_runs=1,
-    default_args=default_args,
-    schedule_interval=None, 
+        "pause_all_dags",
+        tags=["airflow_db"],
+        description="Pause all dags.",
+        is_paused_upon_creation=False,
+        catchup=False,
+        start_date=datetime(2024, 1, 1),
+        dagrun_timeout=timedelta(minutes=30),
+        max_active_runs=1,
+        default_args=default_args,
+        schedule_interval=None,
 ) as dag:
-    
-    pause_all_dags = PostgresOperator(
-        task_id='pause_all_dags',
-        postgres_conn_id='airflow_db', 
-        sql="""
+
+    pause_all_dags = PostgresOperator(task_id='pause_all_dags',
+                                      postgres_conn_id='airflow_db',
+                                      sql="""
             UPDATE dag
             SET is_paused = true 
             WHERE 
                 dag_id != 'airflow_monitoring' AND 
                 dag_id != 'pause_all_dags';
-            """
-    )
+            """)

--- a/tools/cloud-composer-environment-rotator/rotate-composer.sh
+++ b/tools/cloud-composer-environment-rotator/rotate-composer.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+
+# Rotate Airflow to a new composer environment and decommission the old environment.
+
+# The script takes three arguments
+# 1. (p) project_id where composer is deployed
+# 2. (c) old composer environment name
+# 3. (l) old composer environment location
+# 1. (C) new composer environment name
+# 2. (L) new composer environment location 
+# 3. (g) gcs location for snapshot
+
+# Sample Usage:
+
+# ./rotate-composer.sh \
+#   -p "cy-artifacts" \
+#   -c "composer-2-small" \
+#   -l "us-central1" \
+#   -C "composer-2-small-new" \
+#   -L "us-central1" \
+#   -g "gs://cy-sandbox/composer-snapshots/" \
+#   -d "gs://us-central1-composer-2-smal-56609903-bucket/dags"
+
+set -e
+
+usage()
+{
+    echo "usage: rotate-composer.sh options:<p|c|l|C|L|g|d>"
+}
+PROJECT_ID=""
+OLD_COMPOSER_ENV=""
+OLD_COMPOSER_LOCATION=""
+NEW_COMPOSER_ENV=""
+NEW_COMPOSER_LOCATION=""
+SNAPSHOT_GCS_FOLDER=""
+OLD_DAG_FOLDER=""
+
+while getopts p:c:l:C:L:g:d: flag
+do
+    case "${flag}" in
+        p) PROJECT_ID=${OPTARG};;
+        c) OLD_COMPOSER_ENV=${OPTARG};;
+        l) OLD_COMPOSER_LOCATION=${OPTARG};;
+        C) NEW_COMPOSER_ENV=${OPTARG};;
+        L) NEW_COMPOSER_LOCATION=${OPTARG};;
+        g) SNAPSHOT_GCS_FOLDER=${OPTARG};;
+        d) OLD_DAG_FOLDER=${OPTARG};;
+        *) usage
+           exit;;
+    esac
+done
+
+[[ $PROJECT_ID == "" || $OLD_COMPOSER_ENV == "" || $OLD_COMPOSER_LOCATION == "" || $NEW_COMPOSER_ENV = "" || $NEW_COMPOSER_LOCATION = "" || $SNAPSHOT_GCS_FOLDER = "" || OLD_DAG_FOLDER = "" ]] && { usage; exit 1; }
+
+# PROJECT_ID="cy-artifacts"
+# OLD_COMPOSER_ENV="composer-2-small"
+# OLD_COMPOSER_LOCATION="us-central1"
+
+# NEW_COMPOSER_ENV="composer-2-small-new"
+# NEW_COMPOSER_LOCATION="us-central1"
+# SNAPSHOT_GCS_FOLDER="gs://cy-sandbox/composer-snapshots/"
+# OLD_DAG_FOLDER="gs://us-central1-composer-2-smal-56609903-bucket/dags"
+
+
+echo "------------------------------------------------------------"
+echo "... Beginning Rotation (this can take up to 30 minutes) ..."
+echo "------------------------------------------------------------"
+
+echo "Project ID:                       ${PROJECT_ID}"
+echo "Old Composer Environment:         ${OLD_COMPOSER_ENV}"
+echo "Old Composer Location:            ${OLD_COMPOSER_LOCATION}"
+echo "Old Composer DAG Folder:          ${OLD_DAG_FOLDER}"
+echo "Composer Snapshot GCS Location:   ${SNAPSHOT_GCS_FOLDER}"
+echo "New Composer Environment:         ${NEW_COMPOSER_ENV}"
+echo "New Composer Location:            ${NEW_COMPOSER_LOCATION}"
+
+echo "------------------------------------------"
+echo "... Saving Airflow DAG inventory state ..."
+echo "------------------------------------------"
+
+gcloud composer environments run composer-2-small \
+  --location us-central1 dags list > ${OLD_COMPOSER_ENV}_${OLD_COMPOSER_LOCATION}_inventory
+
+echo "Inventory stored in file: ${OLD_COMPOSER_ENV}_${OLD_COMPOSER_LOCATION}_inventory"
+
+echo "---------------------------------------------------"
+echo "... Saving snapshot of old Composer environment ..."
+echo "---------------------------------------------------"
+
+SAVED_SNAPSHOT=$(gcloud beta composer environments snapshots save \
+  ${OLD_COMPOSER_ENV} \
+  --location ${OLD_COMPOSER_LOCATION} \
+  --snapshot-location ${SNAPSHOT_GCS_FOLDER})
+
+SAVED_SNAPSHOT_PATH=$(echo ${SAVED_SNAPSHOT} | awk '{split($0, a, ": "); print a[3]}')
+echo "Saved Snapshot GCS Path: ${SAVED_SNAPSHOT_PATH}" 
+
+echo "-------------------------------"
+echo "... uploading pause_all DAG ..."
+echo "-------------------------------"
+
+gsutil cp dags/pause_all_dags.py $OLD_DAG_FOLDER
+
+echo "---------------------------------------------------"
+echo "... waiting for DAG to be synced to environment ..."
+echo "---------------------------------------------------"
+
+while true; do
+  # we want to see if the dag exists and isn't paused
+  DAG_PAUSED=$(gcloud composer environments run $OLD_COMPOSER_ENV \
+    --location $OLD_COMPOSER_LOCATION dags list -- --output=json | jq --raw-output '.[] | select(.dag_id == "'pause_all_dags'") | .paused')
+
+  if [[ "$DAG_PAUSED" == "False" ]]; then
+    echo "DAG FOUND AND READY!"
+    break  # Exit the loop if the DAG exists
+  else
+    echo "Waiting..."
+    sleep 15  # Adjust the polling interval as needed
+  fi
+done
+
+echo "-------------------------------------------------------------"
+echo "... Triggering pause_all_dags in old Composer environment ..."
+echo "-------------------------------------------------------------"
+
+gcloud composer environments run ${OLD_COMPOSER_ENV} \
+  --location ${OLD_COMPOSER_LOCATION} \
+  dags trigger -- "pause_all_dags"
+
+echo "-------------------------------"
+echo "... Removing pause_all DAG ..."
+echo "-------------------------------"
+
+gsutil rm $OLD_DAG_FOLDER/pause_all_dags.py
+
+echo "------------------------------------------------------"
+echo "... Loading snapshot into new Composer environment ..."
+echo "------------------------------------------------------"
+
+gcloud beta composer environments snapshots load \
+  ${NEW_COMPOSER_ENV} \
+  --location ${NEW_COMPOSER_LOCATION} \
+  --snapshot-path ${SAVED_SNAPSHOT_PATH}
+
+echo "Rotation COMPLETE!"

--- a/tools/cloud-composer-environment-rotator/rotate-composer.sh
+++ b/tools/cloud-composer-environment-rotator/rotate-composer.sh
@@ -1,14 +1,15 @@
 #!/bin/bash
 
-# Rotate Airflow to a new composer environment and decommission the old environment.
+# Rotate Airflow to a new Composer environment and decommission the old environment.
 
-# The script takes three arguments
-# 1. (p) project_id where composer is deployed
-# 2. (c) old composer environment name
-# 3. (l) old composer environment location
-# 1. (C) new composer environment name
-# 2. (L) new composer environment location 
-# 3. (g) gcs location for snapshot
+# The script takes seven arguments:
+# 1. (p) project_id where Composer is deployed
+# 2. (c) old Composer environment name
+# 3. (l) old Composer environment location
+# 4. (C) new Composer environment name
+# 5. (L) new Composer environment location
+# 6. (g) GCS location for snapshot
+# 7. (d) old DAG folder
 
 # Sample Usage:
 
@@ -23,10 +24,11 @@
 
 set -e
 
-usage()
-{
-    echo "usage: rotate-composer.sh options:<p|c|l|C|L|g|d>"
+usage() {
+    echo "usage: rotate-composer.sh -p <project_id> -c <old_env> -l <old_location> -C <new_env> -L <new_location> -g <snapshot_gcs> -d <old_dag_folder>"
+    exit 1
 }
+
 PROJECT_ID=""
 OLD_COMPOSER_ENV=""
 OLD_COMPOSER_LOCATION=""
@@ -35,32 +37,22 @@ NEW_COMPOSER_LOCATION=""
 SNAPSHOT_GCS_FOLDER=""
 OLD_DAG_FOLDER=""
 
-while getopts p:c:l:C:L:g:d: flag
-do
+while getopts p:c:l:C:L:g:d: flag; do
     case "${flag}" in
-        p) PROJECT_ID=${OPTARG};;
-        c) OLD_COMPOSER_ENV=${OPTARG};;
-        l) OLD_COMPOSER_LOCATION=${OPTARG};;
-        C) NEW_COMPOSER_ENV=${OPTARG};;
-        L) NEW_COMPOSER_LOCATION=${OPTARG};;
-        g) SNAPSHOT_GCS_FOLDER=${OPTARG};;
-        d) OLD_DAG_FOLDER=${OPTARG};;
-        *) usage
-           exit;;
+        p) PROJECT_ID=${OPTARG} ;;
+        c) OLD_COMPOSER_ENV=${OPTARG} ;;
+        l) OLD_COMPOSER_LOCATION=${OPTARG} ;;
+        C) NEW_COMPOSER_ENV=${OPTARG} ;;
+        L) NEW_COMPOSER_LOCATION=${OPTARG} ;;
+        g) SNAPSHOT_GCS_FOLDER=${OPTARG} ;;
+        d) OLD_DAG_FOLDER=${OPTARG} ;;
+        *) usage ;;
     esac
 done
 
-[[ $PROJECT_ID == "" || $OLD_COMPOSER_ENV == "" || $OLD_COMPOSER_LOCATION == "" || $NEW_COMPOSER_ENV = "" || $NEW_COMPOSER_LOCATION = "" || $SNAPSHOT_GCS_FOLDER = "" || OLD_DAG_FOLDER = "" ]] && { usage; exit 1; }
-
-# PROJECT_ID="cy-artifacts"
-# OLD_COMPOSER_ENV="composer-2-small"
-# OLD_COMPOSER_LOCATION="us-central1"
-
-# NEW_COMPOSER_ENV="composer-2-small-new"
-# NEW_COMPOSER_LOCATION="us-central1"
-# SNAPSHOT_GCS_FOLDER="gs://cy-sandbox/composer-snapshots/"
-# OLD_DAG_FOLDER="gs://us-central1-composer-2-smal-56609903-bucket/dags"
-
+if [[ -z "$PROJECT_ID" || -z "$OLD_COMPOSER_ENV" || -z "$OLD_COMPOSER_LOCATION" || -z "$NEW_COMPOSER_ENV" || -z "$NEW_COMPOSER_LOCATION" || -z "$SNAPSHOT_GCS_FOLDER" || -z "$OLD_DAG_FOLDER" ]]; then
+    usage
+fi
 
 echo "------------------------------------------------------------"
 echo "... Beginning Rotation (this can take up to 30 minutes) ..."
@@ -78,8 +70,8 @@ echo "------------------------------------------"
 echo "... Saving Airflow DAG inventory state ..."
 echo "------------------------------------------"
 
-gcloud composer environments run composer-2-small \
-  --location us-central1 dags list > ${OLD_COMPOSER_ENV}_${OLD_COMPOSER_LOCATION}_inventory
+gcloud composer environments run "${OLD_COMPOSER_ENV}" \
+  --location "${OLD_COMPOSER_LOCATION}" dags list > "${OLD_COMPOSER_ENV}_${OLD_COMPOSER_LOCATION}_inventory"
 
 echo "Inventory stored in file: ${OLD_COMPOSER_ENV}_${OLD_COMPOSER_LOCATION}_inventory"
 
@@ -88,58 +80,57 @@ echo "... Saving snapshot of old Composer environment ..."
 echo "---------------------------------------------------"
 
 SAVED_SNAPSHOT=$(gcloud beta composer environments snapshots save \
-  ${OLD_COMPOSER_ENV} \
-  --location ${OLD_COMPOSER_LOCATION} \
-  --snapshot-location ${SNAPSHOT_GCS_FOLDER})
+  "${OLD_COMPOSER_ENV}" \
+  --location "${OLD_COMPOSER_LOCATION}" \
+  --snapshot-location "${SNAPSHOT_GCS_FOLDER}")
 
-SAVED_SNAPSHOT_PATH=$(echo ${SAVED_SNAPSHOT} | awk '{split($0, a, ": "); print a[3]}')
-echo "Saved Snapshot GCS Path: ${SAVED_SNAPSHOT_PATH}" 
+SAVED_SNAPSHOT_PATH=$(echo "${SAVED_SNAPSHOT}" | awk -F': ' '/Saved snapshot to/ {print $2}')
+echo "Saved Snapshot GCS Path: ${SAVED_SNAPSHOT_PATH}"
 
 echo "-------------------------------"
-echo "... uploading pause_all DAG ..."
+echo "... Uploading pause_all DAG ..."
 echo "-------------------------------"
 
-gsutil cp dags/pause_all_dags.py $OLD_DAG_FOLDER
+gsutil cp dags/pause_all_dags.py "${OLD_DAG_FOLDER}"
 
 echo "---------------------------------------------------"
-echo "... waiting for DAG to be synced to environment ..."
+echo "... Waiting for DAG to be synced to environment ..."
 echo "---------------------------------------------------"
 
 while true; do
-  # we want to see if the dag exists and isn't paused
-  DAG_PAUSED=$(gcloud composer environments run $OLD_COMPOSER_ENV \
-    --location $OLD_COMPOSER_LOCATION dags list -- --output=json | jq --raw-output '.[] | select(.dag_id == "'pause_all_dags'") | .paused')
+    DAG_PAUSED=$(gcloud composer environments run "${OLD_COMPOSER_ENV}" \
+      --location "${OLD_COMPOSER_LOCATION}" dags list -- --output=json | jq --raw-output '.[] | select(.dag_id=="pause_all_dags") | .paused')
 
-  if [[ "$DAG_PAUSED" == "False" ]]; then
-    echo "DAG FOUND AND READY!"
-    break  # Exit the loop if the DAG exists
-  else
-    echo "Waiting..."
-    sleep 15  # Adjust the polling interval as needed
-  fi
+    if [[ "$DAG_PAUSED" == "False" ]]; then
+        echo "DAG FOUND AND READY!"
+        break
+    else
+        echo "Waiting..."
+        sleep 15
+    fi
 done
 
 echo "-------------------------------------------------------------"
 echo "... Triggering pause_all_dags in old Composer environment ..."
 echo "-------------------------------------------------------------"
 
-gcloud composer environments run ${OLD_COMPOSER_ENV} \
-  --location ${OLD_COMPOSER_LOCATION} \
+gcloud composer environments run "${OLD_COMPOSER_ENV}" \
+  --location "${OLD_COMPOSER_LOCATION}" \
   dags trigger -- "pause_all_dags"
 
 echo "-------------------------------"
 echo "... Removing pause_all DAG ..."
 echo "-------------------------------"
 
-gsutil rm $OLD_DAG_FOLDER/pause_all_dags.py
+gsutil rm "${OLD_DAG_FOLDER}/pause_all_dags.py"
 
 echo "------------------------------------------------------"
 echo "... Loading snapshot into new Composer environment ..."
 echo "------------------------------------------------------"
 
 gcloud beta composer environments snapshots load \
-  ${NEW_COMPOSER_ENV} \
-  --location ${NEW_COMPOSER_LOCATION} \
-  --snapshot-path ${SAVED_SNAPSHOT_PATH}
+  "${NEW_COMPOSER_ENV}" \
+  --location "${NEW_COMPOSER_LOCATION}" \
+  --snapshot-path "${SAVED_SNAPSHOT_PATH}"
 
 echo "Rotation COMPLETE!"


### PR DESCRIPTION
TL;DR: Rotate Airflow resources from an old composer environment to a new composer environment with minimal downtime. Ideal for non in-place environment updates, downgrading environment versions, or migrating to different regions.

---
While in-place updates are preferred for Composer environments (e.g., minor version updates using the Google beta-provider), there are scenarios where environment rotation is unavoidable:

- Changing network configurations like tags, VPC networks, or IP ranges.
- Updating the encryption key.
- Resolving an unhealthy environment status that doesn't go away.
- downgrading environment versions
- migrating resources to a new region

Safe updates that do **not** require environment rotation include:

- Modifying labels.
- Updating software configurations such as image versions, PyPI packages, and environment variables.
- Adjusting workload configurations like the scheduler and triggerer.

This script automates the process of rotating a Composer environment to a new Cloud Composer environment. It performs the following steps:

1. **Save the DAG inventory** locally and take a snapshot of the old Composer environment.
2. **Pause all DAGs** instantly in the old Composer environment to ensure no overlap in DAG runs.
3. **Load the snapshot** into the new Composer environment.