### PR TITLE
build(ci): update deprecated GitHub Actions to use Node 20/24 compatible versions

### DIFF
--- a/examples/cloud-functions-act-as/.github/workflows/call-function.yml
+++ b/examples/cloud-functions-act-as/.github/workflows/call-function.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Assign environment variables
         run: |
@@ -42,14 +42,14 @@ jobs:
 
       - id: 'auth'
         name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@v0.6.0'
+        uses: 'google-github-actions/auth@v2'
         with:
           token_format: 'access_token'
           workload_identity_provider: "projects/${{ env.project_number }}/locations/global/workloadIdentityPools/${{ env.wi_pool_name }}/providers/wip-github"
           service_account: 'wi-sample-account@${{ env.project_id }}.iam.gserviceaccount.com'
 
       - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v0'
+        uses: 'google-github-actions/setup-gcloud@v2'
 
       - id: 'store-token'
         name: 'Store Access Token'

--- a/examples/vertex_mlops_enterprise/.github/workflows/containers.yml.TEMPLATE
+++ b/examples/vertex_mlops_enterprise/.github/workflows/containers.yml.TEMPLATE
@@ -39,13 +39,13 @@ jobs:
     name: 'Build container CI/CD BigQuery ML'
     runs-on: 'ubuntu-latest'
     steps:
-    - uses: 'actions/checkout@v3'
+    - uses: 'actions/checkout@v4'
       with:
         token: $${{ github.token }}
          
     - id: 'auth'
       name: 'Authenticate to Google Cloud'
-      uses: 'google-github-actions/auth@v1'
+      uses: 'google-github-actions/auth@v2'
       with:
         create_credentials_file: 'true'
         workload_identity_provider: $${{ env.WORKLOAD_ID_PROVIDER }}
@@ -60,13 +60,13 @@ jobs:
     name: 'Build container CI/CD TFX'
     runs-on: 'ubuntu-latest'
     steps:
-    - uses: 'actions/checkout@v3'
+    - uses: 'actions/checkout@v4'
       with:
         token: $${{ github.token }}
          
     - id: 'auth'
       name: 'Authenticate to Google Cloud'
-      uses: 'google-github-actions/auth@v1'
+      uses: 'google-github-actions/auth@v2'
       with:
         create_credentials_file: 'true'
         workload_identity_provider: $${{ env.WORKLOAD_ID_PROVIDER }}
@@ -83,13 +83,13 @@ jobs:
     name: 'Build container CI/CD KFP'
     runs-on: 'ubuntu-latest'
     steps:
-    - uses: 'actions/checkout@v3'
+    - uses: 'actions/checkout@v4'
       with:
         token: $${{ github.token }}
          
     - id: 'auth'
       name: 'Authenticate to Google Cloud'
-      uses: 'google-github-actions/auth@v1'
+      uses: 'google-github-actions/auth@v2'
       with:
         create_credentials_file: 'true'
         workload_identity_provider: $${{ env.WORKLOAD_ID_PROVIDER }}
@@ -104,13 +104,13 @@ jobs:
     name: 'Build container for Model Card'
     runs-on: 'ubuntu-latest'
     steps:
-    - uses: 'actions/checkout@v3'
+    - uses: 'actions/checkout@v4'
       with:
         token: $${{ github.token }}
          
     - id: 'auth'
       name: 'Authenticate to Google Cloud'
-      uses: 'google-github-actions/auth@v1'
+      uses: 'google-github-actions/auth@v2'
       with:
         create_credentials_file: 'true'
         workload_identity_provider: $${{ env.WORKLOAD_ID_PROVIDER }}
@@ -126,13 +126,13 @@ jobs:
     name: 'Build container Vertex'
     runs-on: 'ubuntu-latest'
     steps:
-    - uses: 'actions/checkout@v3'
+    - uses: 'actions/checkout@v4'
       with:
         token: $${{ github.token }}
          
     - id: 'auth'
       name: 'Authenticate to Google Cloud'
-      uses: 'google-github-actions/auth@v1'
+      uses: 'google-github-actions/auth@v2'
       with:
         create_credentials_file: 'true'
         workload_identity_provider: $${{ env.WORKLOAD_ID_PROVIDER }}
