### PR TITLE
Add Dataflow Flex Template: CSV in GCS → DLP de-identification → BigQuery

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ them to fit your particular use case.
     approach
 *   [Dataflow Streaming XML to GCS](examples/dataflow-xml-pubsub-to-gcs) -
     Dataflow example to handle streaming of xml encoded messages and write them to Google Cloud Storage
+*   [Dataflow – DLP Flex De-ID (CSV from GCS to BigQuery)](examples/dataflow-dlp-flex-deid) - Dataflow Flex Template that batches CSV rows from Cloud Storage, de-identifies with Sensitive Data Protection (DLP), and writes to BigQuery.
 *   [Dataflow DLP Hashpipeline](examples/dataflow-dlp-hash-pipeline) - Match DLP
     Social Security Number findings against a hashed dictionary in Firestore.
     Use Secret Manager for the hash key.

--- a/examples/dataflow-dlp-flex-deid/.dockerignore
+++ b/examples/dataflow-dlp-flex-deid/.dockerignore
@@ -1,0 +1,10 @@
+**/.git
+**/.github
+**/__pycache__
+**/.pytest_cache
+*.pyc
+*.pyo
+*.pyd
+*.egg-info
+*.log
+.DS_Store

--- a/examples/dataflow-dlp-flex-deid/.gcloudignore
+++ b/examples/dataflow-dlp-flex-deid/.gcloudignore
@@ -1,0 +1,10 @@
+.git/
+.github/
+__pycache__/
+.pytest_cache/
+*.pyc
+*.pyo
+*.pyd
+*.egg-info/
+*.log
+.DS_Store

--- a/examples/dataflow-dlp-flex-deid/.gitignore
+++ b/examples/dataflow-dlp-flex-deid/.gitignore
@@ -1,0 +1,15 @@
+# Python / build
+__pycache__/
+*.py[cod]
+*.egg-info/
+.build/
+dist/
+
+# Local env / IDE
+.venv/
+.env
+.idea/
+.vscode/
+
+# OS / misc
+.DS_Store

--- a/examples/dataflow-dlp-flex-deid/Dockerfile
+++ b/examples/dataflow-dlp-flex-deid/Dockerfile
@@ -1,0 +1,25 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/dataflow-templates-base/python3-template-launcher-base:PY311-2024-12-01
+
+ENV FLEX_TEMPLATE_PYTHON_PY_FILE=/app/main.py
+ENV FLEX_TEMPLATE_PYTHON_REQUIREMENTS_FILE=/app/requirements.txt
+
+WORKDIR /app
+COPY . /app
+
+RUN pip install --no-cache-dir -r /app/requirements.txt
+
+ENTRYPOINT ["/opt/google/dataflow/python_template_launcher"]

