### PR TITLE
style(agent-eval): enable Ruff isort and format imports across codebase

### DIFF
--- a/tools/agent-eval/pyproject.toml
+++ b/tools/agent-eval/pyproject.toml
@@ -57,6 +57,7 @@ select = [
     "E",    # pycodestyle errors
     "W",    # pycodestyle warnings
     "F",    # Pyflakes
+    "I",    # isort (import sorting)
 ]
 ignore = [
     "E501",  # line too long

--- a/tools/agent-eval/src/agent_eval/cli/_stories.py
+++ b/tools/agent-eval/src/agent_eval/cli/_stories.py
@@ -758,8 +758,8 @@ def render_story_panel(
     ``StoryStreamer`` instead — Panels feel like UI; prose feels like
     reading.
     """
-    from rich.panel import Panel
     from rich.padding import Padding
+    from rich.panel import Panel
 
     title_str = f"[bold]{title}[/]"
     if index is not None and total is not None:
@@ -882,9 +882,9 @@ class StoryStreamer:
         # Windows / no termios → fall back to a one-shot welcome and exit
         # rather than crashing.
         try:
+            import select
             import termios
             import tty
-            import select
         except ImportError:
             self._console.print()
             self._console.print(

--- a/tools/agent-eval/src/agent_eval/cli/commands/agent_engine.py
+++ b/tools/agent-eval/src/agent_eval/cli/commands/agent_engine.py
@@ -657,8 +657,8 @@ def _ensure_bucket_exists(
         return
 
     try:
-        from google.cloud import storage
         from google.api_core.exceptions import Forbidden, GoogleAPICallError
+        from google.cloud import storage
     except ImportError:
         return  # storage not installed — let the SDK error speak for itself.
 
@@ -1219,6 +1219,7 @@ def _print_dashboard_url(run: Any, project: str, location: str) -> None:
 def _wait_for_run(client: Any, run: Any, *, timeout: int) -> Any:
     """Poll get_evaluation_run until terminal state or timeout."""
     import time
+
     from vertexai._genai.types import EvaluationRunState
 
     terminal = {

--- a/tools/agent-eval/src/agent_eval/cli/commands/analyze.py
+++ b/tools/agent-eval/src/agent_eval/cli/commands/analyze.py
@@ -24,7 +24,6 @@ from rich.console import Console
 from rich.markdown import Markdown
 from rich.panel import Panel
 from rich.rule import Rule
-
 from rich.table import Table
 
 from agent_eval.cli._pacing import _pauses_disabled
@@ -429,8 +428,9 @@ def analyze(
     # already declined via --no-open at run time. webbrowser.open returns
     # False on remote/headless systems — we surface --serve in that case.
     if rel_html and not _pauses_disabled() and sys.stdin.isatty():
-        from rich.prompt import Confirm
         import webbrowser
+
+        from rich.prompt import Confirm
 
         if Confirm.ask(
             "\n  Open the report in your default browser now?", default=True

--- a/tools/agent-eval/src/agent_eval/cli/commands/init.py
+++ b/tools/agent-eval/src/agent_eval/cli/commands/init.py
@@ -684,7 +684,6 @@ STARTER_METRICS = [
 ]
 
 
-
 def _find_agents(search_dir: Path) -> list[tuple[str, Path]]:
     """Find ADK agents by looking for agent.py files.
 
@@ -809,6 +808,8 @@ def _verify_environment(auto_approve: bool = False) -> None:
     # import the other way would create a cycle at module load time.
     from agent_eval.cli.commands.setup import (
         _adc_file_path,
+    )
+    from agent_eval.cli.commands.setup import (
         _check_api_enabled as _setup_check_api,
     )
 
@@ -1344,6 +1345,7 @@ def _display_metrics_education(managed_metrics: Dict[str, Dict]) -> None:
     Then a callout that the picker is SDK-introspected — resilient to upstream changes.
     """
     from rich.syntax import Syntax
+
     from agent_eval.core import metric_families
 
     # Mirror the picker's grouping (anything classified as "custom" — i.e. GCS YAML
@@ -3357,8 +3359,8 @@ def init(target_dir, agent_name, mode, auto_approve, ai_metrics):
                     )
                     from agent_eval.core.metric_generator import (
                         analyze_agent_data,
-                        generate_metric_definitions,
                         generate_eval_data,
+                        generate_metric_definitions,
                     )
 
                     # Per Vertex AI docs: start with GENERAL_QUALITY as the default.
@@ -3606,7 +3608,7 @@ def _explain_metrics_file(path: Path, custom_metrics: Optional[Dict[str, Any]]) 
 def _explain_dataset_file(path: Path) -> None:
     """Render a row breakdown of the unified dataset.jsonl so the user
     sees the kinds of rows we generated and which paths each one feeds."""
-    from agent_eval.core.dataset_io import read_dataset, is_multi_turn, is_single_turn
+    from agent_eval.core.dataset_io import is_multi_turn, is_single_turn, read_dataset
 
     try:
         rows = read_dataset(path)

--- a/tools/agent-eval/src/agent_eval/cli/commands/interact.py
+++ b/tools/agent-eval/src/agent_eval/cli/commands/interact.py
@@ -25,10 +25,10 @@ from rich.panel import Panel
 from rich.rule import Rule
 
 from agent_eval.cli._pacing import _continue
-from agent_eval.core.interactions import InteractionRunner
-from agent_eval.core.processor import InteractionProcessor
 from agent_eval.core.converters import write_jsonl
+from agent_eval.core.interactions import InteractionRunner
 from agent_eval.core.path_resolver import find_eval_dir
+from agent_eval.core.processor import InteractionProcessor
 
 console = Console()
 
@@ -274,8 +274,9 @@ def interact(
 
     if in_process:
         import asyncio
-        from agent_eval.core.simulation import run_simulation_in_process
+
         from agent_eval.core.path_resolver import agent_project_root
+        from agent_eval.core.simulation import run_simulation_in_process
 
         project_root = agent_project_root(agent_path)
         dataset_path = Path(questions_file)

--- a/tools/agent-eval/src/agent_eval/cli/commands/report.py
+++ b/tools/agent-eval/src/agent_eval/cli/commands/report.py
@@ -75,8 +75,8 @@ def _serve(report: Path, port_hint: int = 0) -> None:
     port_hint=0 → OS picks a free port. Otherwise we try the hint first.
     """
     import http.server
-    import socketserver
     import socket
+    import socketserver
 
     serve_dir = report.parent
     rel_to_serve_root = report.name  # always 'report.html'

--- a/tools/agent-eval/src/agent_eval/cli/commands/run.py
+++ b/tools/agent-eval/src/agent_eval/cli/commands/run.py
@@ -441,7 +441,7 @@ def run(
         sys.exit(1)
 
     # Count rows by capability — single source of truth for what phases can run.
-    from agent_eval.core.dataset_io import read_dataset, is_multi_turn, is_single_turn
+    from agent_eval.core.dataset_io import is_multi_turn, is_single_turn, read_dataset
 
     try:
         _all_rows = read_dataset(dataset_path)
@@ -492,6 +492,7 @@ def run(
         # who started the agent on a non-default port aren't punished.
         if run_interact and not in_process:
             from concurrent.futures import ThreadPoolExecutor
+
             from rich.prompt import Prompt
 
             def _check_url(url: str, timeout: float = 1.5) -> bool:
@@ -1692,8 +1693,8 @@ def _run_simulate_phase(
     pressure). Eval_history files are timestamp-suffixed → no collisions.
     """
     if in_process:
-        from agent_eval.core.simulation import run_simulation_in_process
         from agent_eval.core.converters import write_jsonl
+        from agent_eval.core.simulation import run_simulation_in_process
 
         dataset_path = project_root / "tests" / "eval" / "dataset.jsonl"
         if not dataset_path.exists():
@@ -2083,9 +2084,9 @@ def _run_interact_phase(
     debug: bool = False,
 ) -> Path | None:
     """Run the interact workflow. Returns the output path on success, None on failure."""
+    from agent_eval.core.converters import write_jsonl
     from agent_eval.core.interactions import InteractionRunner
     from agent_eval.core.processor import InteractionProcessor
-    from agent_eval.core.converters import write_jsonl
 
     config = {
         "app_name": app_name,
@@ -2110,7 +2111,7 @@ def _run_interact_phase(
     try:
         qf = Path(questions_file)
         if qf.suffix.lower() == ".jsonl":
-            from agent_eval.core.dataset_io import read_dataset, is_single_turn
+            from agent_eval.core.dataset_io import is_single_turn, read_dataset
 
             _q_count = sum(1 for r in read_dataset(qf) if is_single_turn(r))
         else:
@@ -2200,8 +2201,8 @@ def _run_evaluate_phase(
     debug: bool = False,
 ) -> None:
     """Run the evaluate workflow."""
-    from agent_eval.core.evaluator import Evaluator
     from agent_eval.cli.commands.evaluate import _display_metrics_summary
+    from agent_eval.core.evaluator import Evaluator
 
     eval_config = {
         "metric_filters": None,
@@ -2238,8 +2239,8 @@ def _run_analyze_phase(
     debug: bool = False,
 ) -> dict:
     """Run the analyze workflow. Returns the analysis result dict or None."""
-    from agent_eval.core.analyzer import Analyzer
     from agent_eval.cli.commands.analyze import _display_metrics_table
+    from agent_eval.core.analyzer import Analyzer
 
     config = {
         "results_dir": str(run_dir),

--- a/tools/agent-eval/src/agent_eval/cli/commands/simulate.py
+++ b/tools/agent-eval/src/agent_eval/cli/commands/simulate.py
@@ -203,7 +203,7 @@ def _project_dataset_to_adk_files(
 
     Returns ``(scenario_count, source_label)`` for logging.
     """
-    from agent_eval.core.dataset_io import read_dataset, is_multi_turn
+    from agent_eval.core.dataset_io import is_multi_turn, read_dataset
 
     dataset_path = project_root / "tests" / "eval" / "dataset.jsonl"
     if not dataset_path.exists():
@@ -768,9 +768,10 @@ def simulate(agent_dir, eval_dir, run_id, debug, in_process):
 
     if in_process:
         import asyncio
-        from agent_eval.core.simulation import run_simulation_in_process
+
         from agent_eval.core.converters import write_jsonl
         from agent_eval.core.path_resolver import agent_project_root, find_dataset_path
+        from agent_eval.core.simulation import run_simulation_in_process
 
         project_root = agent_project_root(agent_path)
         dataset_path = find_dataset_path(agent_path)

--- a/tools/agent-eval/src/agent_eval/cli/commands/stories.py
+++ b/tools/agent-eval/src/agent_eval/cli/commands/stories.py
@@ -32,7 +32,7 @@ import click
 from rich.console import Console
 from rich.rule import Rule
 
-from agent_eval.cli._stories import STORIES, render_story_panel, random_story
+from agent_eval.cli._stories import STORIES, random_story, render_story_panel
 
 console = Console()
 

--- a/tools/agent-eval/src/agent_eval/cli/main.py
+++ b/tools/agent-eval/src/agent_eval/cli/main.py
@@ -80,20 +80,20 @@ def cli() -> None:
 
 # --- Register commands ---
 
-from agent_eval.cli.commands.interact import interact  # noqa: E402
-from agent_eval.cli.commands.evaluate import evaluate  # noqa: E402
 from agent_eval.cli.commands.analyze import analyze  # noqa: E402
 from agent_eval.cli.commands.convert import convert  # noqa: E402
 from agent_eval.cli.commands.create_dataset import create_dataset  # noqa: E402
+from agent_eval.cli.commands.dashboard import dashboard  # noqa: E402
+from agent_eval.cli.commands.evaluate import evaluate  # noqa: E402
+from agent_eval.cli.commands.import_adk import import_adk  # noqa: E402
 from agent_eval.cli.commands.init import init  # noqa: E402
+from agent_eval.cli.commands.interact import interact  # noqa: E402
+from agent_eval.cli.commands.migrate import migrate  # noqa: E402
+from agent_eval.cli.commands.report import report  # noqa: E402
+from agent_eval.cli.commands.run import run  # noqa: E402
 from agent_eval.cli.commands.setup import setup  # noqa: E402
 from agent_eval.cli.commands.simulate import simulate  # noqa: E402
-from agent_eval.cli.commands.run import run  # noqa: E402
-from agent_eval.cli.commands.dashboard import dashboard  # noqa: E402
-from agent_eval.cli.commands.import_adk import import_adk  # noqa: E402
-from agent_eval.cli.commands.migrate import migrate  # noqa: E402
 from agent_eval.cli.commands.stories import stories  # noqa: E402
-from agent_eval.cli.commands.report import report  # noqa: E402
 
 # Order matches the Vertex AI eval docs sidebar workflow so `agent-eval --help`
 # reads top-down as: set up → bring in data → generate traces → score →

--- a/tools/agent-eval/src/agent_eval/core/analyzer.py
+++ b/tools/agent-eval/src/agent_eval/core/analyzer.py
@@ -922,7 +922,7 @@ class Analyzer:
 
     def _get_gemini_client(self):
         """Initialize and return (model_name, genai.Client) for Gemini calls."""
-        from agent_eval.core.config import get_project_id, get_location
+        from agent_eval.core.config import get_location, get_project_id
 
         model = self.config.get("model", "gemini-3.1-pro-preview")
 

--- a/tools/agent-eval/src/agent_eval/core/config.py
+++ b/tools/agent-eval/src/agent_eval/core/config.py
@@ -14,6 +14,7 @@
 import os
 from pathlib import Path
 from typing import Dict, List, Optional
+
 from dotenv import load_dotenv
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict

--- a/tools/agent-eval/src/agent_eval/core/converters.py
+++ b/tools/agent-eval/src/agent_eval/core/converters.py
@@ -11,14 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import glob
 import json
 import logging
 import os
-import glob
-import uuid
 import time
+import uuid
 from datetime import datetime
-from typing import Dict, Any, List, Optional
+from typing import Any, Dict, List, Optional
 
 from agent_eval.core.agent_client import AgentClient
 

--- a/tools/agent-eval/src/agent_eval/core/data_mapper.py
+++ b/tools/agent-eval/src/agent_eval/core/data_mapper.py
@@ -15,6 +15,7 @@ import ast
 import json
 import logging
 from typing import Any, Dict, List, Optional, Union
+
 import pandas as pd
 from google.genai import types as genai_types
 from vertexai import types

--- a/tools/agent-eval/src/agent_eval/core/evaluator.py
+++ b/tools/agent-eval/src/agent_eval/core/evaluator.py
@@ -15,10 +15,10 @@ import asyncio
 import json
 import logging
 import math
+import statistics
 import subprocess
 import sys
 import time
-import statistics
 from collections import defaultdict
 from datetime import datetime
 from pathlib import Path
@@ -29,24 +29,25 @@ from google.cloud import aiplatform
 from google.genai.types import HttpOptions
 from vertexai import Client, types
 
-from agent_eval.core.metric_schema import (
-    SDK_COLUMN_DEFAULTS as _SDK_COLUMN_DEFAULTS,
-    MANAGED_METRIC_REQUIRED_COLUMNS as _MANAGED_METRIC_REQUIRED_COLUMNS,
-)
-
 from agent_eval.core.config import CONFIG, get_project_id
-from agent_eval.core.deterministic_metrics import (
-    DETERMINISTIC_METRICS,
-    evaluate_deterministic_metrics,
-)
 from agent_eval.core.data_mapper import (
     map_dataset_columns,
     robust_json_loads,
 )
+from agent_eval.core.deterministic_metrics import (
+    DETERMINISTIC_METRICS,
+    evaluate_deterministic_metrics,
+)
+from agent_eval.core.metric_discovery import _GCS_PLACEHOLDERS
 from agent_eval.core.metric_discovery import (
     is_api_predefined as _is_api_predefined_discovery,
 )
-from agent_eval.core.metric_discovery import _GCS_PLACEHOLDERS
+from agent_eval.core.metric_schema import (
+    MANAGED_METRIC_REQUIRED_COLUMNS as _MANAGED_METRIC_REQUIRED_COLUMNS,
+)
+from agent_eval.core.metric_schema import (
+    SDK_COLUMN_DEFAULTS as _SDK_COLUMN_DEFAULTS,
+)
 from agent_eval.core.metric_schema import is_managed_entry, managed_base_name
 
 # Setup Logger — root logger at CRITICAL silences all third-party noise by default.

--- a/tools/agent-eval/src/agent_eval/core/interactions.py
+++ b/tools/agent-eval/src/agent_eval/core/interactions.py
@@ -11,13 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import asyncio
 import json
 import logging
 import os
-import asyncio
-import pandas as pd
 from datetime import datetime
-from typing import List, Dict, Any, Optional
+from typing import Any, Dict, List, Optional
+
+import pandas as pd
 
 from agent_eval.core.agent_client import AgentClient
 
@@ -36,7 +37,7 @@ def get_golden_questions(filepath: str) -> List[Dict[str, Any]]:
     """
     p = filepath if isinstance(filepath, str) else str(filepath)
     if p.endswith(".jsonl"):
-        from agent_eval.core.dataset_io import read_dataset, is_single_turn
+        from agent_eval.core.dataset_io import is_single_turn, read_dataset
 
         try:
             rows = read_dataset(p)

--- a/tools/agent-eval/src/agent_eval/core/metric_discovery.py
+++ b/tools/agent-eval/src/agent_eval/core/metric_discovery.py
@@ -344,10 +344,10 @@ def extract_adk_eval_knowledge() -> Dict[str, Any]:
 
     # 3. Rubric evaluation prompt patterns
     try:
-        from google.adk.evaluation import rubric_based_tool_use_quality_v1 as tool_mod
         from google.adk.evaluation import (
             rubric_based_final_response_quality_v1 as resp_mod,
         )
+        from google.adk.evaluation import rubric_based_tool_use_quality_v1 as tool_mod
 
         for module, pattern_name in [
             (tool_mod, "tool_use_quality"),

--- a/tools/agent-eval/src/agent_eval/core/metric_factory.py
+++ b/tools/agent-eval/src/agent_eval/core/metric_factory.py
@@ -52,6 +52,18 @@ import logging
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Tuple
 
+from agent_eval.core.metric_schema import (
+    ALL_KINDS as _KNOWN_KINDS,
+)
+from agent_eval.core.metric_schema import (
+    KIND_COMPUTATION,
+    KIND_CUSTOM_LLM_JUDGE,
+    KIND_MANAGED,
+    KIND_PARAMETRIZED_MANAGED,
+    KIND_PYTHON_FUNCTION,
+    KIND_REMOTE_CODE,
+)
+
 logger = logging.getLogger("agent_eval")
 
 
@@ -168,15 +180,6 @@ def computation(name: str, metric_name: str):
 # ---------------------------------------------------------------------------
 
 # Single source of truth — see ``core/metric_schema.py``.
-from agent_eval.core.metric_schema import (  # noqa: E402
-    ALL_KINDS as _KNOWN_KINDS,
-    KIND_MANAGED,
-    KIND_PARAMETRIZED_MANAGED,
-    KIND_CUSTOM_LLM_JUDGE,
-    KIND_COMPUTATION,
-    KIND_PYTHON_FUNCTION,
-    KIND_REMOTE_CODE,
-)
 
 
 def _load_python_callable(module_path: str | Path, function: str) -> Callable:

--- a/tools/agent-eval/src/agent_eval/core/metric_generator.py
+++ b/tools/agent-eval/src/agent_eval/core/metric_generator.py
@@ -904,7 +904,7 @@ def _call_gemini(prompt: str, model: str) -> str:
             "Install it with: pip install google-genai"
         )
 
-    from agent_eval.core.config import get_project_id, get_location
+    from agent_eval.core.config import get_location, get_project_id
 
     project = get_project_id()
     location = get_location(model)
@@ -1018,10 +1018,10 @@ def _validate_single_metric(name: str, defn: Dict) -> List[str]:
     """
     from agent_eval.core.metric_schema import (
         ALL_KINDS,
-        REQUIRED_FIELDS,
         KIND_CUSTOM_LLM_JUDGE,
         KIND_MANAGED,
         KIND_PARAMETRIZED_MANAGED,
+        REQUIRED_FIELDS,
     )
 
     errors: List[str] = []

--- a/tools/agent-eval/src/agent_eval/core/processor.py
+++ b/tools/agent-eval/src/agent_eval/core/processor.py
@@ -11,11 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import asyncio
 import json
 import logging
-import asyncio
+from typing import Any, Dict, Optional
+
 import pandas as pd
-from typing import Dict, Any, Optional
 
 from agent_eval.core.agent_client import AgentClient
 

--- a/tools/agent-eval/src/agent_eval/core/schema.py
+++ b/tools/agent-eval/src/agent_eval/core/schema.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from typing import Any
+
 from pydantic import BaseModel, Field, model_serializer, model_validator
 
 

--- a/tools/agent-eval/src/agent_eval/core/simulation.py
+++ b/tools/agent-eval/src/agent_eval/core/simulation.py
@@ -13,40 +13,39 @@
 # limitations under the License.
 """In-process simulation runner using ADK Python APIs."""
 
+import contextvars
 import logging
 import os
 import tempfile
+import uuid
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from google.adk.agents.base_agent import BaseAgent
 from google.adk.cli.utils.agent_loader import AgentLoader
-from google.adk.evaluation.eval_case import EvalCase, SessionInput
+from google.adk.evaluation.base_eval_service import (
+    EvaluateConfig,
+    EvaluateRequest,
+    InferenceConfig,
+    InferenceRequest,
+    InferenceResult,
+)
 from google.adk.evaluation.conversation_scenarios import ConversationScenario
+from google.adk.evaluation.eval_case import EvalCase, SessionInput
 from google.adk.evaluation.in_memory_eval_sets_manager import InMemoryEvalSetsManager
 from google.adk.evaluation.local_eval_service import LocalEvalService
 from google.adk.evaluation.local_eval_set_results_manager import (
     LocalEvalSetResultsManager,
 )
-from google.adk.evaluation.base_eval_service import (
-    InferenceRequest,
-    InferenceConfig,
-    EvaluateRequest,
-    EvaluateConfig,
-)
-
+from google.adk.evaluation.simulation.user_simulator import UserSimulator
 from google.adk.evaluation.simulation.user_simulator_provider import (
     UserSimulatorProvider,
 )
-from google.adk.evaluation.simulation.user_simulator import UserSimulator
-import contextvars
-import uuid
-from google.adk.agents.base_agent import BaseAgent
-from google.adk.evaluation.base_eval_service import InferenceResult
 from google.adk.events.event import Event
 from google.adk.sessions.in_memory_session_service import InMemorySessionService
 
-from agent_eval.core.dataset_io import read_dataset, is_multi_turn, is_single_turn
 from agent_eval.core.converters import AdkHistoryConverter
+from agent_eval.core.dataset_io import is_multi_turn, is_single_turn, read_dataset
 
 
 class SingleTurnLimitingUserSimulatorProvider(UserSimulatorProvider):
@@ -55,8 +54,8 @@ class SingleTurnLimitingUserSimulatorProvider(UserSimulatorProvider):
     def provide(self, eval_case: EvalCase) -> UserSimulator:
         if eval_case.eval_id.startswith("single_turn_"):
             from google.adk.evaluation.simulation.llm_backed_user_simulator import (
-                LlmBackedUserSimulatorConfig,
                 LlmBackedUserSimulator,
+                LlmBackedUserSimulatorConfig,
             )
 
             model = "gemini-2.5-flash"

--- a/tools/agent-eval/src/agent_eval/sdk.py
+++ b/tools/agent-eval/src/agent_eval/sdk.py
@@ -15,27 +15,29 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+import asyncio
 import logging
+from datetime import datetime
 from pathlib import Path
 from typing import Any
+
 import pandas as pd
 from pydantic import BaseModel, ConfigDict, Field
 
-from agent_eval.core.evaluator import Evaluator
-from agent_eval.core.path_resolver import agent_project_root, find_eval_dir
-from agent_eval.core.simulation import run_simulation_in_process
-from agent_eval.core.converters import write_jsonl
-import asyncio
 from agent_eval.core.analyzer import Analyzer
+from agent_eval.core.converters import write_jsonl
+from agent_eval.core.evaluator import Evaluator
 from agent_eval.core.html_report import generate_html_report
+from agent_eval.core.path_resolver import agent_project_root, find_eval_dir
 from agent_eval.core.schema import EvaluationSummary
+from agent_eval.core.simulation import run_simulation_in_process
 
 logger = logging.getLogger("agent_eval.sdk")
 
 
 class EvaluationResult(BaseModel):
     """The result of an evaluation run."""
+
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     success: bool

--- a/tools/agent-eval/tests/cli/test_interact.py
+++ b/tools/agent-eval/tests/cli/test_interact.py
@@ -11,13 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import unittest
-from unittest.mock import patch
-from pathlib import Path
-import tempfile
 import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
 
 from click.testing import CliRunner
+
 from agent_eval.cli.commands.interact import interact
 
 

--- a/tools/agent-eval/tests/core/test_analyzer_comparison.py
+++ b/tools/agent-eval/tests/core/test_analyzer_comparison.py
@@ -14,12 +14,12 @@
 """Tests for analyzer comparison logic: deltas, direction, optimization log, prompts."""
 
 from agent_eval.core.analyzer import (
-    compute_comparison,
-    format_comparison_table,
-    _is_lower_better,
+    Analyzer,
     _classify_direction,
     _compute_pct_change,
-    Analyzer,
+    _is_lower_better,
+    compute_comparison,
+    format_comparison_table,
 )
 from agent_eval.core.gemini_prompt_builder import GeminiAnalysisPrompter
 

--- a/tools/agent-eval/tests/core/test_evaluator.py
+++ b/tools/agent-eval/tests/core/test_evaluator.py
@@ -21,8 +21,8 @@ from pathlib import Path
 
 import pandas as pd
 
+from agent_eval.core.converters import read_jsonl, write_jsonl
 from agent_eval.core.evaluator import save_metrics_summary
-from agent_eval.core.converters import write_jsonl, read_jsonl
 
 # ── Helpers ──────────────────────────────────────────────────────────
 

--- a/tools/agent-eval/tests/core/test_evaluator_generated.py
+++ b/tools/agent-eval/tests/core/test_evaluator_generated.py
@@ -15,9 +15,9 @@ import json
 import shutil
 import tempfile
 import unittest
-from unittest import IsolatedAsyncioTestCase
 from pathlib import Path
-from unittest.mock import patch, AsyncMock
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, patch
 
 import pandas as pd
 

--- a/tools/agent-eval/tests/core/test_metric_discovery.py
+++ b/tools/agent-eval/tests/core/test_metric_discovery.py
@@ -194,8 +194,8 @@ class TestDiscoverManagedMetrics:
 
     def test_multi_turn_metrics_have_requires_multi_turn_flag(self):
         from agent_eval.core.metric_discovery import (
-            discover_managed_metrics,
             _MULTI_TURN_METRICS,
+            discover_managed_metrics,
         )
 
         metrics = discover_managed_metrics()
@@ -208,8 +208,8 @@ class TestDiscoverManagedMetrics:
 
     def test_single_turn_metrics_do_not_require_multi_turn(self):
         from agent_eval.core.metric_discovery import (
-            discover_managed_metrics,
             _MULTI_TURN_METRICS,
+            discover_managed_metrics,
         )
 
         metrics = discover_managed_metrics()

--- a/tools/agent-eval/tests/core/test_metric_factory.py
+++ b/tools/agent-eval/tests/core/test_metric_factory.py
@@ -15,7 +15,9 @@
 
 import tempfile
 from pathlib import Path
+
 import pytest
+
 from agent_eval.core import metric_factory
 
 

--- a/tools/agent-eval/tests/core/test_metric_generator.py
+++ b/tools/agent-eval/tests/core/test_metric_generator.py
@@ -17,12 +17,13 @@ import json
 import tempfile
 from pathlib import Path
 from unittest.mock import patch
+
 import pytest
 
 from agent_eval.core.metric_generator import (
-    generate_metric_definitions,
-    generate_eval_data,
     MetricGenerationError,
+    generate_eval_data,
+    generate_metric_definitions,
 )
 
 

--- a/tools/agent-eval/tests/core/test_simulation.py
+++ b/tools/agent-eval/tests/core/test_simulation.py
@@ -11,14 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import unittest
-from unittest.mock import MagicMock, patch
-from pathlib import Path
-import tempfile
 import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 # No mocks needed if google-genai is installed in the venv
 from google.adk.evaluation.base_eval_service import InferenceResult
+
 from agent_eval.core.simulation import _row_to_adk_scenario, run_simulation_in_process
 
 
@@ -344,8 +345,8 @@ class TestPrePopulatingSessionService(unittest.IsolatedAsyncioTestCase):
             }
         ]
         from agent_eval.core.simulation import (
-            PrePopulatingSessionService,
             EVAL_SESSION_ID_PREFIX,
+            PrePopulatingSessionService,
         )
 
         service = PrePopulatingSessionService(rows)
@@ -368,8 +369,8 @@ class TestPrePopulatingSessionService(unittest.IsolatedAsyncioTestCase):
             }
         ]
         from agent_eval.core.simulation import (
-            PrePopulatingSessionService,
             EVAL_SESSION_ID_PREFIX,
+            PrePopulatingSessionService,
         )
 
         service = PrePopulatingSessionService(rows)

