### PR TITLE
Added Werkzeug dependency to requirement.txt in risk-analysis-asset

### DIFF
--- a/examples/risk-analysis-asset/backend/requirements.txt
+++ b/examples/risk-analysis-asset/backend/requirements.txt
@@ -3,3 +3,4 @@ google-cloud-firestore
 flask-cors
 python-dotenv 
 google-auth
+Werkzeug==2.2.2


### PR DESCRIPTION
Adding Werkzeug dependency with version to requirements.txt in risk-analysis asset to fix the import error while running backend apis. Currently it throws an import error - `ImportError: cannot import name 'url_quote' from 'werkzeug.urls' (/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/werkzeug/urls.py). Did you mean: 'unquote'?`

