### PR TITLE
Setup mTLS and TLS with GCP Application Load Balancer (EXTERNAL_MANAGED)

### DIFF
--- a/examples/gclb-mtls-tls/README.md
+++ b/examples/gclb-mtls-tls/README.md
@@ -1,0 +1,84 @@
+## Setup mTLS and TLS with GCP Application Load Balancer (EXTERNAL_MANAGED)
+
+### OVERVIEW:
+
+mTLS with GCP Application Load Balancer enhances security by requiring clients to authenticate themselves with certificates, in addition to the server authenticating itself to the client. This provides mutual authentication, ensuring that both parties are who they claim to be.
+
+To implement mTLS with GCP Application Load Balancer, you need to create a trust config resource that contains the root and intermediate certificates used to validate client certificates. You then create a client authentication resource that specifies the client validation mode and associates it with the trust config. Finally, you attach the client authentication resource to your load balancer's HTTPS frontend.
+
+mTLS with GCP Application Load Balancer supports various features, including custom mTLS headers that can be used to pass information about the mTLS connection to backend services. It also supports different client validation modes, allowing you to choose how to handle invalid or missing client certificates.
+
+### [Create a VPC native cluster:](https://cloud.google.com/kubernetes-engine/docs/how-to/standalone-neg#create-cluster)
+
+```bash
+gcloud container clusters create neg-demo-cluster \
+    --create-subnetwork="" \
+    --network=default \
+    --zone=us-central1-a
+```
+### Connect to GKE cluster:
+```bash
+gcloud container clusters get-credentials neg-demo-cluster --zone us-central1-a --project <GCP_PROJECT_ID>
+```
+### Deploy the Sample application deployment and service(along with [NEG](https://cloud.google.com/load-balancing/docs/negs/zonal-neg-concepts)):
+```bash
+kubectl apply -f manifests/deploy.yaml
+```
+
+### Generate the self signed certificates
+
+A detailed steps to generate the self signed certificates are documented in the [Medium Article.](https://medium.com/google-cloud/tls-and-mtls-connection-with-gcp-application-load-balancer-6e2cd5189707)
+
+After executing the steps from the above article, you should have a root, 2 intermediate, server and client certificates generated. Copy all the generated certificates along with the following unencrypted server keys in the `terraform/certs` directory.
+
+Decrypt the server key file using the passphrase used in previous steps:
+```bash
+openssl rsa -in server.key -out un-server.key
+```
+
+### Deploy the GCP Global application load balancer with both tls and mTLS configuration
+
+#### Update the following terraform local variables in `terraform/main.tf`:
+* project_id: GCP Project ID where the GCP load balancer will be deployed.
+* vpc_networks: List of VPC network where the load balancer backend exists. The additional firewall rules required by load balancer are added using this input variable.
+* vpc_projects: The GCP project ID where the VPC network exists.
+
+#### Initialize the terraform directory
+
+```bash
+terraform init
+```
+
+#### Generate the terraform plan
+```bash
+terraform plan
+```
+
+#### Apply the terraform plan to provision all GCP resources.
+
+```bash
+terraform apply
+```
+
+After executing the terraform script, we should have the GCP application load balancer provisioned with 2 forwarding rules:
+* One forwarding rule is used to send the tls connection.
+
+
+* Another forwarding rule is used to send the mtls connection to load balancer.
+
+#### Test the tls connection to the GCP Load balancer by sending the following curl request
+
+```bash
+curl -v --cacert int2.cert --connect-to test-domain.com:443:34.149.90.136:443 https://test-domain.com
+```
+
+The GCP application load balancer is also configured to send the custom headers of the mtls request back to the backend service which are seen in the curl request output of the mTLS connection, since the above request was tls connection, the custom headers are empty in the above tls connection response.
+
+
+#### Test the mTLS connection to the GCP application load balancer by sending the following request
+
+```bash
+curl -v --cacert int2.cert --key client.key --cert client.cert --connect-to test-domain.com:443:34.8.115.55:443 https://test-domain.com
+```
+
+We see the mTLS custom headers in above mtls connection response are populated automatically by load balancer frontend and sent back to the backend server after a successful mTLS connection is established.

--- a/examples/gclb-mtls-tls/README.md
+++ b/examples/gclb-mtls-tls/README.md
@@ -62,16 +62,19 @@ terraform apply
 
 After executing the terraform script, we should have the GCP application load balancer provisioned with 2 forwarding rules:
 * One forwarding rule is used to send the tls connection.
+![tls](https://github.com/user-attachments/assets/6d52967b-c275-497d-9c35-fd09254e183d)
 
 
 * Another forwarding rule is used to send the mtls connection to load balancer.
+![mtls](https://github.com/user-attachments/assets/0f8852f5-0ee7-47b1-a27f-faa7d3337153)
+
 
 #### Test the tls connection to the GCP Load balancer by sending the following curl request
 
 ```bash
 curl -v --cacert int2.cert --connect-to test-domain.com:443:34.149.90.136:443 https://test-domain.com
 ```
-
+<img width="1098" alt="Screenshot 2025-02-06 at 10 46 25 PM" src="https://github.com/user-attachments/assets/d392214c-da93-4198-be47-eb2e0ac3315f" />
 The GCP application load balancer is also configured to send the custom headers of the mtls request back to the backend service which are seen in the curl request output of the mTLS connection, since the above request was tls connection, the custom headers are empty in the above tls connection response.
 
 
@@ -80,5 +83,5 @@ The GCP application load balancer is also configured to send the custom headers 
 ```bash
 curl -v --cacert int2.cert --key client.key --cert client.cert --connect-to test-domain.com:443:34.8.115.55:443 https://test-domain.com
 ```
-
+<img width="1204" alt="Screenshot 2025-02-06 at 10 49 07 PM" src="https://github.com/user-attachments/assets/24f69993-46a9-4329-bb8f-6609c7d2680f" />
 We see the mTLS custom headers in above mtls connection response are populated automatically by load balancer frontend and sent back to the backend server after a successful mTLS connection is established.

--- a/examples/gclb-mtls-tls/manifests/deploy.yaml
+++ b/examples/gclb-mtls-tls/manifests/deploy.yaml
@@ -1,0 +1,61 @@
+# Copyright 2025 Google Inc. All Rights Reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mtls-demo
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: echo
+  namespace: mtls-demo
+spec:
+  selector:
+    matchLabels:
+      app: echo
+  template:
+    metadata:
+      labels:
+        app: echo
+    spec:
+      containers:
+      - name: echo
+        image: gcr.io/istio-testing/app:latest
+        args:
+        - --tcp=7070
+        - --tcp=7071
+        - --port=8080
+        - --grpc=9090
+        - --server-first=7071
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+  namespace: mtls-demo
+  annotations:
+    cloud.google.com/neg: '{"exposed_ports": {"8080":{"name": "mtls-demo-neg"}}}'
+spec:
+  selector:
+    app: echo
+  ports:
+  - name: http
+    port: 8080
+  - name: tcp
+    port: 7070
+  - name: tcp-sf
+    port: 7071
+  - name: grpc
+    port: 9090

--- a/examples/gclb-mtls-tls/terraform/certs/client.conf
+++ b/examples/gclb-mtls-tls/terraform/certs/client.conf
@@ -1,0 +1,19 @@
+[req]
+default_bits              = 2048
+req_extensions            = extension_requirements
+distinguished_name        = dn_requirements
+prompt                    = no
+
+[extension_requirements]
+basicConstraints          = CA:FALSE
+keyUsage                  = nonRepudiation, digitalSignature, keyEncipherment
+extendedKeyUsage          = serverAuth,clientAuth
+subjectAltName            = DNS:test-client.com,DNS:www.test-client.com
+
+[dn_requirements]
+countryName               = IN
+stateOrProvinceName       = Telangana
+localityName              = Hyderabad
+0.organizationName        = Google
+organizationalUnitName    = QA
+commonName                = test-client

--- a/examples/gclb-mtls-tls/terraform/certs/int.conf
+++ b/examples/gclb-mtls-tls/terraform/certs/int.conf
@@ -1,0 +1,17 @@
+[req]
+default_bits              = 2048
+req_extensions            = extension_requirements
+distinguished_name        = dn_requirements
+prompt                    = no
+
+[extension_requirements]
+basicConstraints          = critical,CA:TRUE
+keyUsage                  = keyCertSign
+
+[dn_requirements]
+countryName               = IN
+stateOrProvinceName       = Telangana
+localityName              = Hyderabad
+0.organizationName        = Google
+organizationalUnitName    = IT
+commonName                = int

--- a/examples/gclb-mtls-tls/terraform/certs/int2.conf
+++ b/examples/gclb-mtls-tls/terraform/certs/int2.conf
@@ -1,0 +1,17 @@
+[req]
+default_bits              = 2048
+req_extensions            = extension_requirements
+distinguished_name        = dn_requirements
+prompt                    = no
+
+[extension_requirements]
+basicConstraints          = critical,CA:TRUE
+keyUsage                  = keyCertSign
+
+[dn_requirements]
+countryName               = IN
+stateOrProvinceName       = Telangana
+localityName              = Hyderabad
+0.organizationName        = Google
+organizationalUnitName    = IT
+commonName                = int2

--- a/examples/gclb-mtls-tls/terraform/certs/root.conf
+++ b/examples/gclb-mtls-tls/terraform/certs/root.conf
@@ -1,0 +1,17 @@
+[req]
+default_bits              = 2048
+req_extensions            = extension_requirements
+distinguished_name        = dn_requirements
+prompt                    = no
+
+[extension_requirements]
+basicConstraints          = critical,CA:TRUE
+keyUsage                  = keyCertSign
+
+[dn_requirements]
+countryName               = IN
+stateOrProvinceName       = Telangana
+localityName              = Hyderabad
+0.organizationName        = Google
+organizationalUnitName    = IT
+commonName                = root

--- a/examples/gclb-mtls-tls/terraform/certs/server.conf
+++ b/examples/gclb-mtls-tls/terraform/certs/server.conf
@@ -1,0 +1,19 @@
+[req]
+default_bits              = 2048
+req_extensions            = extension_requirements
+distinguished_name        = dn_requirements
+prompt                    = no
+
+[extension_requirements]
+basicConstraints          = CA:FALSE
+keyUsage                  = nonRepudiation, digitalSignature, keyEncipherment
+extendedKeyUsage          = serverAuth,clientAuth
+subjectAltName            = DNS:test-domain.com,DNS:www.test-domain.com
+
+[dn_requirements]
+countryName               = IN
+stateOrProvinceName       = Telangana
+localityName              = Hyderabad
+0.organizationName        = Google
+organizationalUnitName    = DEV
+commonName                = test-domain.com

--- a/examples/gclb-mtls-tls/terraform/main.tf
+++ b/examples/gclb-mtls-tls/terraform/main.tf
@@ -1,0 +1,162 @@
+# Copyright 2025 Google Inc. All Rights Reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+
+locals {
+  project_id = "gcp-project-id" // Update GCP_PROJECT_ID
+  vpc_networks = [
+    "default"
+  ]
+  vpc_projects = [
+    "gcp-project-id", // Update GCP_PROJECT_ID of vpc network project.
+  ]
+  zonal_neg_configs = [
+    { "name" : "mtls-demo-neg", "zone" : "us-central1-a" },
+  ]
+}
+
+data "google_project" "project" {
+  project_id = local.project_id
+}
+
+# create trust config
+resource "google_certificate_manager_trust_config" "default" {
+  name        = "mtls-demo-trust-config"
+  project     = local.project_id
+  description = "Trust config for mTLS demo app"
+  location    = "global"
+
+  trust_stores {
+    trust_anchors {
+      pem_certificate = file("certs/root.cert")
+    }
+    intermediate_cas {
+      pem_certificate = file("certs/int.cert")
+    }
+    intermediate_cas {
+      pem_certificate = file("certs/int2.cert")
+    }
+  }
+}
+
+# Create server tls policy
+resource "google_network_security_server_tls_policy" "default" {
+  provider    = google-beta
+  name        = "mtls-demo-server-tls-policy"
+  project     = local.project_id
+  description = "mTLS Demo server tls policy"
+  location    = "global"
+  allow_open  = "false"
+  mtls_policy {
+    client_validation_mode         = "REJECT_INVALID" # REJECT_INVALID , ALLOW_INVALID_OR_MISSING_CLIENT_CERT
+    client_validation_trust_config = "projects/${data.google_project.project.number}/locations/global/trustConfigs/${google_certificate_manager_trust_config.default.name}"
+  }
+}
+
+# HTTPS proxy for tls traffic only
+resource "google_compute_target_https_proxy" "tls-proxy" {
+  project = local.project_id
+  name    = "mtls-demo-tls-https-proxy"
+  url_map = join("", module.gce-lb-http.url_map)
+
+  ssl_certificates = module.gce-lb-http.ssl_certificate_created
+}
+
+# External Global IP address for tls frontend
+resource "google_compute_global_address" "tls-ip" {
+  provider   = google-beta
+  project    = local.project_id
+  name       = "mtls-demo-ip-tls"
+  ip_version = "IPV4"
+}
+
+# External Global IP address for mtls frontend
+resource "google_compute_global_address" "mtls-ip" {
+  provider   = google-beta
+  project    = local.project_id
+  name       = "mtls-demo-ip-mtls"
+  ip_version = "IPV4"
+}
+
+# Attach the https proxy to forwarding rule
+resource "google_compute_global_forwarding_rule" "tls-https" {
+  provider              = google-beta
+  project               = local.project_id
+  name                  = "mtls-demo-tls-https"
+  target                = google_compute_target_https_proxy.tls-proxy.self_link
+  ip_address            = google_compute_global_address.tls-ip.address
+  port_range            = 443
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+}
+
+# create load balancer
+module "gce-lb-http" {
+  source  = "GoogleCloudPlatform/lb-http/google"
+  version = "10.2.0"
+
+  project                = local.project_id
+  name                   = "mtls-demo"
+  load_balancing_scheme  = "EXTERNAL_MANAGED"
+  create_address         = false
+  address                = google_compute_global_address.mtls-ip.address
+  firewall_networks      = local.vpc_networks
+  firewall_projects      = local.vpc_projects
+  create_url_map         = true
+  ssl                    = true
+  create_ssl_certificate = true
+  certificate            = file("certs/server.cert")
+  private_key            = file("certs/un-server.key")
+  http_forward           = false
+  server_tls_policy      = google_network_security_server_tls_policy.default.id
+  backends = {
+    default = {
+      protocol    = "HTTP"
+      timeout_sec = 60
+      enable_cdn  = false
+      custom_request_headers = [
+        "X-Client-Cert-Present: {client_cert_present}",
+        "X-Client-Cert-Chain-Verified: {client_cert_chain_verified}",
+        "X-Client-Cert-Error: {client_cert_error}",
+        "X-Client-Cert-Hash: {client_cert_sha256_fingerprint}",
+        "X-Client-Cert-Serial-Number: {client_cert_serial_number}",
+        "X-Client-Cert-SPIFFE: {client_cert_spiffe_id}",
+        "X-Client-Cert-URI-SANs: {client_cert_uri_sans}",
+        "X-Client-Cert-DNSName-SANs: {client_cert_dnsname_sans}",
+        "X-Client-Cert-Valid-Not-Before: {client_cert_valid_not_before}",
+        "X-Client-Cert-Valid-Not-After: {client_cert_valid_not_after}",
+        "X-Client-Cert-Issuer-Dn: {client_cert_issuer_dn}",
+        "X-Client-Cert-Subject-Dn: {client_cert_subject_dn}",
+        "X-Client-Cert-Leaf: {client_cert_leaf}"
+      ]
+      health_check = {
+        protocol           = "TCP"
+        port_specification = "USE_FIXED_PORT"
+        port               = "8080"
+      }
+      log_config = {
+        enable      = true
+        sample_rate = 1.0
+      }
+      groups = [
+        for neg in local.zonal_neg_configs :
+        {
+          group                 = "projects/${local.project_id}/zones/${neg.zone}/networkEndpointGroups/${neg.name}"
+          max_rate_per_endpoint = "10000"
+          balancing_mode        = "RATE"
+        }
+      ]
+      iap_config = {
+        enable = false
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Overview

mTLS with GCP Application Load Balancer enhances security by requiring clients to authenticate themselves with certificates, in addition to the server authenticating itself to the client. This provides mutual authentication, ensuring that both parties are who they claim to be.

This repository provides a detailed steps along with the code(kubernetes manifests and terraform scripts) required to deploy a GCP Global application load balancer and a sample app which is configured for both tls and mTLS connection with 2 forwarding rules and also has mTLS custom headers configured which are sent to the backend upon successful mTLS connection.