@@ -148,13 +148,13 @@ jobs:
     name: 'Build container Dataflow'
     runs-on: 'ubuntu-latest'
     steps:
-    - uses: 'actions/checkout@v3'
+    - uses: 'actions/checkout@v4'
       with:
         token: $${{ github.token }}
          
     - id: 'auth'
       name: 'Authenticate to Google Cloud'
-      uses: 'google-github-actions/auth@v1'
+      uses: 'google-github-actions/auth@v2'
       with:
         create_credentials_file: 'true'
         workload_identity_provider: $${{ env.WORKLOAD_ID_PROVIDER }}

--- a/examples/vertex_mlops_enterprise/.github/workflows/deploy.yml.TEMPLATE
+++ b/examples/vertex_mlops_enterprise/.github/workflows/deploy.yml.TEMPLATE
@@ -34,13 +34,13 @@ jobs:
     name: 'Deploy TFX model to endpoint'
     runs-on: 'ubuntu-latest'
     steps:
-    - uses: 'actions/checkout@v3'
+    - uses: 'actions/checkout@v4'
       with:
         token: $${{ github.token }}
          
     - id: 'auth'
       name: 'Authenticate to Google Cloud'
-      uses: 'google-github-actions/auth@v1'
+      uses: 'google-github-actions/auth@v2'
       with:
         create_credentials_file: 'true'
         workload_identity_provider: $${{ env.WORKLOAD_ID_PROVIDER }}

--- a/examples/vertex_mlops_enterprise/.github/workflows/main.yml.TEMPLATE
+++ b/examples/vertex_mlops_enterprise/.github/workflows/main.yml.TEMPLATE
@@ -34,13 +34,13 @@ jobs:
     name: 'Compile Vertex AI pipeline'
     runs-on: 'ubuntu-latest'
     steps:
-    - uses: 'actions/checkout@v3'
+    - uses: 'actions/checkout@v4'
       with:
         token: $${{ github.token }}
          
     - id: 'auth'
       name: 'Authenticate to Google Cloud'
-      uses: 'google-github-actions/auth@v1'
+      uses: 'google-github-actions/auth@v2'
       with:
         create_credentials_file: 'true'
         workload_identity_provider: $${{ env.WORKLOAD_ID_PROVIDER }}

--- a/examples/vertex_mlops_enterprise/.github/workflows/run.yml.TEMPLATE
+++ b/examples/vertex_mlops_enterprise/.github/workflows/run.yml.TEMPLATE
@@ -34,13 +34,13 @@ jobs:
     name: 'Run Vertex AI ${framework} pipeline'
     runs-on: 'ubuntu-latest'
     steps:
-    - uses: 'actions/checkout@v3'
+    - uses: 'actions/checkout@v4'
       with:
         token: $${{ github.token }}
          
     - id: 'auth'
       name: 'Authenticate to Google Cloud'
-      uses: 'google-github-actions/auth@v1'
+      uses: 'google-github-actions/auth@v2'
       with:
         create_credentials_file: 'true'
         workload_identity_provider: $${{ env.WORKLOAD_ID_PROVIDER }}


### PR DESCRIPTION
### Summary
This PR updates several deprecated GitHub Actions used in examples and templates to their latest major versions. This addresses the GitHub announcement regarding the deprecation of Node 20 actions and their transition to Node 24.

### Changes
Upgraded the following actions in example workflows and templates:
*   `actions/checkout`: upgraded `@v2` and `@v3` to `@v4`
*   `google-github-actions/auth`: upgraded `@v0.6.0` and `@v1` to `@v2`
*   `google-github-actions/setup-gcloud`: upgraded `@v0` to `@v2`

### Files Impacted
1.  `examples/cloud-functions-act-as/.github/workflows/call-function.yml`
2.  `examples/vertex_mlops_enterprise/.github/workflows/main.yml.TEMPLATE`
3.  `examples/vertex_mlops_enterprise/.github/workflows/containers.yml.TEMPLATE`
4.  `examples/vertex_mlops_enterprise/.github/workflows/deploy.yml.TEMPLATE`
5.  `examples/vertex_mlops_enterprise/.github/workflows/run.yml.TEMPLATE`