### PR TITLE
chore(agent-eval): configure Ruff linter with minimal rules

### DIFF
--- a/tools/agent-eval/pyproject.toml
+++ b/tools/agent-eval/pyproject.toml
@@ -47,3 +47,17 @@ dev = [
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 norecursedirs = ["my-agent", "agents", ".venv", ".backup", "build", "dist"]
+
+[tool.ruff]
+target-version = "py310"
+line-length = 88
+
+[tool.ruff.lint]
+select = [
+    "E",    # pycodestyle errors
+    "W",    # pycodestyle warnings
+    "F",    # Pyflakes
+]
+ignore = [
+    "E501",  # line too long
+]

--- a/tools/agent-eval/src/agent_eval/core/html_report.py
+++ b/tools/agent-eval/src/agent_eval/core/html_report.py
@@ -2596,7 +2596,7 @@ _HTML_TEMPLATE = r"""<!doctype html>
             const sym = subPass === true ? '✓' : subPass === false ? '✗' : (sub.label === 'no_rad' ? '·' : '—');
             const cls = subPass === true ? 'verdict-pass' : subPass === false ? 'verdict-fail' : 'verdict-na';
             const scoreStr = (typeof subScore === 'number') ? subScore.toFixed(2) : (sub.label ? sub.label.toUpperCase() : '');
-            
+
             return '<div class="verdict-item">' +
               '<div class="verdict-head">' +
                 '<span class="verdict-sym ' + cls + '">' + sym + '</span>' +


### PR DESCRIPTION
### Summary
Configures the Ruff linter for the `agent-eval` tool with an ultra-minimal rule set to establish code quality gates without introducing large style refactors or file churn.

### Changes
1.  **Minimal Ruff Configuration (`pyproject.toml`)**:
    *   Enabled only the core rules: `E` (style errors), `W` (style warnings), and `F` (Pyflakes logic/syntax errors).
    *   Explicitly ignored `E501` (line length) to avoid formatting churn.
    *   Excluded strict formatting or import sorting rules (like `I` / `isort`) to prevent unnecessary changes to existing files.
2.  **Lint Fix (`src/agent_eval/core/html_report.py`)**:
    *   Resolved the single true violation in the codebase: removed a trailing whitespace line at L2599.

### Impact
*   Establishes a lightweight linting framework that can be run locally via `ruff check` or in CI.
*   Introduces **zero functional changes** and **practically zero code churn** (only 2 files modified in total).
*   Enables smooth, conflict-free rebasing for all stacked branches.