### PR TITLE
Fix typo in Snowflake GCS URL prefix

### DIFF
--- a/tools/snowflake2bq/README.md
+++ b/tools/snowflake2bq/README.md
@@ -17,7 +17,7 @@ CREATE STORAGE INTEGRATION gcs_int
   TYPE = EXTERNAL_STAGE
   STORAGE_PROVIDER = GCS
   ENABLED = TRUE
-  STORAGE_ALLOWED_LOCATIONS = ('gs://from-sf/sf-data/');
+  STORAGE_ALLOWED_LOCATIONS = ('gcs://from-sf/sf-data/');
 ```
 
 


### PR DESCRIPTION
Corrected the URL prefix from  to  in the  and  parameters within the Snowflake integration and stage creation examples in the  file. This fixes an issue where Snowflake would throw an error due to the incorrect prefix.