--- a/examples/dataflow-dlp-flex-deid/README.md
+++ b/examples/dataflow-dlp-flex-deid/README.md
@@ -1,0 +1,144 @@
+# Dataflow Flex Template: De-identify CSVs in GCS (DLP) → BigQuery
+
+A runnable Flex Template that takes CSVs in Cloud Storage, calls DLP to de-identify sensitive fields, and writes sanitized rows to BigQuery.
+
+> **Prerequisites**
+> - Google Cloud project with billing enabled
+> - You can run commands either in **Cloud Shell** or locally with the **gcloud** CLI
+> - A DLP **De-identification Template** (`projects/<P>/locations/<L>/deidentifyTemplates/<ID>`)
+
+---
+
+## Parameters
+
+| Name | Required | Default | Description |
+|------|:--------:|---------|-------------|
+| `file_pattern` | ✅ | — | GCS glob to input CSVs |
+| `dataset` | ✅ | — | BigQuery dataset (table is created if needed) |
+| `deidentify_template_name` | ✅ | — | `projects/<P>/locations/<L>/deidentifyTemplates/<ID>` |
+| `csv_headers` **or** `headers_gcs_uri` | ⚙️ | — | Provide headers inline (comma-separated) **or** via a `gs://` file (first line is header) |
+| `batch_size` | ⚙️ | 500 | CSV lines per DLP call |
+| `dlp_api_retry_count` | ⚙️ | 3 | Retries per batch |
+| `skip_header_lines` | ⚙️ | 1 | Header lines to skip in `ReadFromText` |
+| `output_table` | ⚙️ | `output_<templateId>` | Output table name within `dataset` |
+
+> **CSV & headers:** The CSV **must** have the same column order/count as the header names you supply. The DLP `table` item uses those names when returning de-identified rows.
+
+---
+
+## Quickstart (Cloud Shell or local with gcloud)
+
+### Variables
+```bash
+# Run from: examples/dataflow-dlp-flex-deid/
+export PROJECT_ID="<YOUR_PROJECT_ID>"
+export REGION="us-central1"
+export DATASET="sensitive_data"
+export STAGING_BUCKET_NAME="${PROJECT_ID}-dataflow-assets"
+export AR_REPO_NAME="dataflow-images"
+export IMAGE_TAG="${REGION}-docker.pkg.dev/${PROJECT_ID}/${AR_REPO_NAME}/dlp-csv-deid:latest"
+export TEMPLATE_SPEC="gs://${STAGING_BUCKET_NAME}/templates/dlp-csv-deid.json"
+export DEID_TEMPLATE_NAME="projects/${PROJECT_ID}/locations/global/deidentifyTemplates/<TEMPLATE_ID>"
+export SERVICE_ACCOUNT_NAME="dlp-flex-template-runner"
+export SERVICE_ACCOUNT_EMAIL="${SERVICE_ACCOUNT_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
+```
+
+### One-time resources
+```bash
+# Run from: examples/dataflow-dlp-flex-deid/
+gcloud config set project "$PROJECT_ID"
+gcloud services enable \
+  dataflow.googleapis.com dlp.googleapis.com cloudbuild.googleapis.com \
+  artifactregistry.googleapis.com bigquery.googleapis.com compute.googleapis.com
+
+gcloud storage buckets create "gs://${STAGING_BUCKET_NAME}" \
+  --location="$REGION" --uniform-bucket-level-access || true
+
+bq --location="$REGION" mk --dataset "${PROJECT_ID}:${DATASET}" || true
+
+gcloud artifacts repositories create "${AR_REPO_NAME}" \
+  --repository-format=docker --location="${REGION}" || true
+
+gcloud iam service-accounts create "${SERVICE_ACCOUNT_NAME}" \
+  --display-name="DLP Flex Template Runner" || true
+
+for ROLE in roles/dataflow.worker roles/storage.objectAdmin \
+           roles/bigquery.jobUser roles/bigquery.dataEditor \
+           roles/artifactregistry.reader roles/dlp.user
+do
+  gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+    --member="serviceAccount:${SERVICE_ACCOUNT_EMAIL}" \
+    --role="$ROLE" --condition=None
+done
+```
+
+### Build and push the template
+```bash
+# Run from: examples/dataflow-dlp-flex-deid/
+gcloud builds submit \
+  --config cloudbuild.yaml \
+  --substitutions=_IMAGE_TAG="${IMAGE_TAG}" \
+  --project="${PROJECT_ID}" .
+```
+
+### Build the Flex Template spec
+```bash
+# Run from: examples/dataflow-dlp-flex-deid/
+gcloud dataflow flex-template build "${TEMPLATE_SPEC}" \
+  --image "${IMAGE_TAG}" \
+  --sdk-language "PYTHON" \
+  --metadata-file "metadata.json" \
+  --project "${PROJECT_ID}"
+```
+
+### Run the job
+```bash
+# Run from: anywhere
+JOB_NAME="dlp-deid-csv-$(date +%Y%m%d-%H%M%S)"
+
+# Option A — inline headers:
+CSV_HEADERS="name,email,phone"
+
+gcloud dataflow flex-template run "${JOB_NAME}" \
+  --template-file-gcs-location "${TEMPLATE_SPEC}" \
+  --region "${REGION}" \
+  --service-account-email "${SERVICE_ACCOUNT_EMAIL}" \
+  --staging-location "gs://${STAGING_BUCKET_NAME}/staging" \
+  --temp-location "gs://${STAGING_BUCKET_NAME}/temp" \
+  --parameters file_pattern="gs://<INPUT_BUCKET>/<PATH>/*.csv" \
+  --parameters dataset="${DATASET}" \
+  --parameters deidentify_template_name="${DEID_TEMPLATE_NAME}" \
+  --parameters csv_headers="${CSV_HEADERS}" \
+  --parameters output_table="output_example"
+
+# Option B — headers file in GCS (first line is the header row):
+HEADERS_GCS_URI="gs://<INPUT_BUCKET>/headers.txt"
+
+gcloud dataflow flex-template run "${JOB_NAME}" \
+  --template-file-gcs-location "${TEMPLATE_SPEC}" \
+  --region "${REGION}" \
+  --service-account-email "${SERVICE_ACCOUNT_EMAIL}" \
+  --staging-location "gs://${STAGING_BUCKET_NAME}/staging" \
+  --temp-location "gs://${STAGING_BUCKET_NAME}/temp" \
+  --parameters file_pattern="gs://<INPUT_BUCKET>/<PATH>/*.csv" \
+  --parameters dataset="${DATASET}" \
+  --parameters deidentify_template_name="${DEID_TEMPLATE_NAME}" \
+  --parameters headers_gcs_uri="${HEADERS_GCS_URI}" \
+  --parameters output_table="output_example"
+```
+
+> **Output table name:** Defaults to `output_<templateId>` (derived from the last segment of `deidentify_template_name`) unless you set `output_table`.
+
+---
+
+**Optional Private IPs:** add `--network`, `--subnetwork`, and `--disable-public-ips` to the run command and ensure Private Google Access (or Cloud NAT) so workers can reach Google APIs.
+
+---
+
+## Troubleshooting
+
+- **Header mismatch** → ensure headers match CSV columns and your DLP template.
+- **Permission denied** → verify runner service account roles listed in “One-time resources”.
+- **Template not found** → check `deidentify_template_name` and its location (`global` or regional).
+
+---

