### PR TITLE
feat(agent-eval): add Cloud Build configuration for linting and tests

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -7,6 +7,10 @@ steps:
 #  name: google/cloud-sdk
 #  args: [gcloud, builds, submit, tools/hive-bigquery/, --config=tools/hive-bigquery/cloudbuild.yaml]
 #  waitFor: ['-']
+#- id: tools/agent-eval
+#  name: google/cloud-sdk
+#  args: [gcloud, builds, submit, tools/agent-eval/, --config=tools/agent-eval/cloudbuild.yaml]
+#  waitFor: ['-']
 #- id: examples/cloud-composer-examples
 #  name: google/cloud-sdk
 #  args: [gcloud, builds, submit, examples/cloud-composer-examples/,

--- a/tools/agent-eval/cloudbuild.yaml
+++ b/tools/agent-eval/cloudbuild.yaml
@@ -1,0 +1,35 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+- id: 'lint'
+  name: 'python:3.11'
+  entrypoint: 'bash'
+  args:
+  - '-c'
+  - |
+    pip install uv
+    uv run --frozen ruff check
+    uv run --frozen ruff format --check
+  dir: 'tools/agent-eval'
+
+- id: 'tests'
+  name: 'python:3.11'
+  entrypoint: 'bash'
+  args:
+  - '-c'
+  - |
+    pip install uv
+    uv run --frozen pytest
+  dir: 'tools/agent-eval'


### PR DESCRIPTION
### Summary
This PR adds a Google Cloud Build configuration for the `agent-eval` tool to enable automated linting and unit testing in CI/CD.

### Changes
*   **Created `tools/agent-eval/cloudbuild.yaml`**: Defines a two-step build process using a `python:3.11` container:
    1.  `lint`: Installs `uv` and runs `ruff check` and `ruff format --check`.
    2.  `tests`: Installs `uv` and runs the `pytest` suite.
    *   Both steps use `uv run --frozen` to ensure dependencies are resolved exactly from `uv.lock` and prevent lockfile modification during build.
*   **Updated root `cloudbuild.yaml`**: Added a commented-out step for `tools/agent-eval` to match the repository's pattern for documenting tool-specific builds.

### Action Required for Maintainers
To enable this check on PRs, a GCP project administrator will need to configure a new Cloud Build Trigger:
*   **Event**: Pull Request
*   **Build configuration**: Cloud Build configuration file (`tools/agent-eval/cloudbuild.yaml`)
*   **Included files filter**: `tools/agent-eval/**` (to ensure it only runs when `agent-eval` changes)