--- a/tools/agent-eval/tests/test_sdk.py
+++ b/tools/agent-eval/tests/test_sdk.py
@@ -16,13 +16,14 @@
 from __future__ import annotations
 
 import json
-from pathlib import Path
 import tempfile
+from pathlib import Path
 from unittest import mock
+
 import pandas as pd
+import pytest
 
 from agent_eval import run_evaluation, run_evaluation_sync
-import pytest
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
This PR enables the **`I` (isort)** linter rule in Ruff to enforce consistent, PEP 8-compliant import sorting across the `agent-eval` codebase. It formats imports in all 33 affected Python files and cleans up a legacy late-import block to improve overall code quality.

Enforcing import sorting now prevents future stylistic drift and eliminates import-related merge conflicts as we continue executing our development roadmap.

---

## Key Changes
1. **Linter Configuration (`pyproject.toml`)**:
   * Appended `"I"` to `tool.ruff.lint.select` to activate the `isort` rule. Import sorting will now be automatically checked and enforced by Ruff in all future commits and CI runs.
2. **Import Cleanup (`metric_factory.py`)**:
   * Discovered a late module-level import of `metric_schema` constants in the middle of the file that was bypassing the linter with `# noqa: E402`.
   * Verified that `metric_schema.py` has no imports (zero circular dependency risk), moved the imports cleanly to the top of the file, and removed the `# noqa` bypass.
3. **Codebase-Wide Formatting**:
   * Executed `ruff check --fix` and `ruff format` to automatically sort and format imports across **33 Python files** (both source code and tests).