--- a/examples/dataflow-dlp-flex-deid/cloudbuild.yaml
+++ b/examples/dataflow-dlp-flex-deid/cloudbuild.yaml
@@ -1,0 +1,28 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+- name: gcr.io/cloud-builders/docker
+  args: ['build','-t','${_IMAGE_TAG}','.']
+- name: gcr.io/cloud-builders/docker
+  args: ['push','${_IMAGE_TAG}']
+
+images:
+- '${_IMAGE_TAG}'
+
+substitutions:
+  _IMAGE_TAG: 'REGION-docker.pkg.dev/PROJECT/REPO/dlp-csv-deid:latest'
+
+options:
+  logging: CLOUD_LOGGING_ONLY

--- a/examples/dataflow-dlp-flex-deid/main.py
+++ b/examples/dataflow-dlp-flex-deid/main.py
@@ -1,0 +1,173 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import csv
+import io
+import logging
+import time
+from typing import Iterable, List, Dict, Optional
+
+import apache_beam as beam
+from apache_beam.options.pipeline_options import PipelineOptions
+from apache_beam.options.pipeline_options import GoogleCloudOptions
+
+
+class DlpDeidOptions(PipelineOptions):
+    """Custom options for the DLP de-identification Flex Template."""
+    @classmethod
+    def _add_argparse_args(cls, parser):
+        parser.add_argument("--file_pattern", required=True)
+        parser.add_argument("--dataset", required=True)
+        parser.add_argument("--deidentify_template_name", required=True)
+        parser.add_argument("--csv_headers", default=None,
+                            help="Comma-separated header names matching the CSV")
+        parser.add_argument("--headers_gcs_uri", default=None,
+                            help="gs:// path to a text file whose first line is the CSV header")
+        parser.add_argument("--batch_size", type=int, default=500)
+        parser.add_argument("--dlp_api_retry_count", type=int, default=3)
+        parser.add_argument("--skip_header_lines", type=int, default=1)
+        parser.add_argument("--output_table", default=None,
+                            help="Output table name (defaults to output_<DLP template id>)")
+
+
+def build_table_schema(headers: List[str]) -> Dict[str, List[Dict[str, str]]]:
+    """Build a BigQuery schema with STRING fields for each header."""
+    fields = [{"name": h, "type": "STRING", "mode": "NULLABLE"} for h in headers]
+    return {"fields": fields}
+
+
+def parse_headers_from_csv_line(line: str) -> List[str]:
+    return next(csv.reader(io.StringIO(line)))
+
+
+class DeidentifyWithDLP(beam.DoFn):
+    """Batch DoFn that calls DLP deidentifyContent on a table-shaped ContentItem."""
+    def __init__(self, *, headers: List[str], template_name: str, retry_count: int):
+        self._headers = headers
+        self._template_name = template_name
+        self._retry_count = retry_count
+        self._project_id = template_name.split("/")[1]
+        self._dlp_client = None
+
+    def setup(self):
+        from google.cloud import dlp_v2
+        self._dlp_client = dlp_v2.DlpServiceClient()
+
+    def process(self, batch: Iterable[str]) -> Iterable[List[Dict[str, str]]]:
+        rows = []
+        for line in batch:
+            try:
+                values = next(csv.reader(io.StringIO(line)))
+            except StopIteration:
+                logging.warning("Skipping empty or malformed line: %r", line)
+                continue
+            if len(values) != len(self._headers):
+                logging.warning(
+                    "Skipping row with column mismatch. expected=%d actual=%d line=%r",
+                    len(self._headers), len(values), line,
+                )
+                continue
+            rows.append({"values": [{"string_value": v} for v in values]})
+
+        if not rows:
+            return
+
+        dlp_table = {"headers": [{"name": h} for h in self._headers], "rows": rows}
+        request = {
+            "parent": f"projects/{self._project_id}",
+            "deidentify_template_name": self._template_name,
+            "item": {"table": dlp_table},
+        }
+
+        for attempt in range(self._retry_count):
+            try:
+                response = self._dlp_client.deidentify_content(request=request)
+                output_rows: List[Dict[str, str]] = []
+                for row in response.item.table.rows:
+                    output_rows.append({
+                        self._headers[i]: val.string_value
+                        for i, val in enumerate(row.values)
+                    })
+                yield output_rows
+                break
+            except Exception as e:
+                logging.warning("DLP API call failed (attempt %d/%d): %s",
+                                attempt + 1, self._retry_count, e)
+                if attempt < self._retry_count - 1:
+                    time.sleep(2 ** attempt)
+                else:
+                    logging.error("All retries failed for batch (first row shown): %r",
+                                  batch[0] if batch else None)
+
+
+def run():
+    options = PipelineOptions(save_main_session=True, streaming=False)
+    opts = options.view_as(DlpDeidOptions)
+    gcp = options.view_as(GoogleCloudOptions)
+
+    # Resolve headers from parameters
+    headers: Optional[List[str]] = None
+    if opts.csv_headers:
+        headers = [h.strip() for h in opts.csv_headers.split(",") if h.strip()]
+    elif opts.headers_gcs_uri:
+        from google.cloud import storage
+        if not opts.headers_gcs_uri.startswith("gs://"):
+            raise ValueError("headers_gcs_uri must be a gs:// path")
+        _, path = opts.headers_gcs_uri.split("gs://", 1)
+        bucket_name, _, object_path = path.partition("/")
+        client = storage.Client()
+        data = client.bucket(bucket_name).blob(object_path).download_as_text()
+        first_line = data.splitlines()[0] if data else ""
+        headers = parse_headers_from_csv_line(first_line)
+    else:
+        raise ValueError("Provide either --csv_headers or --headers_gcs_uri")
+
+    if not headers:
+        raise ValueError("No CSV headers resolved")
+
+    # Default output table naming: output_<templateId>
+    template_suffix = opts.deidentify_template_name.split("/")[-1]
+    output_table = opts.output_table or f"output_{template_suffix}"
+
+    # Determine project for BigQuery sink
+    bq_project = gcp.project or opts.deidentify_template_name.split("/")[1]
+    table_spec = f"{bq_project}:{opts.dataset}.{output_table}"
+
+    table_schema = build_table_schema(headers)
+
+    with beam.Pipeline(options=options) as p:
+        (
+            p
+            | "ReadFromGCS" >> beam.io.ReadFromText(
+                opts.file_pattern, skip_header_lines=opts.skip_header_lines)
+            | "BatchForDLP" >> beam.BatchElements(
+                min_batch_size=opts.batch_size, max_batch_size=opts.batch_size)
+            | "CallDLP" >> beam.ParDo(DeidentifyWithDLP(
+                headers=headers,
+                template_name=opts.deidentify_template_name,
+                retry_count=opts.dlp_api_retry_count,
+            ))
+            | "FlattenBatches" >> beam.FlatMap(lambda rows: rows)
+            | "WriteToBQ" >> beam.io.WriteToBigQuery(
+                table=table_spec,
+                schema=table_schema,
+                write_disposition=beam.io.BigQueryDisposition.WRITE_TRUNCATE,
+                create_disposition=beam.io.BigQueryDisposition.CREATE_IF_NEEDED,
+            )
+        )
+
+
+if __name__ == "__main__":
+    logging.getLogger().setLevel(logging.INFO)
+    run()

