### PR TITLE
Correct license reference in example

### DIFF
--- a/examples/iam-deny/README.md
+++ b/examples/iam-deny/README.md
@@ -163,5 +163,5 @@ Contributions are welcome! Please refer to the main repository's contributing gu
 
 ## License
 
-Licensed under the Apache License, Version 2.0. See the [LICENSE](../../../LICENSE) file for the full license text.
+Licensed under the Apache License, Version 2.0. See the [LICENSE](../../LICENSE) file for the full license text.
 (Note: Adjust the path to the main LICENSE file if this example is moved).


### PR DESCRIPTION
## PR Summary
This small PR corrects the license reference in `examples/iam-deny/README.md`.