--- a/examples/dataflow-dlp-flex-deid/metadata.json
+++ b/examples/dataflow-dlp-flex-deid/metadata.json
@@ -1,0 +1,14 @@
+{
+  "name": "deidentify-csv-gcs-to-bq",
+  "description": "De-identifies structured CSV data from GCS using a DLP template and writes it to BigQuery.",
+  "parameters": [
+    { "name": "file_pattern", "label": "Input GCS file pattern", "helpText": "e.g. gs://<bucket>/*.csv", "regexes": ["^gs://.*$"] },
+    { "name": "dataset", "label": "Output BigQuery Dataset", "helpText": "BigQuery dataset where the output table will be created." },
+    { "name": "deidentify_template_name", "label": "DLP De-identification Template", "helpText": "Full resource name, e.g. projects/<PROJECT_ID>/locations/<LOCATION>/deidentifyTemplates/<TEMPLATE_ID>" },
+    { "name": "csv_headers", "label": "CSV headers (comma-separated)", "helpText": "Provide column names matching the CSV and DLP template (alternative to headers_gcs_uri)", "optional": true },
+    { "name": "headers_gcs_uri", "label": "Headers file (gs://)", "helpText": "GCS path to a text file whose first line is the header row (alternative to csv_headers)", "regexes": ["^gs://.*$"], "optional": true },
+    { "name": "batch_size", "label": "Batch size", "helpText": "CSV lines per DLP call (keep within DLP request limits)", "optional": true },
+    { "name": "skip_header_lines", "label": "Skip header lines", "helpText": "Number of header lines to skip when reading CSV", "optional": true },
+    { "name": "output_table", "label": "Output table name", "helpText": "Defaults to output_<DLP template id>", "optional": true }
+  ]
+}

--- a/examples/dataflow-dlp-flex-deid/requirements.txt
+++ b/examples/dataflow-dlp-flex-deid/requirements.txt
@@ -1,0 +1,3 @@
+google-cloud-dlp>=3.14.0,<4.0.0
+# Only needed if you use --headers_gcs_uri
+google-cloud-storage>=2.14.0,<3.0.0

--- a/examples/dataflow-dlp-flex-deid/tests/test_csv_to_dlp_rows.py
+++ b/examples/dataflow-dlp-flex-deid/tests/test_csv_to_dlp_rows.py
@@ -1,0 +1,35 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+import pathlib
+
+# Load main.py without installing as a module
+_spec = importlib.util.spec_from_file_location(
+    "example_main", pathlib.Path(__file__).resolve().parents[1] / "main.py"
+)
+_main = importlib.util.module_from_spec(_spec)
+assert _spec.loader is not None
+_spec.loader.exec_module(_main)  # type: ignore
+
+def test_build_table_schema():
+    headers = ["name", "email", "phone"]
+    schema = _main.build_table_schema(headers)
+    assert "fields" in schema
+    assert [f["name"] for f in schema["fields"]] == headers
+    assert all(f["type"] == "STRING" for f in schema["fields"])
+
+def test_parse_headers_from_csv_line():
+    headers = _main.parse_headers_from_csv_line("a,b,c\n")
+    assert headers == ["a","b","c"]


### PR DESCRIPTION
This PR adds a new example under `examples/dataflow-dlp-flex-deid`.

The example shows how to build and run a Python Dataflow Flex Template that:
- Reads CSV files from Cloud Storage
- Batches rows and calls Sensitive Data Protection (DLP) `deidentifyContent` on a table-shaped item
- Writes sanitized rows to BigQuery

Included in this contribution:
- `main.py` Beam pipeline
- `metadata.json` with template parameters
- `Dockerfile`, `requirements.txt`, and `cloudbuild.yaml` for building the Flex Template
- Unit tests (`tests/test_csv_to_dlp_rows.py`)
- Example-level `.gitignore`
- `README.md` with full usage instructions
- Link to this example in the top-level README (alphabetical order)

All files include Apache 2.0 license headers with the current year and attribution to Google LLC.