### PR TITLE
style(agent-eval): enable Ruff pyupgrade and modernize Python syntax codebase-wide

### DIFF
--- a/tools/agent-eval/pyproject.toml
+++ b/tools/agent-eval/pyproject.toml
@@ -58,6 +58,7 @@ select = [
     "W",    # pycodestyle warnings
     "F",    # Pyflakes
     "I",    # isort (import sorting)
+    "UP",   # pyupgrade (syntax modernization)
 ]
 ignore = [
     "E501",  # line too long

--- a/tools/agent-eval/src/agent_eval/cli/_pacing.py
+++ b/tools/agent-eval/src/agent_eval/cli/_pacing.py
@@ -33,8 +33,8 @@ from __future__ import annotations
 
 import os
 import time
+from collections.abc import Iterator
 from contextlib import contextmanager
-from typing import Iterator
 
 import questionary
 from rich.console import Console

--- a/tools/agent-eval/src/agent_eval/cli/_stories.py
+++ b/tools/agent-eval/src/agent_eval/cli/_stories.py
@@ -30,10 +30,9 @@ Add new stories freely — append to STORIES below. Each entry is a
 from __future__ import annotations
 
 import random
-from typing import Optional, Tuple
 
 # (title, body) — bodies should read in 60-120 seconds (250-400 words).
-STORIES: list[Tuple[str, str]] = [
+STORIES: list[tuple[str, str]] = [
     (
         "Why parallel sim hits Amdahl's law",
         "ADK's `adk eval` runs scenarios sequentially within a single eval_set. "
@@ -724,7 +723,7 @@ STORIES: list[Tuple[str, str]] = [
 ]
 
 
-def random_story() -> Optional[Tuple[str, str]]:
+def random_story() -> tuple[str, str] | None:
     """Return a random ``(title, body)`` story. None if the pool is empty
     (defensive — shouldn't happen)."""
     if not STORIES:
@@ -732,7 +731,7 @@ def random_story() -> Optional[Tuple[str, str]]:
     return random.choice(STORIES)
 
 
-def random_stories(n: int) -> list[Tuple[str, str]]:
+def random_stories(n: int) -> list[tuple[str, str]]:
     """Return up to ``n`` UNIQUE random stories (no repeats in one wait).
 
     If n exceeds the pool size, returns the entire shuffled pool. Used by
@@ -747,7 +746,7 @@ def random_stories(n: int) -> list[Tuple[str, str]]:
 
 
 def render_story_panel(
-    title: str, body: str, *, index: Optional[int] = None, total: Optional[int] = None
+    title: str, body: str, *, index: int | None = None, total: int | None = None
 ):
     """Render one story as a Rich Panel for display. Index/total optional
     for the browser context (e.g. \"Story 7 of 15\"); omitted in the
@@ -815,7 +814,7 @@ class StoryStreamer:
 
         self._console = console
         self._stop_event = threading.Event()
-        self._thread: Optional[threading.Thread] = None
+        self._thread: threading.Thread | None = None
 
     def start(self) -> None:
         import threading

--- a/tools/agent-eval/src/agent_eval/cli/commands/agent_engine.py
+++ b/tools/agent-eval/src/agent_eval/cli/commands/agent_engine.py
@@ -37,7 +37,7 @@ import json
 import os
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 import click
 import pandas as pd
@@ -50,7 +50,7 @@ console = Console()
 # ---------------------------------------------------------------------------
 
 
-def _resolve_resource_name(explicit: Optional[str], cwd: Path) -> Optional[str]:
+def _resolve_resource_name(explicit: str | None, cwd: Path) -> str | None:
     """Resolve the Agent Engine resource name from CLI arg, env, or metadata file."""
     if explicit:
         return explicit
@@ -83,7 +83,7 @@ def _resolve_metrics_path(metrics_path: Path) -> Path:
     return metrics_path
 
 
-def _load_metric_definitions(metrics_path: Path) -> Dict[str, Dict[str, Any]]:
+def _load_metric_definitions(metrics_path: Path) -> dict[str, dict[str, Any]]:
     """Read metric definitions JSON, returning {} if file is missing."""
     resolved = _resolve_metrics_path(metrics_path)
     if not resolved.exists():
@@ -107,8 +107,8 @@ def _load_metric_definitions(metrics_path: Path) -> Dict[str, Dict[str, Any]]:
 
 
 def _build_evaluation_run_metrics(
-    metric_definitions: Dict[str, Dict[str, Any]],
-) -> List[Any]:
+    metric_definitions: dict[str, dict[str, Any]],
+) -> list[Any]:
     """Convert the canonical-schema metric definitions into EvaluationRunMetric objects.
 
     Routes EVERY entry through ``metric_factory.build_metric``, which dispatches
@@ -126,7 +126,7 @@ def _build_evaluation_run_metrics(
     """
     from agent_eval.core import metric_factory
 
-    run_metrics: List[Any] = []
+    run_metrics: list[Any] = []
     for name, spec in metric_definitions.items():
         if not isinstance(spec, dict):
             continue
@@ -410,7 +410,7 @@ def _default_destination(project: str) -> str:
     return f"gs://{bucket}/agent-eval/{timestamp}"
 
 
-def _bucket_name_from_uri(uri: str) -> Optional[str]:
+def _bucket_name_from_uri(uri: str) -> str | None:
     """Extract the bucket name from a ``gs://bucket/path`` URI."""
     if not uri.startswith("gs://"):
         return None
@@ -418,7 +418,7 @@ def _bucket_name_from_uri(uri: str) -> Optional[str]:
     return rest.split("/", 1)[0] or None
 
 
-def _load_local_agent(agent_module: Optional[str], cwd: Path) -> Optional[Any]:
+def _load_local_agent(agent_module: str | None, cwd: Path) -> Any | None:
     """Import the local ADK agent so we can build ``AgentInfo`` for the run.
 
     The Vertex SDK's ``create_evaluation_run`` doesn't *require* an
@@ -439,7 +439,7 @@ def _load_local_agent(agent_module: Optional[str], cwd: Path) -> Optional[Any]:
     import sys
 
     spec = agent_module
-    extra_sys_path: Optional[Path] = None
+    extra_sys_path: Path | None = None
 
     if spec is None:
         from agent_eval.core.path_detector import detect_execution_path
@@ -521,8 +521,8 @@ def _load_local_agent(agent_module: Optional[str], cwd: Path) -> Optional[Any]:
 
 
 def _build_agent_info(
-    vt_evals: Any, agent: Optional[Any], resource_name: str
-) -> Optional[Any]:
+    vt_evals: Any, agent: Any | None, resource_name: str
+) -> Any | None:
     """Build an ``AgentInfo`` for ``create_evaluation_run``.
 
     Three layers of fidelity:
@@ -546,7 +546,7 @@ def _build_agent_info(
     # Layer 1: Full SDK helper (only when we have a real agent)
     if agent is not None:
 
-        def _try_load() -> Optional[Any]:
+        def _try_load() -> Any | None:
             try:
                 return AgentInfo.load_from_agent(
                     agent, agent_resource_name=resource_name
@@ -570,7 +570,7 @@ def _build_agent_info(
         if agent is not None
         else "root_agent"
     )
-    common: Dict[str, Any] = {"name": name}
+    common: dict[str, Any] = {"name": name}
     if "agent_resource_name" in fields:
         common["agent_resource_name"] = resource_name
     if "instruction" in fields:
@@ -622,7 +622,7 @@ _VERTEX_LOCATIONS_NOT_VALID_FOR_GCS = {"global"}
 _DEFAULT_BUCKET_REGION = "us-central1"
 
 
-def _resolve_bucket_location(vertex_location: str, override: Optional[str]) -> str:
+def _resolve_bucket_location(vertex_location: str, override: str | None) -> str:
     """Pick a GCS-valid location for bucket creation.
 
     Order: explicit ``--bucket-location`` override → Vertex location if it's
@@ -639,7 +639,7 @@ def _ensure_bucket_exists(
     uri: str,
     project: str,
     vertex_location: str,
-    bucket_location_override: Optional[str] = None,
+    bucket_location_override: str | None = None,
 ) -> None:
     """Create the destination bucket if it doesn't already exist.
 
@@ -801,14 +801,14 @@ def _ensure_bucket_exists(
 def agent_engine(
     dataset_path: Path,
     metrics_path: Path,
-    resource_name: Optional[str],
-    dest: Optional[str],
-    project: Optional[str],
-    location: Optional[str],
-    bucket_location: Optional[str],
+    resource_name: str | None,
+    dest: str | None,
+    project: str | None,
+    location: str | None,
+    bucket_location: str | None,
     timeout: int,
     no_wait: bool,
-    agent_module: Optional[str],
+    agent_module: str | None,
     no_abort_on_broken_inference: bool,
     debug: bool,
 ) -> None:
@@ -1040,7 +1040,7 @@ def agent_engine(
     console.print()
     console.rule("[dim]Submission[/]", style="grey50", align="left")
 
-    create_kwargs: Dict[str, Any] = {
+    create_kwargs: dict[str, Any] = {
         "dataset": inference_df,
         "metrics": run_metrics,
         "dest": destination,
@@ -1157,7 +1157,7 @@ def _summarize_run_errors(error: Any) -> None:
     from collections import Counter
 
     by_code: Counter = Counter(code for code, _ in items)
-    sample_by_code: Dict[str, str] = {}
+    sample_by_code: dict[str, str] = {}
     for code, detail in items:
         if code not in sample_by_code:
             sample_by_code[code] = detail.strip()

--- a/tools/agent-eval/src/agent_eval/cli/commands/analyze.py
+++ b/tools/agent-eval/src/agent_eval/cli/commands/analyze.py
@@ -17,7 +17,6 @@ import asyncio
 import os
 import sys
 from pathlib import Path
-from typing import Optional
 
 import click
 from rich.console import Console
@@ -52,11 +51,11 @@ def _display_analysis(results_dir: str) -> None:
 
 def _display_metrics_table(
     current_summary: dict,
-    comparison_data: Optional[dict] = None,
-    focus: Optional[str] = None,
+    comparison_data: dict | None = None,
+    focus: str | None = None,
     *,
-    results_dir: Optional[str] = None,
-    run_name_override: Optional[str] = None,
+    results_dir: str | None = None,
+    run_name_override: str | None = None,
 ) -> None:
     """Display a Rich table of metrics with optional delta columns.
 

--- a/tools/agent-eval/src/agent_eval/cli/commands/init.py
+++ b/tools/agent-eval/src/agent_eval/cli/commands/init.py
@@ -19,8 +19,9 @@ import hashlib
 import json
 import os
 import re
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any
 
 import click
 import questionary
@@ -78,11 +79,11 @@ def _parse_artifact(path: Path) -> Any:
     return text
 
 
-def _summarize_diff(before: Any, after: Any) -> List[str]:
+def _summarize_diff(before: Any, after: Any) -> list[str]:
     """Render a short human-readable diff for the artifact. Limited to
     common shapes (dict-of-metrics for metric_definitions; list-of-rows
     for dataset.jsonl). Returns a list of bullet lines."""
-    lines: List[str] = []
+    lines: list[str] = []
 
     if isinstance(before, dict) and isinstance(after, dict):
         b_metrics = (before.get("metrics") or {}) if "metrics" in before else before
@@ -125,7 +126,7 @@ def _review_artifact(
     explanation: Callable[[], None],
     title: str,
     auto_approve: bool,
-) -> Tuple[bool, Optional[Any]]:
+) -> tuple[bool, Any | None]:
     """Show ``path``, run ``explanation()``, wait, detect edits, parse + diff.
 
     Returns ``(was_edited, parsed_content)``. When ``was_edited`` is True
@@ -223,7 +224,7 @@ def _save_generated_snapshot(path: Path) -> None:
 
 
 def _render_metric_review_guide(
-    custom_metrics: Dict[str, Any],
+    custom_metrics: dict[str, Any],
     rationale: str,
     metrics_path: Path,
 ) -> None:
@@ -315,7 +316,7 @@ def _render_metric_review_guide(
     )
 
 
-def _validate_user_edited_metrics(parsed: Any) -> List[str]:
+def _validate_user_edited_metrics(parsed: Any) -> list[str]:
     """Re-validate a user-edited metric_definitions.json against the canonical schema.
 
     Returns a list of plain-English error messages (empty when clean). Each
@@ -324,7 +325,7 @@ def _validate_user_edited_metrics(parsed: Any) -> List[str]:
     """
     from agent_eval.core.metric_generator import _validate_single_metric
 
-    errors: List[str] = []
+    errors: list[str] = []
     if not isinstance(parsed, dict):
         return ["The file's top-level shape is wrong — expected a JSON object."]
     metrics = parsed.get("metrics")
@@ -347,7 +348,7 @@ def _validate_user_edited_metrics(parsed: Any) -> List[str]:
     return errors
 
 
-def _required_reference_fields(custom_metrics: Dict[str, Any]) -> List[Tuple[str, str]]:
+def _required_reference_fields(custom_metrics: dict[str, Any]) -> list[tuple[str, str]]:
     """Extract (metric_name, reference_data_field) pairs from the metrics dict.
 
     The data-generation step needs this to know which ``reference_data:<field>``
@@ -360,7 +361,7 @@ def _required_reference_fields(custom_metrics: Dict[str, Any]) -> List[Tuple[str
     ("subagent_routing_accuracy", "expected_route")]``. Empty when no metric
     needs reference data.
     """
-    pairs: List[Tuple[str, str]] = []
+    pairs: list[tuple[str, str]] = []
     for name, defn in custom_metrics.items():
         if not isinstance(defn, dict):
             continue
@@ -378,7 +379,7 @@ def _required_reference_fields(custom_metrics: Dict[str, Any]) -> List[Tuple[str
             pairs.append((name, ref_field))
     # Dedupe while preserving order.
     seen: set = set()
-    unique: List[Tuple[str, str]] = []
+    unique: list[tuple[str, str]] = []
     for pair in pairs:
         if pair not in seen:
             seen.add(pair)
@@ -389,10 +390,10 @@ def _required_reference_fields(custom_metrics: Dict[str, Any]) -> List[Tuple[str
 def _review_with_validation_loop(
     metrics_path: Path,
     *,
-    custom_metrics: Dict[str, Any],
+    custom_metrics: dict[str, Any],
     rationale: str,
     auto_approve: bool,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Wrap ``_review_artifact`` with a validation gate that loops on errors.
 
     After the user edits the file, re-validate against the canonical schema.
@@ -461,8 +462,8 @@ def _review_with_validation_loop(
 
 def _validate_dataset_against_metrics(
     dataset_path: Path,
-    custom_metrics: Dict[str, Any],
-) -> List[str]:
+    custom_metrics: dict[str, Any],
+) -> list[str]:
     """Check that ``dataset.jsonl`` actually feeds every metric the user picked.
 
     The dangerous case is a metric with ``requires_reference: true`` that needs
@@ -473,8 +474,8 @@ def _validate_dataset_against_metrics(
 
     Returns plain-English warning strings (empty when clean).
     """
-    warnings: List[str] = []
-    rows: List[dict] = []
+    warnings: list[str] = []
+    rows: list[dict] = []
     try:
         with dataset_path.open() as f:
             for line in f:
@@ -572,7 +573,7 @@ def _validate_dataset_against_metrics(
 def _review_dataset_with_validation(
     dataset_path: Path,
     *,
-    custom_metrics: Dict[str, Any],
+    custom_metrics: dict[str, Any],
     auto_approve: bool,
 ) -> None:
     """Wrap the dataset review pause with the coverage validation gate.
@@ -880,7 +881,7 @@ def _verify_environment(auto_approve: bool = False) -> None:
 # ── Path detection (Vertex AI GenAI Eval execution path) ──────────────────
 
 
-def _display_path_detection(search_dir: Path) -> "PathDetection":  # noqa: F821
+def _display_path_detection(search_dir: Path) -> PathDetection:  # noqa: F821
     """Detect and explain how we'll reach the user's agent.
 
     The narrative leads with the *local* pipeline (always available, the
@@ -1332,7 +1333,7 @@ def _prompt_starter_metrics() -> list[str]:
     return selected
 
 
-def _display_metrics_education(managed_metrics: Dict[str, Dict]) -> None:
+def _display_metrics_education(managed_metrics: dict[str, dict]) -> None:
     """Walk the user through the relevant Vertex AI eval docs before the picker.
 
     Three short backgrounders, in the order the docs sidebar uses:
@@ -1350,7 +1351,7 @@ def _display_metrics_education(managed_metrics: Dict[str, Dict]) -> None:
 
     # Mirror the picker's grouping (anything classified as "custom" — i.e. GCS YAML
     # metrics like COHERENCE / FLUENCY — gets bucketed as adaptive in the picker).
-    family_counts: Dict[str, int] = {}
+    family_counts: dict[str, int] = {}
     for key, info in managed_metrics.items():
         family = metric_families.classify(managed_base_name(info) or key)
         if family == "custom":
@@ -1560,9 +1561,9 @@ def _display_metrics_education(managed_metrics: Dict[str, Dict]) -> None:
 
 
 def _prompt_managed_metrics_selection(
-    managed_metrics: Dict[str, Dict],
-    preselected: Optional[set] = None,
-) -> Dict[str, Dict]:
+    managed_metrics: dict[str, dict],
+    preselected: set | None = None,
+) -> dict[str, dict]:
     """Arrow-key checkbox selection for managed metrics.
 
     Uses questionary.checkbox() with grouped separators for a clean UX.
@@ -1598,7 +1599,7 @@ def _prompt_managed_metrics_selection(
         "computation",
         "translation",
     ]
-    grouped: Dict[str, Dict[str, Dict]] = {f: {} for f in KNOWN_FAMILY_ORDER}
+    grouped: dict[str, dict[str, dict]] = {f: {} for f in KNOWN_FAMILY_ORDER}
 
     for key, info in managed_metrics.items():
         family = metric_families.classify(managed_base_name(info) or key)
@@ -1613,7 +1614,7 @@ def _prompt_managed_metrics_selection(
         f for f in grouped if f not in KNOWN_FAMILY_ORDER
     ]
 
-    def _tag_for(info: Dict) -> str:
+    def _tag_for(info: dict) -> str:
         """Short capability gate that decides whether a metric can run on the user's data."""
         if info.get("requires_multi_turn"):
             return "multi-turn"
@@ -1842,7 +1843,7 @@ def _prompt_managed_metrics_selection(
         if selected_keys:
             from collections import defaultdict as _defaultdict
 
-            review_by_family: Dict[str, list] = _defaultdict(list)
+            review_by_family: dict[str, list] = _defaultdict(list)
             for key in selected_keys:
                 entry = managed_metrics.get(key, {})
                 fam = metric_families.classify(managed_base_name(entry) or key)
@@ -1905,7 +1906,7 @@ def _prompt_managed_metrics_selection(
     # Build selected metrics dict (final — review confirmed above)
     from agent_eval.core.metric_discovery import get_metric_definition_entry
 
-    selected: Dict[str, Dict] = {}
+    selected: dict[str, dict] = {}
     for key in selected_keys:
         entry = get_metric_definition_entry(key, managed_metrics)
         if entry:
@@ -1926,7 +1927,7 @@ def _prompt_managed_metrics_selection(
     return selected
 
 
-def _display_agent_analysis(analysis: Dict[str, Any]) -> None:
+def _display_agent_analysis(analysis: dict[str, Any]) -> None:
     """Display the agent analysis results in a Rich table."""
     console.print("  [bold]Your agent's evaluation data[/]")
     console.print(
@@ -2047,7 +2048,7 @@ def _prompt_ai_metrics_multistep(
 
     # Split existing metrics into managed and custom
     existing_managed_keys: set = set()
-    existing_custom: Dict[str, Any] = {}
+    existing_custom: dict[str, Any] = {}
     if existing_metrics:
         for k, v in existing_metrics.items():
             if isinstance(v, dict) and is_managed_entry(v):
@@ -2171,7 +2172,7 @@ def _prompt_ai_metrics_multistep(
         "  [dim]Reading agent.py, tools, and prompts to understand available evaluation data.[/]"
     )
     console.print()
-    agent_analysis: Dict[str, Any] = {}
+    agent_analysis: dict[str, Any] = {}
     with console.status(
         "[bold blue]  Analyzing agent source code...[/]",
         spinner="dots",
@@ -2291,7 +2292,7 @@ def _prompt_ai_metrics_multistep(
             )
 
     # ── Gemini Call 2 — Generate custom metrics (if opted in) ─────────────
-    custom_metrics: Dict[str, Any] = {}
+    custom_metrics: dict[str, Any] = {}
     rationale = ""
 
     if generate_custom:
@@ -2508,7 +2509,7 @@ def _prompt_ai_metrics_multistep(
     required_ref_fields = _required_reference_fields(custom_metrics)
 
     # ── Gemini Call 3 — Generate test data ────────────────────────────────
-    recommendations: Dict[str, Any] = {}
+    recommendations: dict[str, Any] = {}
     with console.status("[bold blue]  Generating test data...[/]", spinner="dots"):
         try:
             from agent_eval.core.metric_generator import generate_eval_data
@@ -2611,7 +2612,7 @@ def _prompt_ai_metrics_multistep(
     return starter_keys, custom_metrics, recommendations, agent_analysis
 
 
-def _load_existing_metrics(agent_dir: Path) -> Optional[Dict[str, Any]]:
+def _load_existing_metrics(agent_dir: Path) -> dict[str, Any] | None:
     """Load existing metric definitions if present."""
     eval_dir = agent_dir / "eval"
     if not eval_dir.exists():
@@ -2631,7 +2632,7 @@ def _load_existing_metrics(agent_dir: Path) -> Optional[Dict[str, Any]]:
 
 def _load_existing_eval_data(
     agent_dir: Path,
-) -> tuple[Optional[list], Optional[list]]:
+) -> tuple[list | None, list | None]:
     """Load existing scenarios and golden data if present."""
     eval_dir = agent_dir / "eval"
     if not eval_dir.exists():
@@ -3552,7 +3553,7 @@ def init(target_dir, agent_name, mode, auto_approve, ai_metrics):
     _display_next_steps(agent_name, agent_dir, mode, custom_metrics, chosen_paths)
 
 
-def _explain_metrics_file(path: Path, custom_metrics: Optional[Dict[str, Any]]) -> None:
+def _explain_metrics_file(path: Path, custom_metrics: dict[str, Any] | None) -> None:
     """Render the per-metric breakdown of metric_definitions.json so the
     user knows what each entry does + which internal flags drive routing."""
     try:

--- a/tools/agent-eval/src/agent_eval/cli/commands/report.py
+++ b/tools/agent-eval/src/agent_eval/cli/commands/report.py
@@ -34,7 +34,6 @@ import os
 import sys
 import webbrowser
 from pathlib import Path
-from typing import Optional
 
 import click
 from rich.console import Console
@@ -43,7 +42,7 @@ from rich.panel import Panel
 console = Console()
 
 
-def _find_latest_report(results_dir: Path) -> Optional[Path]:
+def _find_latest_report(results_dir: Path) -> Path | None:
     """Walk results_dir/*/report.html, return the most recently modified."""
     if not results_dir.is_dir():
         return None
@@ -54,7 +53,7 @@ def _find_latest_report(results_dir: Path) -> Optional[Path]:
     return candidates[0]
 
 
-def _resolve_results_dir(explicit: Optional[str]) -> Optional[Path]:
+def _resolve_results_dir(explicit: str | None) -> Path | None:
     """Default: <project_root>/tests/eval/results/. Override with --results-dir."""
     if explicit:
         p = Path(explicit).resolve()

--- a/tools/agent-eval/src/agent_eval/cli/commands/run.py
+++ b/tools/agent-eval/src/agent_eval/cli/commands/run.py
@@ -20,7 +20,6 @@ import subprocess
 import sys
 from datetime import datetime
 from pathlib import Path
-from typing import Dict
 
 import click
 from rich.console import Console
@@ -763,7 +762,7 @@ def run(
     # Track per-phase outcomes for the end-of-run banner. The lying
     # "Pipeline complete!" green banner from the 2026-04-23 customer demo
     # is replaced with reality: phase_outcomes drives title/border/body.
-    phase_outcomes: Dict[str, str] = {}  # name → "completed" | "failed" | "skipped"
+    phase_outcomes: dict[str, str] = {}  # name → "completed" | "failed" | "skipped"
 
     # ── Phase: Simulate ────────────────────────────────────────────────────
 

--- a/tools/agent-eval/src/agent_eval/cli/commands/setup.py
+++ b/tools/agent-eval/src/agent_eval/cli/commands/setup.py
@@ -33,7 +33,6 @@ import json
 import os
 import subprocess
 from pathlib import Path
-from typing import List, Optional, Tuple
 
 import click
 import questionary
@@ -46,7 +45,7 @@ console = Console()
 
 # ── Step definitions ────────────────────────────────────────────────────────
 
-_FOUNDATION_APIS: List[Tuple[str, str]] = [
+_FOUNDATION_APIS: list[tuple[str, str]] = [
     (
         "serviceusage.googleapis.com",
         "Required to enable any other API on the project — must come first.",
@@ -65,7 +64,7 @@ _FOUNDATION_APIS: List[Tuple[str, str]] = [
     ),
 ]
 
-_ASP_APIS: List[Tuple[str, str]] = [
+_ASP_APIS: list[tuple[str, str]] = [
     (
         "cloudbuild.googleapis.com",
         "ASP CI/CD pipelines (the `google_cloud_build` runner choice).",
@@ -151,7 +150,7 @@ def _adc_file_path() -> Path:
     return Path.home() / ".config" / "gcloud" / "application_default_credentials.json"
 
 
-def _adc_account(path: Path) -> Optional[str]:
+def _adc_account(path: Path) -> str | None:
     """Identifier for the ADC file, or None if unreadable / unknown structure.
 
     Modern user ADC files (`type: "authorized_user"`) are just a refresh token —
@@ -327,7 +326,7 @@ def _check_api_enabled(project: str, api: str):
     return _GcloudFailure(_classify_stderr(err), err)
 
 
-def _enable_api(project: str, api: str) -> Tuple[bool, str]:
+def _enable_api(project: str, api: str) -> tuple[bool, str]:
     """Enable an API. Returns (success, error_message)."""
     try:
         with console.status(f"  [bold blue]Enabling {api}…[/]", spinner="dots"):
@@ -565,7 +564,7 @@ def _step_3_adc(
         return False  # skip
 
 
-def _step_2_project(auto_approve: bool) -> Tuple[Optional[str], Optional[str]]:
+def _step_2_project(auto_approve: bool) -> tuple[str | None, str | None]:
     """Resolve project + location, save to .env, point gcloud config at it.
 
     Runs BEFORE Step 3 (ADC) so the ADC login can pass `--billing-project=<project>`
@@ -796,7 +795,7 @@ def _step_5_autorater_iam(project: str, auto_approve: bool) -> None:
         return  # skip
 
 
-def _step_6_asp_apis(project: str, *, asp: Optional[bool], auto_approve: bool) -> None:
+def _step_6_asp_apis(project: str, *, asp: bool | None, auto_approve: bool) -> None:
     """Enable Cloud Build / Cloud Run / Artifact Registry for ASP deployments."""
     if asp is None and not auto_approve:
         asp = questionary.confirm(
@@ -817,7 +816,7 @@ def _step_6_asp_apis(project: str, *, asp: Optional[bool], auto_approve: bool) -
 
 def _enable_apis(
     project: str,
-    apis: List[Tuple[str, str]],
+    apis: list[tuple[str, str]],
     *,
     auto_approve: bool,
 ) -> None:

--- a/tools/agent-eval/src/agent_eval/cli/commands/simulate.py
+++ b/tools/agent-eval/src/agent_eval/cli/commands/simulate.py
@@ -20,7 +20,6 @@ import subprocess
 import sys
 from datetime import datetime
 from pathlib import Path
-from typing import List, Optional
 
 import click
 from rich.console import Console
@@ -249,9 +248,9 @@ def _project_dataset_to_adk_files(
     # then point the user at metric_definitions.json as the single rubric
     # surface. Idempotent: after the first call, criteria is {} so we no-op.
     project_eval_config = project_root / "tests" / "eval" / "eval_config.json"
-    backup_path: Optional[Path] = None
+    backup_path: Path | None = None
     backed_up_count = 0
-    backed_up_names: List[str] = []
+    backed_up_names: list[str] = []
 
     if project_eval_config.exists():
         try:

--- a/tools/agent-eval/src/agent_eval/cli/main.py
+++ b/tools/agent-eval/src/agent_eval/cli/main.py
@@ -19,6 +19,21 @@ import click
 from rich.console import Console
 from rich.panel import Panel
 
+from agent_eval.cli.commands.analyze import analyze
+from agent_eval.cli.commands.convert import convert
+from agent_eval.cli.commands.create_dataset import create_dataset
+from agent_eval.cli.commands.dashboard import dashboard
+from agent_eval.cli.commands.evaluate import evaluate
+from agent_eval.cli.commands.import_adk import import_adk
+from agent_eval.cli.commands.init import init
+from agent_eval.cli.commands.interact import interact
+from agent_eval.cli.commands.migrate import migrate
+from agent_eval.cli.commands.report import report
+from agent_eval.cli.commands.run import run
+from agent_eval.cli.commands.setup import setup
+from agent_eval.cli.commands.simulate import simulate
+from agent_eval.cli.commands.stories import stories
+
 console = Console()
 
 
@@ -79,21 +94,6 @@ def cli() -> None:
 
 
 # --- Register commands ---
-
-from agent_eval.cli.commands.analyze import analyze  # noqa: E402
-from agent_eval.cli.commands.convert import convert  # noqa: E402
-from agent_eval.cli.commands.create_dataset import create_dataset  # noqa: E402
-from agent_eval.cli.commands.dashboard import dashboard  # noqa: E402
-from agent_eval.cli.commands.evaluate import evaluate  # noqa: E402
-from agent_eval.cli.commands.import_adk import import_adk  # noqa: E402
-from agent_eval.cli.commands.init import init  # noqa: E402
-from agent_eval.cli.commands.interact import interact  # noqa: E402
-from agent_eval.cli.commands.migrate import migrate  # noqa: E402
-from agent_eval.cli.commands.report import report  # noqa: E402
-from agent_eval.cli.commands.run import run  # noqa: E402
-from agent_eval.cli.commands.setup import setup  # noqa: E402
-from agent_eval.cli.commands.simulate import simulate  # noqa: E402
-from agent_eval.cli.commands.stories import stories  # noqa: E402
 
 # Order matches the Vertex AI eval docs sidebar workflow so `agent-eval --help`
 # reads top-down as: set up → bring in data → generate traces → score →

--- a/tools/agent-eval/src/agent_eval/core/agent_client.py
+++ b/tools/agent-eval/src/agent_eval/core/agent_client.py
@@ -17,7 +17,7 @@ import re
 import subprocess
 import time
 import uuid
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 import requests
 
@@ -35,7 +35,7 @@ class AgentClient:
         base_url: str,
         app_name: str,
         user_id: str = "eval_user",
-        token: Optional[str] = None,
+        token: str | None = None,
     ):
         """
         Initialize the AgentClient.
@@ -52,7 +52,7 @@ class AgentClient:
         self._token = token
 
     @property
-    def token(self) -> Optional[str]:
+    def token(self) -> str | None:
         """Returns the current token, fetching it if necessary. Returns None for localhost."""
         if self._is_localhost():
             return None
@@ -77,7 +77,7 @@ class AgentClient:
                 "Ensure you are logged in with 'gcloud auth login'."
             ) from e
 
-    def _get_headers(self) -> Dict[str, str]:
+    def _get_headers(self) -> dict[str, str]:
         """Returns the headers for API requests. Skips auth for localhost."""
         headers = {
             "accept": "application/json",
@@ -108,7 +108,7 @@ class AgentClient:
 
     def run_interaction(
         self, session_id: str, question: str, streaming: bool = False
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """
         Sends a question to the agent.
 
@@ -131,7 +131,7 @@ class AgentClient:
         logger.debug("Sending question to agent...")
         return self._make_request("POST", url, json=payload)
 
-    def get_session_state(self, session_id: str) -> Dict[str, Any]:
+    def get_session_state(self, session_id: str) -> dict[str, Any]:
         """
         Retrieves the final state of a session.
 
@@ -145,7 +145,7 @@ class AgentClient:
         logger.debug("Retrieving final session state...")
         return self._make_request("GET", url)
 
-    def get_session_trace(self, session_id: str) -> Dict[str, Any]:
+    def get_session_trace(self, session_id: str) -> dict[str, Any]:
         """
         Get the session trace. Tries multiple endpoints.
 
@@ -237,7 +237,7 @@ class AgentClient:
     # --- Static Utility Methods for Analysis ---
 
     @staticmethod
-    def analyze_trace_and_extract_spans(trace_data: List[Dict]) -> List[Dict]:
+    def analyze_trace_and_extract_spans(trace_data: list[dict]) -> list[dict]:
         """Analyzes raw trace data to build a tree and extract classified information."""
 
         class _SpanNode:
@@ -383,7 +383,7 @@ class AgentClient:
         return [traverse_and_extract(root) for root in root_nodes]
 
     @staticmethod
-    def get_latency_from_spans(analyzed_trace: List[Dict]) -> List[Dict]:
+    def get_latency_from_spans(analyzed_trace: list[dict]) -> list[dict]:
         """Extracts latency information from the analyzed trace."""
 
         def process_span(span):
@@ -409,7 +409,7 @@ class AgentClient:
         return [process_span(root) for root in analyzed_trace]
 
     @staticmethod
-    def get_agent_trajectory(analyzed_trace: List[Dict]) -> List[str]:
+    def get_agent_trajectory(analyzed_trace: list[dict]) -> list[str]:
         """
         Extracts the sequence of agents and tools invoked.
 
@@ -465,13 +465,13 @@ class AgentClient:
         return trajectory
 
     @staticmethod
-    def get_state_variable(session_data: Dict, variable: str) -> Any:
+    def get_state_variable(session_data: dict, variable: str) -> Any:
         """Extracts a state variable from the session data."""
         state = session_data.get("state", {})
         return state.get(variable, None)
 
     @staticmethod
-    def get_tool_interactions(session_data: Dict) -> List[Dict[str, Any]]:
+    def get_tool_interactions(session_data: dict) -> list[dict[str, Any]]:
         """
         Extracts a chronological list of tool interactions (call and response pairs) from the session events.
 
@@ -533,7 +533,7 @@ class AgentClient:
         return interactions
 
     @staticmethod
-    def get_sub_agent_trace(session_data: Dict) -> List[Dict[str, Any]]:
+    def get_sub_agent_trace(session_data: dict) -> list[dict[str, Any]]:
         """
         Extracts the sequence of agent turns and their text responses.
 
@@ -576,7 +576,7 @@ class AgentClient:
         return trace
 
     @staticmethod
-    def get_final_payload_field(session_data: Dict, field_name: str) -> Any:
+    def get_final_payload_field(session_data: dict, field_name: str) -> Any:
         """Extracts a field from the final JSON payload event."""
         events = session_data.get("events", [])
         for event in reversed(events):

--- a/tools/agent-eval/src/agent_eval/core/analyzer.py
+++ b/tools/agent-eval/src/agent_eval/core/analyzer.py
@@ -20,7 +20,7 @@ import re
 import subprocess
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional, TypedDict
+from typing import Any, TypedDict
 
 import pandas as pd
 from google import genai
@@ -36,19 +36,19 @@ class LogEntry(TypedDict):
     """A structured representation of a single question's evaluation results."""
 
     question_id: str
-    metadata: Dict[str, Any]
-    user_inputs: List[str]
+    metadata: dict[str, Any]
+    user_inputs: list[str]
     final_response: str
-    trace_summary: List[str]
-    sub_agent_trace: List[Dict[str, Any]]
-    tool_interactions: List[Dict[str, Any]]
-    eval_results: Dict[str, Dict[str, Any]]
-    latency_summary: Dict[str, Any]
-    adk_scores: Dict[str, float]
-    agents_evaluated: List[str]
+    trace_summary: list[str]
+    sub_agent_trace: list[dict[str, Any]]
+    tool_interactions: list[dict[str, Any]]
+    eval_results: dict[str, dict[str, Any]]
+    latency_summary: dict[str, Any]
+    adk_scores: dict[str, float]
+    agents_evaluated: list[str]
 
 
-def robust_json_loads(x: Any) -> Optional[Dict[str, Any]]:
+def robust_json_loads(x: Any) -> dict[str, Any] | None:
     """Safely load JSON strings, handling various input types.
 
     Tries json.loads first, then ast.literal_eval for Python dict syntax.
@@ -323,10 +323,10 @@ def format_comparison_table(comparison: dict) -> str:
 
 
 class Analyzer:
-    def __init__(self, config: Dict[str, Any]):
+    def __init__(self, config: dict[str, Any]):
         self.config = config
 
-    def _process_log_row(self, row: pd.Series, index: int) -> Optional[LogEntry]:
+    def _process_log_row(self, row: pd.Series, index: int) -> LogEntry | None:
         """Processes a single DataFrame row to extract structured log data for Markdown reporting."""
         try:
             question_id = row.get("question_id", f"row_{index}")
@@ -566,7 +566,7 @@ class Analyzer:
         self,
         summary_path: Path,
         results_path: Path,
-    ) -> tuple[Optional[dict], Optional[str]]:
+    ) -> tuple[dict | None, str | None]:
         """Analyzes evaluation results and returns the content for the Gemini prompt."""
         try:
             summary_data = json.loads(summary_path.read_text())
@@ -633,13 +633,13 @@ class Analyzer:
 
         return summary_data, "".join(output_lines)
 
-    def _discover_agent_context(self, agent_dir: Optional[Path]) -> Dict[str, str]:
+    def _discover_agent_context(self, agent_dir: Path | None) -> dict[str, str]:
         """Discovers and loads agent source code and ADK context from agent directory."""
         return discover_agent_context(agent_dir)
 
     def _auto_find_previous_run(
         self, results_dir: Path, current_run_folder: Path
-    ) -> Optional[Path]:
+    ) -> Path | None:
         """Find the most recent previous run folder in results_dir.
 
         Scans for subdirectories containing eval_summary.json, sorted by
@@ -659,7 +659,7 @@ class Analyzer:
         candidates.sort(key=lambda x: x.stat().st_mtime, reverse=True)
         return candidates[0]
 
-    def _load_baseline_summary(self, compare_to_path: Path) -> Optional[dict]:
+    def _load_baseline_summary(self, compare_to_path: Path) -> dict | None:
         """Load eval_summary.json from a baseline run directory."""
         run_folder = self._find_run_folder(compare_to_path)
         if not run_folder:
@@ -682,10 +682,10 @@ class Analyzer:
     def generate_optimization_log(
         self,
         comparison: dict,
-        focus: Optional[str],
+        focus: str | None,
         run_folder: Path,
-        gemini_comparison_text: Optional[str] = None,
-        current_summary: Optional[dict] = None,
+        gemini_comparison_text: str | None = None,
+        current_summary: dict | None = None,
     ) -> Path:
         """Generate or append to OPTIMIZATION_LOG.md in the results directory.
 
@@ -944,7 +944,7 @@ class Analyzer:
         )
         return model, client
 
-    def _find_run_folder(self, results_dir: Path) -> Optional[Path]:
+    def _find_run_folder(self, results_dir: Path) -> Path | None:
         """
         Find the run folder to analyze. Supports two structures:
         1. Direct run folder: results_dir/raw/evaluation_results_*.csv

--- a/tools/agent-eval/src/agent_eval/core/config.py
+++ b/tools/agent-eval/src/agent_eval/core/config.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from pathlib import Path
-from typing import Dict, List, Optional
 
 from pydantic import AliasChoices, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -39,7 +38,7 @@ class EvalConfig(BaseSettings):
     COL_TOOL_USAGE: str = "tool_usage"
 
     # Execution Settings
-    GOOGLE_CLOUD_PROJECT: Optional[str] = Field(
+    GOOGLE_CLOUD_PROJECT: str | None = Field(
         default=None,
         validation_alias=AliasChoices(
             "EVAL_GOOGLE_CLOUD_PROJECT", "GOOGLE_CLOUD_PROJECT", "PROJECT_ID"
@@ -66,7 +65,7 @@ class EvalConfig(BaseSettings):
 CONFIG = EvalConfig()
 
 
-def get_project_id() -> Optional[str]:
+def get_project_id() -> str | None:
     """Get the GCP project ID from any supported source.
 
     Checks (in order): GOOGLE_CLOUD_PROJECT env var, PROJECT_ID env var.
@@ -74,7 +73,7 @@ def get_project_id() -> Optional[str]:
     return EvalConfig().GOOGLE_CLOUD_PROJECT
 
 
-def get_location(model: Optional[str] = None) -> str:
+def get_location(model: str | None = None) -> str:
     """Get the GCP location, with smart defaults for Gemini 3+ models.
 
     Args:
@@ -88,7 +87,7 @@ def get_location(model: Optional[str] = None) -> str:
     return EvalConfig().GOOGLE_CLOUD_LOCATION
 
 
-def find_eval_files(eval_dir: Path) -> Dict[str, List[Path]]:
+def find_eval_files(eval_dir: Path) -> dict[str, list[Path]]:
     """Discover all eval files in the eval directory.
 
     Scans each subdirectory for .json files instead of relying on
@@ -102,7 +101,7 @@ def find_eval_files(eval_dir: Path) -> Dict[str, List[Path]]:
         Dict with keys: 'metrics', 'scenarios', 'golden_data', 'session_input'
         Each value is a list of matching files (sorted by name).
     """
-    result: Dict[str, List[Path]] = {
+    result: dict[str, list[Path]] = {
         "metrics": [],
         "scenarios": [],
         "golden_data": [],

--- a/tools/agent-eval/src/agent_eval/core/converters.py
+++ b/tools/agent-eval/src/agent_eval/core/converters.py
@@ -18,16 +18,16 @@ import os
 import time
 import uuid
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from agent_eval.core.agent_client import AgentClient
 
 logger = logging.getLogger("agent_eval.converters")
 
 
-def robust_json_load(file_path: str) -> Optional[Dict[str, Any]]:
+def robust_json_load(file_path: str) -> dict[str, Any] | None:
     try:
-        with open(file_path, "r", encoding="utf-8") as f:
+        with open(file_path, encoding="utf-8") as f:
             content = f.read().strip()
         data = json.loads(content)
         if isinstance(data, str):
@@ -63,8 +63,8 @@ def convert_keys_to_camel_case(data: Any) -> Any:
 
 
 def synthesize_trace_from_events(
-    events: List[Dict[str, Any]], session_id: str, agent_name: str
-) -> List[Dict[str, Any]]:
+    events: list[dict[str, Any]], session_id: str, agent_name: str
+) -> list[dict[str, Any]]:
     """
     Constructs a synthetic OpenTelemetry-style span trace from a flat list of ADK events.
     Compatible with AgentClient analysis methods.
@@ -209,8 +209,8 @@ class AdkHistoryConverter:
     def __init__(
         self,
         history_dir: str,
-        questions_file: Optional[str] = None,
-        prompt_to_reference: Optional[Dict[str, Dict[str, Any]]] = None,
+        questions_file: str | None = None,
+        prompt_to_reference: dict[str, dict[str, Any]] | None = None,
     ):
         self.history_dir = history_dir
         self.golden_map = (
@@ -223,9 +223,9 @@ class AdkHistoryConverter:
         # first user message in the trace), so multi-turn rows with
         # reference_data flow through. Built by run.py from dataset.jsonl
         # before invoking the converter.
-        self.prompt_to_reference: Dict[str, Dict[str, Any]] = prompt_to_reference or {}
+        self.prompt_to_reference: dict[str, dict[str, Any]] = prompt_to_reference or {}
 
-    def _load_golden_map(self, filepath: str) -> Dict[str, Dict[str, Any]]:
+    def _load_golden_map(self, filepath: str) -> dict[str, dict[str, Any]]:
         """Loads Golden Dataset to merge reference data based on ID."""
         mapping = {}
         try:
@@ -250,8 +250,8 @@ class AdkHistoryConverter:
         return mapping
 
     def _resolve_reference_data(
-        self, eval_id: str, user_inputs: List[str]
-    ) -> Dict[str, Any]:
+        self, eval_id: str, user_inputs: list[str]
+    ) -> dict[str, Any]:
         """Try the golden_map (keyed by row id) first; fall back to
         prompt_to_reference (keyed by the scenario's starting_prompt) so
         sim traces inherit reference_data from the source dataset row."""
@@ -262,7 +262,7 @@ class AdkHistoryConverter:
             return self.prompt_to_reference[user_inputs[0]]
         return {}
 
-    def process_file(self, file_path: str) -> List[Dict[str, Any]]:
+    def process_file(self, file_path: str) -> list[dict[str, Any]]:
         data = robust_json_load(file_path)
         if not data:
             return []
@@ -533,11 +533,11 @@ class AdkHistoryConverter:
     def _process_per_invocation_format(
         self,
         eval_id: str,
-        session_id: Optional[str],
+        session_id: str | None,
         per_invocation: list,
         case: dict,
         is_st: bool = False,
-    ) -> Optional[Dict[str, Any]]:
+    ) -> dict[str, Any] | None:
         """Process Format 2: eval_metric_result_per_invocation (no session_details).
 
         This format appears when ADK eval runs without capturing full session details.
@@ -711,7 +711,7 @@ class AdkHistoryConverter:
 
         return row
 
-    def run(self) -> List[Dict[str, Any]]:
+    def run(self) -> list[dict[str, Any]]:
         """Processes ADK eval history files and returns a list of interaction records.
 
         Returns:
@@ -728,7 +728,7 @@ class AdkHistoryConverter:
         return all_rows
 
 
-def write_jsonl(records: List[Dict[str, Any]], output_path: str) -> None:
+def write_jsonl(records: list[dict[str, Any]], output_path: str) -> None:
     """Writes a list of records to a JSONL file (one JSON object per line).
 
     Args:
@@ -740,7 +740,7 @@ def write_jsonl(records: List[Dict[str, Any]], output_path: str) -> None:
             f.write(json.dumps(record, ensure_ascii=False, default=str) + "\n")
 
 
-def read_jsonl(input_path: str) -> List[Dict[str, Any]]:
+def read_jsonl(input_path: str) -> list[dict[str, Any]]:
     """Reads a JSONL file and returns a list of records.
 
     Args:
@@ -750,7 +750,7 @@ def read_jsonl(input_path: str) -> List[Dict[str, Any]]:
         List of dictionaries.
     """
     records = []
-    with open(input_path, "r", encoding="utf-8") as f:
+    with open(input_path, encoding="utf-8") as f:
         for line in f:
             line = line.strip()
             if line:
@@ -764,7 +764,7 @@ class TestToGoldenConverter:
     def __init__(self):
         pass
 
-    def _parse_kv_pairs(self, pairs: Optional[List[str]]) -> Dict[str, str]:
+    def _parse_kv_pairs(self, pairs: list[str] | None) -> dict[str, str]:
         """Parses a list of 'key:value' strings into a dictionary."""
         result = {}
         if not pairs:
@@ -782,10 +782,10 @@ class TestToGoldenConverter:
         input_path: str,
         output_path: str,
         agent_name: str,
-        metadata_pairs: Optional[List[str]] = None,
+        metadata_pairs: list[str] | None = None,
         id_prefix: str = "q",
     ):
-        with open(input_path, "r") as f:
+        with open(input_path) as f:
             data = json.load(f)
 
         if not isinstance(data, list):
@@ -826,7 +826,7 @@ class TestToGoldenConverter:
 
         if os.path.exists(output_path):
             try:
-                with open(output_path, "r") as f:
+                with open(output_path) as f:
                     existing_data = json.load(f)
                     if (
                         isinstance(existing_data, dict)

--- a/tools/agent-eval/src/agent_eval/core/data_mapper.py
+++ b/tools/agent-eval/src/agent_eval/core/data_mapper.py
@@ -14,7 +14,7 @@
 import ast
 import json
 import logging
-from typing import Any, Dict, List, Optional, Union
+from typing import Any
 
 import pandas as pd
 from google.genai import types as genai_types
@@ -23,7 +23,7 @@ from vertexai import types
 logger = logging.getLogger("agent_eval")
 
 
-def robust_json_loads(x: Any) -> Optional[Union[Dict, List, str]]:
+def robust_json_loads(x: Any) -> dict | list | str | None:
     """Safely parse a JSON string, returning None for invalid or empty inputs.
 
     Falls back on ``ast.literal_eval`` for Python-repr forms that survive a
@@ -56,7 +56,7 @@ def robust_json_loads(x: Any) -> Optional[Union[Dict, List, str]]:
 # Conventional field names for the "expected" output, ordered by how
 # strongly each one signals the canonical reference. Add domain-specific
 # names here as new agent patterns appear.
-_REFERENCE_FIELD_PRIORITY: List[str] = [
+_REFERENCE_FIELD_PRIORITY: list[str] = [
     "expected_response",
     "expected_behavior",
     "expected_output",
@@ -80,7 +80,7 @@ def _stringify_reference_value(val: Any) -> str:
 
 def extract_reference_text(
     reference_data: Any,
-    preferred_field: Optional[str] = None,
+    preferred_field: str | None = None,
 ) -> str:
     """Resolve a reference string from a reference_data dict.
 
@@ -110,7 +110,7 @@ def extract_reference_text(
         if text.strip():
             return text
 
-    parts: List[str] = []
+    parts: list[str] = []
     for k, v in reference_data.items():
         text = _stringify_reference_value(v)
         if text.strip():
@@ -118,12 +118,12 @@ def extract_reference_text(
     return "\n".join(parts)
 
 
-def reference_field_candidates() -> List[str]:
+def reference_field_candidates() -> list[str]:
     """Return the conventional reference field names (read-only copy)."""
     return list(_REFERENCE_FIELD_PRIORITY)
 
 
-def convert_interactions_to_events(val: Any, sub_agent_trace: Any = None) -> List[Dict]:
+def convert_interactions_to_events(val: Any, sub_agent_trace: Any = None) -> list[dict]:
     """
     Converts tool interactions and agent text responses into Vertex AI SDK Event dictionaries.
 
@@ -199,7 +199,7 @@ def convert_interactions_to_events(val: Any, sub_agent_trace: Any = None) -> Lis
     return events
 
 
-def build_conversation_history(user_inputs: Any, sub_agent_trace: Any) -> List[Dict]:
+def build_conversation_history(user_inputs: Any, sub_agent_trace: Any) -> list[dict]:
     """
     Builds conversation_history for multi-turn metrics from user_inputs and sub_agent_trace.
 
@@ -267,7 +267,7 @@ def get_nested_value(row_val: Any, path: str) -> Any:
 def map_dataset_columns(
     agent_df: pd.DataFrame,
     original_df: pd.DataFrame,
-    mapping: Dict[str, Any],
+    mapping: dict[str, Any],
     metric_name: str,
     metric_tool_use_name: str = "TOOL_USE_QUALITY",
     is_managed_metric: bool = False,

--- a/tools/agent-eval/src/agent_eval/core/dataset_io.py
+++ b/tools/agent-eval/src/agent_eval/core/dataset_io.py
@@ -37,7 +37,7 @@ import json
 import logging
 import shutil
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set
+from typing import Any
 
 logger = logging.getLogger("agent_eval")
 
@@ -53,12 +53,12 @@ CAP_RESPONSE = "has_response"
 # ---------------------------------------------------------------------------
 
 
-def read_dataset(path: Path | str) -> List[Dict[str, Any]]:
+def read_dataset(path: Path | str) -> list[dict[str, Any]]:
     """Read a JSONL dataset file. Returns ``[]`` if the file does not exist."""
     p = Path(path)
     if not p.exists():
         return []
-    rows: List[Dict[str, Any]] = []
+    rows: list[dict[str, Any]] = []
     with p.open("r", encoding="utf-8") as f:
         for lineno, line in enumerate(f, start=1):
             line = line.strip()
@@ -73,7 +73,7 @@ def read_dataset(path: Path | str) -> List[Dict[str, Any]]:
     return rows
 
 
-def write_dataset(path: Path | str, rows: List[Dict[str, Any]]) -> None:
+def write_dataset(path: Path | str, rows: list[dict[str, Any]]) -> None:
     """Write rows as JSONL (UTF-8). Creates parent directories as needed."""
     p = Path(path)
     p.parent.mkdir(parents=True, exist_ok=True)
@@ -82,7 +82,7 @@ def write_dataset(path: Path | str, rows: List[Dict[str, Any]]) -> None:
             f.write(json.dumps(row, ensure_ascii=False) + "\n")
 
 
-def append_dataset(path: Path | str, rows: List[Dict[str, Any]]) -> None:
+def append_dataset(path: Path | str, rows: list[dict[str, Any]]) -> None:
     """Append rows to an existing JSONL dataset."""
     p = Path(path)
     p.parent.mkdir(parents=True, exist_ok=True)
@@ -96,7 +96,7 @@ def append_dataset(path: Path | str, rows: List[Dict[str, Any]]) -> None:
 # ---------------------------------------------------------------------------
 
 
-def detect_capabilities(row: Dict[str, Any]) -> Set[str]:
+def detect_capabilities(row: dict[str, Any]) -> set[str]:
     """Return the capabilities a row supports for metric routing.
 
     Reads the explicit ``kind`` field FIRST (``"multi_turn"`` / ``"single_turn"``
@@ -105,7 +105,7 @@ def detect_capabilities(row: Dict[str, Any]) -> Set[str]:
     - ``conversation_plan`` / ``history`` / ``conversation_history`` → multi-turn
     - ``reference`` or nested ``reference_data`` → reference-eligible
     """
-    caps: Set[str] = set()
+    caps: set[str] = set()
     kind = row.get("kind")
 
     # Reference eligibility — both nested (canonical) and top-level (legacy mirror)
@@ -137,7 +137,7 @@ def detect_capabilities(row: Dict[str, Any]) -> Set[str]:
     return caps
 
 
-def is_single_turn(row: Dict[str, Any]) -> bool:
+def is_single_turn(row: dict[str, Any]) -> bool:
     """True when the row drives the single-turn path (interact / agent-engine).
 
     A row with ``kind: "both"`` qualifies for both — the single-turn path uses
@@ -153,7 +153,7 @@ def is_single_turn(row: Dict[str, Any]) -> bool:
     return CAP_MULTI_TURN not in detect_capabilities(row)
 
 
-def is_multi_turn(row: Dict[str, Any]) -> bool:
+def is_multi_turn(row: dict[str, Any]) -> bool:
     """True when the row drives the multi-turn path (simulate / UserSim).
 
     A row with ``kind: "both"`` qualifies for both — the multi-turn path uses
@@ -173,7 +173,7 @@ def is_multi_turn(row: Dict[str, Any]) -> bool:
 # ---------------------------------------------------------------------------
 
 
-def _adk_text_from_content(content: Optional[Dict[str, Any]]) -> str:
+def _adk_text_from_content(content: dict[str, Any] | None) -> str:
     """Extract joined text from an ADK ``user_content``-shaped dict."""
     if not content:
         return ""
@@ -182,7 +182,7 @@ def _adk_text_from_content(content: Optional[Dict[str, Any]]) -> str:
     return "\n".join(chunks)
 
 
-def import_adk_evalset(evalset_path: Path | str) -> List[Dict[str, Any]]:
+def import_adk_evalset(evalset_path: Path | str) -> list[dict[str, Any]]:
     """Convert an ADK ``.evalset.json`` file into unified rows.
 
     For each ``eval_case``, the LAST user turn becomes ``prompt`` and any
@@ -192,15 +192,15 @@ def import_adk_evalset(evalset_path: Path | str) -> List[Dict[str, Any]]:
     """
     p = Path(evalset_path)
     data = json.loads(p.read_text(encoding="utf-8"))
-    rows: List[Dict[str, Any]] = []
+    rows: list[dict[str, Any]] = []
 
     for case in data.get("eval_cases") or []:
         conversation = case.get("conversation") or []
         if not conversation:
             continue
 
-        history: List[Dict[str, Any]] = []
-        tool_calls: List[Dict[str, Any]] = []
+        history: list[dict[str, Any]] = []
+        tool_calls: list[dict[str, Any]] = []
         last_text = ""
 
         for i, turn in enumerate(conversation):
@@ -214,7 +214,7 @@ def import_adk_evalset(evalset_path: Path | str) -> List[Dict[str, Any]]:
             elif text:
                 history.append({"role": "user", "parts": [{"text": text}]})
 
-        row: Dict[str, Any] = {"prompt": last_text}
+        row: dict[str, Any] = {"prompt": last_text}
         if history:
             # Use SDK-canonical column name 'history' (FLATTEN schema).
             row["history"] = history
@@ -242,14 +242,14 @@ def import_adk_evalset(evalset_path: Path | str) -> List[Dict[str, Any]]:
 _CANONICAL_REFERENCE_KEYS = {"expected_behavior"}
 
 
-def _flatten_reference_data(reference_data: Dict[str, Any]) -> Dict[str, Any]:
+def _flatten_reference_data(reference_data: dict[str, Any]) -> dict[str, Any]:
     """Map the legacy nested ``reference_data`` dict to flat top-level columns.
 
     - ``expected_behavior`` → ``reference`` (canonical SDK column)
     - any other key kept verbatim at top level (e.g. ``expected_docs``,
       ``expected_tool_call``)
     """
-    out: Dict[str, Any] = {}
+    out: dict[str, Any] = {}
     for key, value in reference_data.items():
         if key == "expected_behavior":
             out["reference"] = value
@@ -260,19 +260,19 @@ def _flatten_reference_data(reference_data: Dict[str, Any]) -> Dict[str, Any]:
 
 def _migrate_scenarios(
     scenarios_path: Path,
-    session_input_path: Optional[Path],
-) -> List[Dict[str, Any]]:
+    session_input_path: Path | None,
+) -> list[dict[str, Any]]:
     """Convert legacy scenarios/conversation_scenarios.json to rows."""
     if not scenarios_path.exists():
         return []
     scen_data = json.loads(scenarios_path.read_text(encoding="utf-8"))
-    session_inputs: Optional[Dict[str, Any]] = None
+    session_inputs: dict[str, Any] | None = None
     if session_input_path and session_input_path.exists():
         session_inputs = json.loads(session_input_path.read_text(encoding="utf-8"))
 
-    rows: List[Dict[str, Any]] = []
+    rows: list[dict[str, Any]] = []
     for scen in scen_data.get("scenarios") or []:
-        row: Dict[str, Any] = {"prompt": scen.get("starting_prompt", "")}
+        row: dict[str, Any] = {"prompt": scen.get("starting_prompt", "")}
         plan = scen.get("conversation_plan")
         if plan:
             row["conversation_plan"] = plan
@@ -282,18 +282,18 @@ def _migrate_scenarios(
     return rows
 
 
-def _migrate_golden_dataset(golden_path: Path) -> List[Dict[str, Any]]:
+def _migrate_golden_dataset(golden_path: Path) -> list[dict[str, Any]]:
     """Convert legacy eval_data/golden_dataset.json to rows."""
     if not golden_path.exists():
         return []
     data = json.loads(golden_path.read_text(encoding="utf-8"))
-    rows: List[Dict[str, Any]] = []
+    rows: list[dict[str, Any]] = []
     for q in data.get("golden_questions") or []:
         user_inputs = q.get("user_inputs") or []
         if not user_inputs:
             continue
 
-        row: Dict[str, Any] = {"prompt": user_inputs[-1]}
+        row: dict[str, Any] = {"prompt": user_inputs[-1]}
         if len(user_inputs) > 1:
             # Canonical SDK FLATTEN column name.
             row["history"] = [
@@ -311,7 +311,7 @@ def _migrate_golden_dataset(golden_path: Path) -> List[Dict[str, Any]]:
     return rows
 
 
-def _find_legacy_eval_dir(agent_dir: Path) -> Optional[Path]:
+def _find_legacy_eval_dir(agent_dir: Path) -> Path | None:
     """Return the legacy ``eval/`` folder under ``<agent_dir>`` or ``<agent_dir>/app``.
 
     Older Agent Starter Pack projects nest the agent under ``app/`` so eval
@@ -327,9 +327,9 @@ def _find_legacy_eval_dir(agent_dir: Path) -> Optional[Path]:
 def migrate_legacy(
     agent_dir: Path | str,
     *,
-    output_path: Optional[Path | str] = None,
+    output_path: Path | str | None = None,
     backup: bool = True,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Migrate legacy layouts → unified ``<project_root>/tests/eval/dataset.jsonl``.
 
     Detects four legacy patterns and folds them all into a single canonical
@@ -355,12 +355,12 @@ def migrate_legacy(
     project_root = agent_project_root(agent_dir)
     legacy_eval = _find_legacy_eval_dir(agent_dir)
 
-    scen_rows: List[Dict[str, Any]] = []
-    golden_rows: List[Dict[str, Any]] = []
-    f3_rows: List[Dict[str, Any]] = []
-    metrics_src: Optional[Path] = None
-    metrics_dst: Optional[Path] = None
-    sources_present: List[Path] = []
+    scen_rows: list[dict[str, Any]] = []
+    golden_rows: list[dict[str, Any]] = []
+    f3_rows: list[dict[str, Any]] = []
+    metrics_src: Path | None = None
+    metrics_dst: Path | None = None
+    sources_present: list[Path] = []
 
     if legacy_eval is not None:
         scenarios_path = legacy_eval / "scenarios" / "conversation_scenarios.json"
@@ -416,14 +416,14 @@ def migrate_legacy(
         metrics_dst.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(metrics_src, metrics_dst)
 
-    backup_dir: Optional[Path] = None
+    backup_dir: Path | None = None
     if backup and sources_present:
         from datetime import datetime
 
         ts = datetime.now().strftime("%Y%m%d_%H%M%S")
         backup_dir = project_root / "tests" / "eval" / ".backup" / ts
         backup_dir.mkdir(parents=True, exist_ok=True)
-        copied_dirs: Set[str] = set()
+        copied_dirs: set[str] = set()
         for src in sources_present:
             parent = src.parent
             key = (

--- a/tools/agent-eval/src/agent_eval/core/deterministic_metrics.py
+++ b/tools/agent-eval/src/agent_eval/core/deterministic_metrics.py
@@ -19,7 +19,7 @@ and session state, without requiring LLM-as-judge evaluation.
 """
 
 import json
-from typing import Any, Dict, List, Tuple
+from typing import Any
 
 # Pricing per 1K tokens (standard tier, prompts <= 200k tokens)
 # Format: {model_substring: (input_price_per_1k, output_price_per_1k)}
@@ -41,8 +41,8 @@ MODEL_PRICING = {
 
 
 def calculate_token_usage(
-    session_trace: List[Dict[str, Any]],
-) -> Tuple[float, str, Dict[str, Any]]:
+    session_trace: list[dict[str, Any]],
+) -> tuple[float, str, dict[str, Any]]:
     """
     Informational metric: Track token usage and estimated cost based on the specific model used.
     """
@@ -131,8 +131,8 @@ def calculate_token_usage(
 
 
 def calculate_latency_metrics(
-    session_trace: List[Dict[str, Any]], latency_data: List[Dict[str, Any]] = None
-) -> Tuple[float, str, Dict[str, Any]]:
+    session_trace: list[dict[str, Any]], latency_data: list[dict[str, Any]] = None
+) -> tuple[float, str, dict[str, Any]]:
     """
     Calculate latency metrics from the session trace.
     Returns the total latency score (seconds), but details contains granular breakdown.
@@ -209,8 +209,8 @@ def calculate_latency_metrics(
 
 
 def calculate_cache_efficiency(
-    session_trace: List[Dict[str, Any]],
-) -> Tuple[float, str, Dict[str, Any]]:
+    session_trace: list[dict[str, Any]],
+) -> tuple[float, str, dict[str, Any]]:
     """
     Calculate the efficiency of context caching.
     Returns the cache hit rate (percentage of potential prompt tokens that were cached).
@@ -265,8 +265,8 @@ def calculate_cache_efficiency(
 
 
 def calculate_thinking_metrics(
-    session_trace: List[Dict[str, Any]],
-) -> Tuple[float, str, Dict[str, Any]]:
+    session_trace: list[dict[str, Any]],
+) -> tuple[float, str, dict[str, Any]]:
     """
     Calculate metrics related to the model's 'thinking' or reasoning process.
     Returns the reasoning ratio (thinking tokens / total output tokens).
@@ -329,8 +329,8 @@ def calculate_thinking_metrics(
 
 
 def calculate_tool_utilization(
-    session_trace: List[Dict[str, Any]],
-) -> Tuple[float, str, Dict[str, Any]]:
+    session_trace: list[dict[str, Any]],
+) -> tuple[float, str, dict[str, Any]]:
     """
     Calculate statistics on tool usage frequency and diversity.
     Returns the total number of tool calls.
@@ -377,8 +377,8 @@ def calculate_tool_utilization(
 
 
 def calculate_tool_success_rate(
-    session_trace: List[Dict[str, Any]],
-) -> Tuple[float, str, Dict[str, Any]]:
+    session_trace: list[dict[str, Any]],
+) -> tuple[float, str, dict[str, Any]]:
     """
     Calculate the success rate of tool executions by inspecting tool responses.
     Returns success rate (successful / total) as score.
@@ -449,8 +449,8 @@ def calculate_tool_success_rate(
 
 
 def calculate_grounding_utilization(
-    session_trace: List[Dict[str, Any]],
-) -> Tuple[float, str, Dict[str, Any]]:
+    session_trace: list[dict[str, Any]],
+) -> tuple[float, str, dict[str, Any]]:
     """
     Calculate the extent of grounding usage by inspecting LLM responses for groundingMetadata.
     Returns total grounding chunks (citations) as the score.
@@ -515,8 +515,8 @@ def calculate_grounding_utilization(
 
 
 def calculate_context_saturation(
-    session_trace: List[Dict[str, Any]],
-) -> Tuple[float, str, Dict[str, Any]]:
+    session_trace: list[dict[str, Any]],
+) -> tuple[float, str, dict[str, Any]]:
     """
     Calculate the maximum context saturation (max total tokens used in a single turn).
     Returns max_tokens as the score.
@@ -556,8 +556,8 @@ def calculate_context_saturation(
 
 
 def calculate_agent_handoffs(
-    session_trace: List[Dict[str, Any]],
-) -> Tuple[float, str, Dict[str, Any]]:
+    session_trace: list[dict[str, Any]],
+) -> tuple[float, str, dict[str, Any]]:
     """
     Count the number of agent handoffs/invocations in the session.
     Returns total handoff events as the score.
@@ -607,8 +607,8 @@ def calculate_agent_handoffs(
 
 
 def calculate_output_density(
-    session_trace: List[Dict[str, Any]],
-) -> Tuple[float, str, Dict[str, Any]]:
+    session_trace: list[dict[str, Any]],
+) -> tuple[float, str, dict[str, Any]]:
     """
     Calculate the average number of output tokens per LLM call.
     Returns average output tokens as the score.
@@ -674,8 +674,8 @@ def calculate_output_density(
 
 
 def calculate_sandbox_usage(
-    session_trace: List[Dict[str, Any]],
-) -> Tuple[float, str, Dict[str, Any]]:
+    session_trace: list[dict[str, Any]],
+) -> tuple[float, str, dict[str, Any]]:
     """
     Count the number of tool calls related to sandbox/file system operations.
     Returns the total count as the score.
@@ -750,15 +750,15 @@ DETERMINISTIC_METRICS = {
 
 
 def evaluate_deterministic_metrics(
-    session_state: Dict[str, Any],
-    session_trace: List[Dict[str, Any]],
-    agents_evaluated: List[str],
-    question_metadata: Dict[str, Any],
-    metrics_to_run: List[str] = None,
-    reference_data: Dict[str, Any] = None,
-    metric_definitions: Dict[str, Any] = None,
-    latency_data: List[Dict[str, Any]] = None,
-) -> Dict[str, Dict[str, Any]]:
+    session_state: dict[str, Any],
+    session_trace: list[dict[str, Any]],
+    agents_evaluated: list[str],
+    question_metadata: dict[str, Any],
+    metrics_to_run: list[str] = None,
+    reference_data: dict[str, Any] = None,
+    metric_definitions: dict[str, Any] = None,
+    latency_data: list[dict[str, Any]] = None,
+) -> dict[str, dict[str, Any]]:
     """
     Evaluate all specified deterministic metrics.
     """

--- a/tools/agent-eval/src/agent_eval/core/evaluator.py
+++ b/tools/agent-eval/src/agent_eval/core/evaluator.py
@@ -22,7 +22,7 @@ import time
 from collections import defaultdict
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any
 
 import pandas as pd
 from google.cloud import aiplatform
@@ -151,7 +151,7 @@ def _decode_maybe_json(v: Any) -> Any:
     return v
 
 
-def _resolve_source_column(source: Optional[str], row: Any) -> Any:
+def _resolve_source_column(source: str | None, row: Any) -> Any:
     """Resolve a source spec against a single interaction row.
 
     Supported syntaxes:
@@ -180,7 +180,7 @@ def _resolve_source_column(source: Optional[str], row: Any) -> Any:
     return row.get(source) if hasattr(row, "get") else None
 
 
-def _normalize_intermediate_events(raw_events: Any) -> List[Dict[str, Any]]:
+def _normalize_intermediate_events(raw_events: Any) -> list[dict[str, Any]]:
     """ADK event dicts → Vertex evals.Event-compatible dicts.
 
     ADK shape: ``{content, id, author, timestamp (float), invocationId, actions, ...}``
@@ -194,14 +194,14 @@ def _normalize_intermediate_events(raw_events: Any) -> List[Dict[str, Any]]:
 
     if not isinstance(raw_events, list):
         return []
-    out: List[Dict[str, Any]] = []
+    out: list[dict[str, Any]] = []
     for ev in raw_events:
         if not isinstance(ev, dict):
             continue
         content = ev.get("content")
         if content is None:
             continue
-        norm: Dict[str, Any] = {"content": content}
+        norm: dict[str, Any] = {"content": content}
         if "id" in ev and ev["id"]:
             norm["event_id"] = str(ev["id"])
         if "author" in ev and ev["author"]:
@@ -219,7 +219,7 @@ def _normalize_intermediate_events(raw_events: Any) -> List[Dict[str, Any]]:
 
 def _build_managed_eval_column(
     sdk_col: str, source: str, df: pd.DataFrame
-) -> List[Any]:
+) -> list[Any]:
     """Build a single SDK column from a source spec, applying any needed transform."""
 
     def _build_one(row: Any) -> Any:
@@ -246,7 +246,7 @@ def _build_managed_eval_column(
     return [_build_one(row) for _, row in df.iterrows()]
 
 
-def _resolve_column_source(metric_info: Dict[str, Any], sdk_col: str) -> Optional[str]:
+def _resolve_column_source(metric_info: dict[str, Any], sdk_col: str) -> str | None:
     """Find the source spec for an SDK column.
 
     Lookup order:
@@ -267,18 +267,18 @@ def _resolve_column_source(metric_info: Dict[str, Any], sdk_col: str) -> Optiona
 
 
 def _build_managed_eval_dataset(
-    metric_info: Dict[str, Any],
+    metric_info: dict[str, Any],
     metric_name: str,
     managed_metric_name: str,
     original_df: pd.DataFrame,
-) -> Tuple[pd.DataFrame, Optional[str]]:
+) -> tuple[pd.DataFrame, str | None]:
     """Build the eval_dataset DataFrame for a managed metric per the FLATTEN
     schema. Returns ``(df, error_reason)`` — when error_reason is set, the
     caller should add the metric to skipped_metrics and continue."""
     required = _MANAGED_METRIC_REQUIRED_COLUMNS.get(
         managed_metric_name, ("prompt", "response")
     )
-    cols: Dict[str, List[Any]] = {}
+    cols: dict[str, list[Any]] = {}
     for sdk_col in required:
         source = _resolve_column_source(metric_info, sdk_col)
         if source is None:
@@ -323,7 +323,7 @@ def _interaction_row_capabilities(row: pd.Series) -> set:
     return caps
 
 
-def _required_capabilities(metric_info: Dict[str, Any]) -> set:
+def _required_capabilities(metric_info: dict[str, Any]) -> set:
     """Translate a metric definition's `requires_*` flags into capability tags."""
     required: set = set()
     if metric_info.get("requires_reference"):
@@ -385,7 +385,7 @@ def configure_logging(debug: bool = False) -> None:
         _install_clean_handler()
 
 
-def serialize_rubric_verdicts(rubric_verdicts: Any) -> Optional[List[Dict]]:
+def serialize_rubric_verdicts(rubric_verdicts: Any) -> list[dict] | None:
     """Serialize rubric verdicts to JSON-compatible format."""
     if not rubric_verdicts:
         return None
@@ -480,10 +480,8 @@ def parse_eval_result(
 
 
 def run_single_metric_evaluation(
-    task_args: Tuple,
-) -> Tuple[
-    Optional[pd.DataFrame], str, Optional[pd.DataFrame], Optional[Dict[str, str]]
-]:
+    task_args: tuple,
+) -> tuple[pd.DataFrame | None, str, pd.DataFrame | None, dict[str, str] | None]:
     """Worker function for parallel evaluation.
 
     Returns:
@@ -504,11 +502,11 @@ def run_single_metric_evaluation(
         gcs_dest,
     ) = task_args
 
-    eval_kwargs: Dict[str, Any] = {}
+    eval_kwargs: dict[str, Any] = {}
     if gcs_dest:
         eval_kwargs["config"] = types.EvaluateMethodConfig(dest=gcs_dest)
 
-    last_exc: Optional[Exception] = None
+    last_exc: Exception | None = None
     for attempt in range(retries):
         try:
             logger.info(f"Starting evaluation: {metric_name} (Attempt {attempt + 1})")
@@ -550,7 +548,7 @@ def run_single_metric_evaluation(
             last_exc = e
             logger.error(f"'{metric_name}' fallback also failed: {e}")
 
-    error_info: Optional[Dict[str, str]] = None
+    error_info: dict[str, str] | None = None
     if last_exc is not None:
         msg = str(last_exc).strip()
         # Trim to the first line of error text so the table column stays
@@ -565,13 +563,13 @@ def run_single_metric_evaluation(
     return None, metric_name, None, error_info
 
 
-def load_and_consolidate_metrics(metric_files: List[str]) -> Dict[str, Any]:
+def load_and_consolidate_metrics(metric_files: list[str]) -> dict[str, Any]:
     """Load and consolidate metric definitions from multiple JSON files."""
     consolidated = {}
     logger.info("--- Consolidating Metric Definitions ---")
     for file_path in metric_files:
         try:
-            with open(file_path, "r") as f:
+            with open(file_path) as f:
                 data = json.load(f)
                 prefix = data.get("metric_prefix", "").lstrip("_")
                 metrics = data.get("metrics", {})
@@ -589,8 +587,8 @@ def load_and_consolidate_metrics(metric_files: List[str]) -> Dict[str, Any]:
 
 
 def filter_metrics_by_criteria(
-    metric_definitions: Dict[str, Any], filters: Dict[str, List[str]]
-) -> Dict[str, Any]:
+    metric_definitions: dict[str, Any], filters: dict[str, list[str]]
+) -> dict[str, Any]:
     """Filter metric definitions based on specified criteria.
 
     The ``metric_type`` filter distinguishes deterministic metrics (latency,
@@ -670,7 +668,7 @@ def save_metrics_summary(
     experiment_id: str,
     run_type: str,
     test_description: str,
-    metric_definitions: Dict[str, Any] = None,
+    metric_definitions: dict[str, Any] = None,
     failed_metrics: list[dict] | list[str] | None = None,
     skipped_metrics: list[dict] | None = None,
 ) -> None:
@@ -904,7 +902,7 @@ def save_metrics_summary(
 
 
 class Evaluator:
-    def __init__(self, config: Dict[str, Any]):
+    def __init__(self, config: dict[str, Any]):
         self.config = config
         self.project_id = get_project_id()
         self.location = CONFIG.GOOGLE_CLOUD_LOCATION
@@ -1255,7 +1253,7 @@ class Evaluator:
         # Run Parallel Execution. failed_metrics is a list of dicts so we
         # can show the user the real exception class + message instead of
         # the long-standing misleading "API rate limits" warning.
-        failed_metrics: List[Dict[str, str]] = []
+        failed_metrics: list[dict[str, str]] = []
 
         async def run_task(task_arg):
             return await asyncio.to_thread(run_single_metric_evaluation, task_arg)
@@ -1267,7 +1265,7 @@ class Evaluator:
             if res is not None:
                 all_llm_results.append((res, m_name, input_df))
             else:
-                entry: Dict[str, str] = {"metric": m_name}
+                entry: dict[str, str] = {"metric": m_name}
                 if error_info:
                     entry["exception_type"] = error_info["exception_type"]
                     entry["message"] = error_info["message"]

--- a/tools/agent-eval/src/agent_eval/core/gemini_prompt_builder.py
+++ b/tools/agent-eval/src/agent_eval/core/gemini_prompt_builder.py
@@ -16,7 +16,7 @@
 from __future__ import annotations
 
 import json
-from typing import Any, Dict, Optional
+from typing import Any
 
 
 class GeminiAnalysisPrompter:
@@ -138,17 +138,17 @@ Format your entire response as a single Markdown document.
 
     def __init__(
         self,
-        summary_data: Dict[str, Any],
+        summary_data: dict[str, Any],
         analysis_content: str,
-        context_files: Dict[str, str],
+        context_files: dict[str, str],
         question_file_path: str,
         consolidated_metrics_path: str,
         # Customizable parameters
-        audience: Optional[str] = None,
-        tone: Optional[str] = None,
-        length: Optional[str] = None,
-        custom_strategy_content: Optional[str] = None,
-        focus_directive: Optional[str] = None,
+        audience: str | None = None,
+        tone: str | None = None,
+        length: str | None = None,
+        custom_strategy_content: str | None = None,
+        focus_directive: str | None = None,
     ):
         self.summary_data = summary_data
         self.analysis_content = analysis_content

--- a/tools/agent-eval/src/agent_eval/core/html_report.py
+++ b/tools/agent-eval/src/agent_eval/core/html_report.py
@@ -38,7 +38,7 @@ import json
 import logging
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 logger = logging.getLogger("agent_eval")
 
@@ -84,9 +84,7 @@ def _format_value(val: Any, metric: str) -> str:
     return str(val)
 
 
-def _normalize_score(
-    val: Any, score_range: Optional[Dict[str, Any]]
-) -> Optional[float]:
+def _normalize_score(val: Any, score_range: dict[str, Any] | None) -> float | None:
     if not isinstance(val, (int, float)):
         return None
     if not score_range:
@@ -97,7 +95,7 @@ def _normalize_score(
     return float(max(0.0, min(1.0, (val - lo) / (hi - lo))))
 
 
-def _build_overview_tiles(summary: Dict[str, Any]) -> List[Dict[str, Any]]:
+def _build_overview_tiles(summary: dict[str, Any]) -> list[dict[str, Any]]:
     det = (summary.get("overall_summary") or {}).get("deterministic_metrics") or {}
     tiles = []
     cost = det.get("token_usage.estimated_cost_usd")
@@ -144,9 +142,9 @@ def _build_overview_tiles(summary: Dict[str, Any]) -> List[Dict[str, Any]]:
 
 
 def _build_llm_metric_rows(
-    summary: Dict[str, Any],
-    comparison: Optional[Dict[str, Any]] = None,
-) -> List[Dict[str, Any]]:
+    summary: dict[str, Any],
+    comparison: dict[str, Any] | None = None,
+) -> list[dict[str, Any]]:
     llm = (summary.get("overall_summary") or {}).get("llm_based_metrics") or {}
     skipped = (summary.get("overall_summary") or {}).get("skipped_metrics") or []
     delta_lookup = {}
@@ -189,9 +187,9 @@ def _build_llm_metric_rows(
 
 
 def _build_deterministic_rows(
-    summary: Dict[str, Any],
-    comparison: Optional[Dict[str, Any]] = None,
-) -> List[Dict[str, Any]]:
+    summary: dict[str, Any],
+    comparison: dict[str, Any] | None = None,
+) -> list[dict[str, Any]]:
     det = (summary.get("overall_summary") or {}).get("deterministic_metrics") or {}
     delta_lookup = {}
     if comparison:
@@ -214,8 +212,8 @@ def _build_deterministic_rows(
     return rows
 
 
-def _flatten_det_metrics(det: Dict[str, Any], prefix: str = "") -> Dict[str, Any]:
-    flat: Dict[str, Any] = {}
+def _flatten_det_metrics(det: dict[str, Any], prefix: str = "") -> dict[str, Any]:
+    flat: dict[str, Any] = {}
     for k, v in (det or {}).items():
         if isinstance(v, dict):
             flat.update(_flatten_det_metrics(v, f"{prefix}{k}."))
@@ -224,7 +222,7 @@ def _flatten_det_metrics(det: Dict[str, Any], prefix: str = "") -> Dict[str, Any
     return flat
 
 
-def _extract_prompt_response(llm_scores: Dict[str, Any]) -> tuple[str, str]:
+def _extract_prompt_response(llm_scores: dict[str, Any]) -> tuple[str, str]:
     for val in (llm_scores or {}).values():
         if not isinstance(val, dict):
             continue
@@ -276,7 +274,7 @@ def _safe_parse(s: Any) -> Any:
             return None
 
 
-def _build_csv_lookup(results_csv: Optional[Path]) -> Dict[str, Dict[str, Any]]:
+def _build_csv_lookup(results_csv: Path | None) -> dict[str, dict[str, Any]]:
     """Pre-parse the per-question CSV into a {question_id: {...}} map.
 
     Each value contains the rich data the eval_summary doesn't carry:
@@ -284,7 +282,7 @@ def _build_csv_lookup(results_csv: Optional[Path]) -> Dict[str, Dict[str, Any]]:
     per-turn latency. All caps applied so the embedded payload doesn't
     balloon (CSV rows are 200-500 KB each in practice).
     """
-    lookup: Dict[str, Dict[str, Any]] = {}
+    lookup: dict[str, dict[str, Any]] = {}
     if not results_csv or not results_csv.exists():
         return lookup
     try:
@@ -393,7 +391,7 @@ def _build_csv_lookup(results_csv: Optional[Path]) -> Dict[str, Dict[str, Any]]:
                 # Flatten to a flat list of dicts so the JS render doesn't
                 # bottom-out on `td.name` (undefined) and dump raw JSON.
                 raw_tds = ed.get("tool_declarations") or []
-                tool_declarations: List[Dict[str, Any]] = []
+                tool_declarations: list[dict[str, Any]] = []
                 if isinstance(raw_tds, list):
                     for td in raw_tds:
                         if isinstance(td, dict) and isinstance(
@@ -565,10 +563,10 @@ def _build_csv_lookup(results_csv: Optional[Path]) -> Dict[str, Dict[str, Any]]:
 
 
 def _build_per_question_data(
-    results_csv: Optional[Path],
-    summary: Dict[str, Any],
-    csv_lookup: Optional[Dict[str, Dict[str, Any]]] = None,
-) -> Dict[str, Any]:
+    results_csv: Path | None,
+    summary: dict[str, Any],
+    csv_lookup: dict[str, dict[str, Any]] | None = None,
+) -> dict[str, Any]:
     """Build heatmap matrix + per-question rubric verdict trees.
 
     Conversation + tool-call detail comes from question_answer_log.md
@@ -586,7 +584,7 @@ def _build_per_question_data(
 
     csv_lookup = csv_lookup or {}
 
-    metric_names: List[str] = []
+    metric_names: list[str] = []
     for qa in qa_list:
         for m in (qa.get("llm_metrics") or qa.get("llm_based_metrics") or {}).keys():
             if m not in metric_names:
@@ -616,7 +614,7 @@ def _build_per_question_data(
         # Rubric verdicts per metric — keep the structure but cap reasoning
         # length so the payload stays sane. This is the rich autorater
         # output the user wants in the report.
-        per_metric_verdicts: Dict[str, Any] = {}
+        per_metric_verdicts: dict[str, Any] = {}
         for mname, mval in llm_scores.items():
             if not isinstance(mval, dict):
                 continue
@@ -756,7 +754,7 @@ def _build_per_question_data(
 
 def _build_iterations_data(
     results_parent: Path, current_run_id: str
-) -> List[Dict[str, Any]]:
+) -> list[dict[str, Any]]:
     """Walk every run folder under ``results_parent`` and build a sorted
     list of iteration entries from each run's ``eval_summary.json``.
 
@@ -828,7 +826,7 @@ def _build_iterations_data(
             it["deltas"] = {}
             continue
         prev = iterations[i - 1]
-        deltas: Dict[str, float] = {}
+        deltas: dict[str, float] = {}
         for src in ("llm_metrics", "det_metrics"):
             for k, v in (it[src] or {}).items():
                 pv = (prev[src] or {}).get(k)
@@ -841,7 +839,7 @@ def _build_iterations_data(
     return iterations
 
 
-def _build_per_source_data(summary: Dict[str, Any]) -> Dict[str, Any]:
+def _build_per_source_data(summary: dict[str, Any]) -> dict[str, Any]:
     """Project ``per_source_summary`` into a shape the JS can render as a
     side-by-side strip (simulation vs interaction). Each source has its own
     averaged metrics — the unified pipeline runs UserSim AND interact, and
@@ -855,7 +853,7 @@ def _build_per_source_data(summary: Dict[str, Any]) -> Dict[str, Any]:
     for src_name, metrics in raw.items():
         if not isinstance(metrics, dict):
             continue
-        flat: Dict[str, Any] = {}
+        flat: dict[str, Any] = {}
         for k, v in metrics.items():
             # Each entry is `{average: float, count: int}`.
             if isinstance(v, dict) and "average" in v:
@@ -868,14 +866,14 @@ def _build_payload(
     *,
     run_id: str,
     agent_name: str,
-    summary: Dict[str, Any],
-    comparison: Optional[Dict[str, Any]],
-    gemini_analysis_md: Optional[str],
-    optimization_log_md: Optional[str],
-    qa_log_md: Optional[str],
-    results_csv: Optional[Path],
-    iterations: Optional[List[Dict[str, Any]]] = None,
-) -> Dict[str, Any]:
+    summary: dict[str, Any],
+    comparison: dict[str, Any] | None,
+    gemini_analysis_md: str | None,
+    optimization_log_md: str | None,
+    qa_log_md: str | None,
+    results_csv: Path | None,
+    iterations: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
     git = summary.get("git_info") or {}
     return {
         "meta": {
@@ -2716,14 +2714,14 @@ _HTML_TEMPLATE = r"""<!doctype html>
 def generate_html_report(
     *,
     run_dir: Path,
-    summary: Dict[str, Any],
-    comparison: Optional[Dict[str, Any]] = None,
-    gemini_analysis_md: Optional[str] = None,
-    optimization_log_md: Optional[str] = None,
-    qa_log_md: Optional[str] = None,
-    results_csv: Optional[Path] = None,
-    agent_name: Optional[str] = None,
-    output_path: Optional[Path] = None,
+    summary: dict[str, Any],
+    comparison: dict[str, Any] | None = None,
+    gemini_analysis_md: str | None = None,
+    optimization_log_md: str | None = None,
+    qa_log_md: str | None = None,
+    results_csv: Path | None = None,
+    agent_name: str | None = None,
+    output_path: Path | None = None,
 ) -> Path:
     """Write a self-contained HTML report and return its path."""
     output_path = output_path or (run_dir / "report.html")
@@ -2738,7 +2736,7 @@ def generate_html_report(
     # if the caller didn't pass them. Symmetric: any one missing gets
     # silently empty before this fix, which is how the AI analysis tab
     # disappeared on report regeneration.
-    def _autoload(name: str, current: Optional[str]) -> Optional[str]:
+    def _autoload(name: str, current: str | None) -> str | None:
         if current is not None:
             return current
         p = run_dir / name

--- a/tools/agent-eval/src/agent_eval/core/interactions.py
+++ b/tools/agent-eval/src/agent_eval/core/interactions.py
@@ -16,7 +16,7 @@ import json
 import logging
 import os
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 import pandas as pd
 
@@ -25,7 +25,7 @@ from agent_eval.core.agent_client import AgentClient
 logger = logging.getLogger("agent_eval.interactions")
 
 
-def get_golden_questions(filepath: str) -> List[Dict[str, Any]]:
+def get_golden_questions(filepath: str) -> list[dict[str, Any]]:
     """Loads single-turn questions from either the unified ``dataset.jsonl``
     or a legacy ``golden_dataset.json``.
 
@@ -43,7 +43,7 @@ def get_golden_questions(filepath: str) -> List[Dict[str, Any]]:
             rows = read_dataset(p)
         except FileNotFoundError:
             raise FileNotFoundError(f"Dataset file not found at '{p}'")
-        questions: List[Dict[str, Any]] = []
+        questions: list[dict[str, Any]] = []
         skipped_multi_turn = 0
         for i, row in enumerate(rows):
             if not is_single_turn(row):
@@ -67,7 +67,7 @@ def get_golden_questions(filepath: str) -> List[Dict[str, Any]]:
         raise FileNotFoundError(f"Questions file not found at '{p}'")
 
 
-def _unified_row_to_question(row: Dict[str, Any], *, default_id: str) -> Dict[str, Any]:
+def _unified_row_to_question(row: dict[str, Any], *, default_id: str) -> dict[str, Any]:
     """Adapt a unified ``dataset.jsonl`` row to the legacy ``question_data``
     shape ``process_single_question`` consumes (``user_inputs``, ``id``,
     ``metadata``, ``reference_data``, ``agents_evaluated``).
@@ -90,7 +90,7 @@ def _unified_row_to_question(row: Dict[str, Any], *, default_id: str) -> Dict[st
     # reference fields (e.g. dataset_mapping.reference.source_column =
     # "reference_data:expected_facts") silently get every row skipped at
     # evaluate time.
-    reference_data: Dict[str, Any] = {}
+    reference_data: dict[str, Any] = {}
     nested_ref = row.get("reference_data")
     if isinstance(nested_ref, dict):
         reference_data.update(
@@ -115,8 +115,8 @@ def _unified_row_to_question(row: Dict[str, Any], *, default_id: str) -> Dict[st
 
 
 def filter_questions_by_metadata(
-    questions: List[Dict[str, Any]], filters: Dict[str, List[str]]
-) -> List[Dict[str, Any]]:
+    questions: list[dict[str, Any]], filters: dict[str, list[str]]
+) -> list[dict[str, Any]]:
     """Filters questions based on metadata key-value pairs."""
     if not filters:
         return questions
@@ -139,7 +139,7 @@ def filter_questions_by_metadata(
     return filtered_questions
 
 
-def parse_metadata_filters(filter_strings: Optional[List[str]]) -> Dict[str, List[str]]:
+def parse_metadata_filters(filter_strings: list[str] | None) -> dict[str, list[str]]:
     """Parses filter strings like 'key:val1,val2' into a dictionary."""
     filters = {}
     if not filter_strings:
@@ -160,7 +160,7 @@ def parse_metadata_filters(filter_strings: Optional[List[str]]) -> Dict[str, Lis
     return filters
 
 
-def parse_state_variables(state_var_strings: Optional[List[str]]) -> Dict[str, Any]:
+def parse_state_variables(state_var_strings: list[str] | None) -> dict[str, Any]:
     """Parses state variable strings like 'key:value' into a dictionary."""
     state_vars = {}
     if not state_var_strings:
@@ -177,12 +177,12 @@ def parse_state_variables(state_var_strings: Optional[List[str]]) -> Dict[str, A
 
 
 async def process_single_question(
-    question_data: Dict[str, Any],
+    question_data: dict[str, Any],
     agent_client: AgentClient,
     run_id: int,
     user_ldap: str,
-    state_vars: Dict[str, Any],
-) -> Dict[str, Any]:
+    state_vars: dict[str, Any],
+) -> dict[str, Any]:
     """
     Runs a single question against the agent.
     """
@@ -252,7 +252,7 @@ class InteractionRunner:
     Orchestrates the running of interactions for a set of questions.
     """
 
-    def __init__(self, config: Dict[str, Any]):
+    def __init__(self, config: dict[str, Any]):
         self.config = config
         self.user_ldap = config.get("user") or os.environ.get("USER") or "unknown"
         self.agent_client = AgentClient(

--- a/tools/agent-eval/src/agent_eval/core/metric_discovery.py
+++ b/tools/agent-eval/src/agent_eval/core/metric_discovery.py
@@ -22,7 +22,7 @@ during the canonical-schema sweep — runtime discovery has fully replaced it.)
 import inspect
 import logging
 import re
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 logger = logging.getLogger("agent_eval")
 
@@ -31,7 +31,7 @@ logger = logging.getLogger("agent_eval")
 # Derived from GCS YAML templates and SDK documentation.
 # ---------------------------------------------------------------------------
 
-_METRIC_DESCRIPTIONS: Dict[str, str] = {
+_METRIC_DESCRIPTIONS: dict[str, str] = {
     # API Predefined (server-side evaluation)
     "GENERAL_QUALITY": "Overall response quality across multiple rubric criteria.",
     "SAFETY": "Whether the response is safe and free of harmful content.",
@@ -58,7 +58,7 @@ _METRIC_DESCRIPTIONS: Dict[str, str] = {
     "SUMMARIZATION_QUALITY": "Summarization coverage, accuracy, and conciseness.",
 }
 
-_SCORE_RANGES: Dict[str, Dict[str, Any]] = {
+_SCORE_RANGES: dict[str, dict[str, Any]] = {
     # API Predefined — rubric-based (0-1 pass rate)
     "GENERAL_QUALITY": {"min": 0, "max": 1, "type": "rubric"},
     "SAFETY": {"min": 0, "max": 1, "type": "rubric"},
@@ -90,7 +90,7 @@ _SCORE_RANGES: Dict[str, Dict[str, Any]] = {
 }
 
 # Template placeholders required by GCS YAML metrics
-_GCS_PLACEHOLDERS: Dict[str, List[str]] = {
+_GCS_PLACEHOLDERS: dict[str, list[str]] = {
     "COHERENCE": ["prompt", "response"],
     "FLUENCY": ["prompt", "response"],
     "GROUNDEDNESS": ["prompt", "response"],
@@ -131,7 +131,7 @@ def requires_reference(managed_metric_name: str) -> bool:
     )
 
 
-def default_response_field(managed_metric_name: str) -> Optional[str]:
+def default_response_field(managed_metric_name: str) -> str | None:
     """Preferred response-side column for a managed metric, if not the default.
 
     Returns ``"final_response"`` for text-comparison metrics (need plain text on
@@ -192,7 +192,7 @@ def is_api_predefined(managed_metric_name: str) -> bool:
 
 def discover_managed_metrics(
     exclude_embedding: bool = True,
-) -> Dict[str, Dict[str, Any]]:
+) -> dict[str, dict[str, Any]]:
     """Discover all available managed metrics from the installed SDK.
 
     Reads types.RubricMetric attributes and classifies each as either
@@ -210,7 +210,7 @@ def discover_managed_metrics(
         logger.warning("vertexai not installed, returning empty metrics catalog")
         return {}
 
-    metrics: Dict[str, Dict[str, Any]] = {}
+    metrics: dict[str, dict[str, Any]] = {}
 
     for attr_name in dir(vtx_types.RubricMetric):
         if attr_name.startswith("_"):
@@ -235,7 +235,7 @@ def discover_managed_metrics(
         # default_response_field) are agent-eval discovery metadata used by the
         # picker UI and the per-row routing — NOT part of the SDK metric
         # construction. They live alongside `kind`/`base` as agent-eval extras.
-        entry: Dict[str, Any] = {
+        entry: dict[str, Any] = {
             "kind": "managed",
             "base": name_upper,
             "resolution": resolution,
@@ -270,13 +270,13 @@ def discover_managed_metrics(
 # ---------------------------------------------------------------------------
 
 
-def extract_adk_eval_knowledge() -> Dict[str, Any]:
+def extract_adk_eval_knowledge() -> dict[str, Any]:
     """Extract evaluation knowledge from the installed ADK package.
 
     Returns a dict with ADK metric descriptions, rubric patterns, and field
     names — suitable for injection into Gemini prompts for metric generation.
     """
-    knowledge: Dict[str, Any] = {
+    knowledge: dict[str, Any] = {
         "prebuilt_metrics": [],
         "rubric_patterns": [],
         "eval_field_names": {},
@@ -393,7 +393,7 @@ def extract_adk_eval_knowledge() -> Dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-def format_metrics_for_prompt(metrics: Optional[Dict[str, Dict]] = None) -> str:
+def format_metrics_for_prompt(metrics: dict[str, dict] | None = None) -> str:
     """Format discovered metrics as text for inclusion in Gemini prompts.
 
     Groups by resolution type, includes descriptions and score ranges.
@@ -456,7 +456,7 @@ def format_metrics_for_prompt(metrics: Optional[Dict[str, Dict]] = None) -> str:
 
 
 def format_adk_knowledge_for_prompt(
-    knowledge: Optional[Dict[str, Any]] = None,
+    knowledge: dict[str, Any] | None = None,
 ) -> str:
     """Format ADK evaluation knowledge as text for inclusion in Gemini prompts.
 
@@ -498,8 +498,8 @@ def format_adk_knowledge_for_prompt(
 
 
 def get_metric_definition_entry(
-    metric_key: str, metrics: Optional[Dict] = None
-) -> Optional[Dict]:
+    metric_key: str, metrics: dict | None = None
+) -> dict | None:
     """Get a ready-to-use metric_definitions.json entry for a managed metric.
 
     Returns a dict suitable for direct inclusion in the metrics JSON file,

--- a/tools/agent-eval/src/agent_eval/core/metric_factory.py
+++ b/tools/agent-eval/src/agent_eval/core/metric_factory.py
@@ -49,8 +49,9 @@ from __future__ import annotations
 
 import importlib.util
 import logging
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Tuple
+from typing import Any
 
 from agent_eval.core.metric_schema import (
     ALL_KINDS as _KNOWN_KINDS,
@@ -100,10 +101,10 @@ def parametrized_managed(
             f"Must be a RubricMetric attribute name."
         )
 
-    kwargs: Dict[str, Any] = {}
+    kwargs: dict[str, Any] = {}
     if version:
         kwargs["version"] = version
-    spec_params: Dict[str, Any] = {}
+    spec_params: dict[str, Any] = {}
     if guidelines:
         spec_params["guidelines"] = guidelines
     if rubric_groups:
@@ -117,8 +118,8 @@ def parametrized_managed(
 def custom_llm_judge(
     name: str,
     *,
-    criteria: Dict[str, str] | None = None,
-    rating_scores: Dict[str, str] | None = None,
+    criteria: dict[str, str] | None = None,
+    rating_scores: dict[str, str] | None = None,
     instruction: str | None = None,
     prompt_template: str | None = None,
 ):
@@ -136,7 +137,7 @@ def custom_llm_judge(
             f"both 'criteria' and 'rating_scores' are required."
         )
 
-    builder_kwargs: Dict[str, Any] = {
+    builder_kwargs: dict[str, Any] = {
         "criteria": criteria,
         "rating_scores": rating_scores,
     }
@@ -148,7 +149,7 @@ def custom_llm_judge(
     )
 
 
-def python_function(name: str, fn: Callable[[Dict[str, Any]], Dict[str, Any]]):
+def python_function(name: str, fn: Callable[[dict[str, Any]], dict[str, Any]]):
     """Wrap a deterministic Python function as ``types.Metric``."""
     vt = _vt()
     return vt.Metric(name=name, custom_function=fn)
@@ -198,7 +199,7 @@ def _load_python_callable(module_path: str | Path, function: str) -> Callable:
     return fn
 
 
-def build_metric(name: str, spec: Dict[str, Any], *, base_dir: Path | None = None):
+def build_metric(name: str, spec: dict[str, Any], *, base_dir: Path | None = None):
     """Build a single SDK metric object from a canonical-schema entry.
 
     Six supported ``kind`` values, mirroring the docs at
@@ -276,16 +277,16 @@ def build_metric(name: str, spec: Dict[str, Any], *, base_dir: Path | None = Non
 
 
 def build_all(
-    definitions: Dict[str, Dict[str, Any]],
+    definitions: dict[str, dict[str, Any]],
     *,
     base_dir: Path | None = None,
-) -> List[Tuple[str, Any]]:
+) -> list[tuple[str, Any]]:
     """Build all metrics from a unified definitions dict.
 
     Returns ``[(name, sdk_object), ...]``. Skips entries whose ``kind`` is
     missing from the known set with a logged warning.
     """
-    built: List[Tuple[str, Any]] = []
+    built: list[tuple[str, Any]] = []
     for name, spec in definitions.items():
         try:
             metric = build_metric(name, spec, base_dir=base_dir)

--- a/tools/agent-eval/src/agent_eval/core/metric_families.py
+++ b/tools/agent-eval/src/agent_eval/core/metric_families.py
@@ -28,7 +28,6 @@ Families mirror ``_evals_metric_handlers._METRIC_HANDLER_MAPPING``:
 from __future__ import annotations
 
 import logging
-from typing import Optional
 
 logger = logging.getLogger("agent_eval")
 
@@ -87,7 +86,7 @@ def _supported_translation() -> frozenset:
         return frozenset()
 
 
-def _matches_predefined(n: str, supported: frozenset) -> Optional[str]:
+def _matches_predefined(n: str, supported: frozenset) -> str | None:
     """Return the canonical SDK name (e.g. ``general_quality_v1``) if ``n``
     matches a predefined metric; otherwise None.
     """

--- a/tools/agent-eval/src/agent_eval/core/metric_generator.py
+++ b/tools/agent-eval/src/agent_eval/core/metric_generator.py
@@ -24,7 +24,7 @@ import json
 import re
 import time
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any
 
 from agent_eval.core.metric_discovery import (
     format_adk_knowledge_for_prompt,
@@ -476,7 +476,7 @@ def analyze_agent_data(
     agent_dir: Path,
     agent_name: str,
     model: str = "gemini-3.1-pro-preview",
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Gemini Call 1: Analyze agent source code to identify evaluation data.
 
     This is a factual extraction task — low hallucination risk. The model
@@ -519,13 +519,13 @@ def analyze_agent_data(
 def generate_metric_definitions(
     agent_dir: Path,
     agent_name: str,
-    agent_analysis: Dict[str, Any],
-    selected_managed: Dict[str, Dict],
+    agent_analysis: dict[str, Any],
+    selected_managed: dict[str, dict],
     user_priorities: str = "",
-    existing_metrics: Optional[Dict[str, Any]] = None,
+    existing_metrics: dict[str, Any] | None = None,
     model: str = "gemini-3.1-pro-preview",
     n_custom_metrics: int = 3,
-) -> Tuple[Dict[str, Any], str]:
+) -> tuple[dict[str, Any], str]:
     """Gemini Call 2: Generate metric_definitions.json content.
 
     Takes the agent analysis from Call 1, user-selected managed metrics,
@@ -617,16 +617,16 @@ def generate_metric_definitions(
 def generate_eval_data(
     agent_dir: Path,
     agent_name: str,
-    agent_analysis: Dict[str, Any],
-    metric_definitions: Dict[str, Any],
-    existing_scenarios: Optional[List] = None,
-    existing_golden: Optional[List] = None,
+    agent_analysis: dict[str, Any],
+    metric_definitions: dict[str, Any],
+    existing_scenarios: list | None = None,
+    existing_golden: list | None = None,
     user_priorities: str = "",
     model: str = "gemini-3.1-pro-preview",
     metric_rationale: str = "",
-    required_reference_fields: Optional[List[Tuple[str, str]]] = None,
+    required_reference_fields: list[tuple[str, str]] | None = None,
     rows_per_kind: int = 5,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Gemini Call 3: Generate scenarios and golden data.
 
     Uses the agent analysis, final metric definitions, and the rationale +
@@ -774,7 +774,7 @@ def generate_eval_data(
     }
 
 
-def _format_source_code(agent_context: Dict[str, str]) -> str:
+def _format_source_code(agent_context: dict[str, str]) -> str:
     """Format agent source code files for inclusion in prompts."""
     source_parts = []
     for filepath, content in agent_context.items():
@@ -785,13 +785,13 @@ def _format_source_code(agent_context: Dict[str, str]) -> str:
     return "\n\n".join(source_parts) if source_parts else "No source code available."
 
 
-def _discover_existing_eval_files(agent_dir: Path) -> Dict[str, str]:
+def _discover_existing_eval_files(agent_dir: Path) -> dict[str, str]:
     """Read existing eval files (metrics, scenarios, golden data) if present.
 
     Returns a dict with keys like 'metrics', 'scenarios', 'golden_data'
     mapped to their file contents (truncated for prompt efficiency).
     """
-    existing: Dict[str, str] = {}
+    existing: dict[str, str] = {}
     eval_dir = agent_dir / "eval"
 
     if not eval_dir.exists():
@@ -922,7 +922,7 @@ def _call_gemini(prompt: str, model: str) -> str:
         http_options=HttpOptions(api_version="v1"),
     )
 
-    last_exc: Optional[BaseException] = None
+    last_exc: BaseException | None = None
     for attempt in range(len(_RETRY_BACKOFF_SECONDS) + 1):
         try:
             response = client.models.generate_content(
@@ -943,7 +943,7 @@ def _call_gemini(prompt: str, model: str) -> str:
     raise MetricGenerationError(f"Gemini API call failed: {last_exc}")
 
 
-def _extract_json(text: str) -> Optional[Dict]:
+def _extract_json(text: str) -> dict | None:
     """Extract JSON from Gemini's response, handling markdown fences."""
     # Try to find JSON in code fences first
     fence_match = re.search(r"```(?:json)?\s*\n(.*?)\n```", text, re.DOTALL)
@@ -973,13 +973,13 @@ def _extract_json(text: str) -> Optional[Dict]:
 def _parse_and_validate_metrics(
     raw_response: str,
     agent_name: str,
-) -> Tuple[Dict[str, Any], List[str]]:
+) -> tuple[dict[str, Any], list[str]]:
     """Parse Gemini's response and validate each metric definition.
 
     Returns:
         Tuple of (valid_metrics_dict, warning_messages).
     """
-    warnings: List[str] = []
+    warnings: list[str] = []
 
     parsed = _extract_json(raw_response)
     if not parsed:
@@ -989,7 +989,7 @@ def _parse_and_validate_metrics(
     if not raw_metrics:
         return {}, ["No 'metrics' key found in response."]
 
-    valid_metrics: Dict[str, Any] = {}
+    valid_metrics: dict[str, Any] = {}
 
     for name, defn in raw_metrics.items():
         metric_warnings = _validate_single_metric(name, defn)
@@ -1009,7 +1009,7 @@ def _parse_and_validate_metrics(
 ALLOWED_PLACEHOLDER_NAMES = {"prompt", "response", "reference"}
 
 
-def _validate_single_metric(name: str, defn: Dict) -> List[str]:
+def _validate_single_metric(name: str, defn: dict) -> list[str]:
     """Validate a single metric definition against the canonical schema.
 
     Per ``core/metric_schema.py``: every entry MUST declare a ``kind`` from
@@ -1024,7 +1024,7 @@ def _validate_single_metric(name: str, defn: Dict) -> List[str]:
         REQUIRED_FIELDS,
     )
 
-    errors: List[str] = []
+    errors: list[str] = []
 
     if not isinstance(defn, dict):
         return [f"'{name}': not a dict"]

--- a/tools/agent-eval/src/agent_eval/core/path_detector.py
+++ b/tools/agent-eval/src/agent_eval/core/path_detector.py
@@ -30,7 +30,6 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import List, Optional
 
 # Mirror init.py's skip set so detection stays consistent with discovery.
 _SKIP_DIRS = {
@@ -67,8 +66,8 @@ class PathDetection:
 
     path: str  # "A" (deployed Agent Engine) | "B" (local source) | "unknown"
     evidence: str = ""
-    agent_engine_resource: Optional[str] = None
-    local_agents: List[Path] = field(default_factory=list)
+    agent_engine_resource: str | None = None
+    local_agents: list[Path] = field(default_factory=list)
 
     def has_both(self) -> bool:
         """True when both a deployed Agent Engine AND a local agent are available."""
@@ -80,7 +79,7 @@ class PathDetection:
 # ---------------------------------------------------------------------------
 
 
-def _resource_from_metadata_file(path: Path) -> Optional[str]:
+def _resource_from_metadata_file(path: Path) -> str | None:
     """Extract a real Agent Engine resource name from a deployment-metadata file.
 
     Returns None if the file is missing, malformed, or holds a placeholder.
@@ -114,7 +113,7 @@ _AGENT_ENGINE_METADATA_FILENAMES = (
 )
 
 
-def _find_metadata_candidates(cwd: Path) -> List[Path]:
+def _find_metadata_candidates(cwd: Path) -> list[Path]:
     """rglob for Agent Engine metadata files, shallowest path first.
 
     Mirrors ``_find_local_agents`` so ``init`` finds an Agent Engine deployment
@@ -122,7 +121,7 @@ def _find_metadata_candidates(cwd: Path) -> List[Path]:
     directory. If multiple metadata files exist (rare — multi-project parent),
     the shallowest one wins, which is usually what the user means.
     """
-    candidates: List[Path] = []
+    candidates: list[Path] = []
     for filename in _AGENT_ENGINE_METADATA_FILENAMES:
         for found in cwd.rglob(filename):
             if any(part in _SKIP_DIRS for part in found.parts):
@@ -132,7 +131,7 @@ def _find_metadata_candidates(cwd: Path) -> List[Path]:
     return candidates
 
 
-def _detect_agent_engine(cwd: Path) -> Optional[PathDetection]:
+def _detect_agent_engine(cwd: Path) -> PathDetection | None:
     """Probe for an Agent Engine deployment. Returns None if not found."""
     env_resource = os.getenv("AGENT_ENGINE_RESOURCE_NAME")
     if env_resource and env_resource not in _PLACEHOLDER_RESOURCE_VALUES:
@@ -164,9 +163,9 @@ def _detect_agent_engine(cwd: Path) -> Optional[PathDetection]:
 # ---------------------------------------------------------------------------
 
 
-def _find_local_agents(cwd: Path) -> List[Path]:
+def _find_local_agents(cwd: Path) -> list[Path]:
     """rglob for ``agent.py`` skipping standard noise directories."""
-    agents: List[Path] = []
+    agents: list[Path] = []
     for agent_py in sorted(cwd.rglob("agent.py")):
         if any(part in _SKIP_DIRS for part in agent_py.parts):
             continue
@@ -174,7 +173,7 @@ def _find_local_agents(cwd: Path) -> List[Path]:
     return agents
 
 
-def _detect_local_adk(cwd: Path) -> Optional[PathDetection]:
+def _detect_local_adk(cwd: Path) -> PathDetection | None:
     agents = _find_local_agents(cwd)
     if not agents:
         return None

--- a/tools/agent-eval/src/agent_eval/core/path_resolver.py
+++ b/tools/agent-eval/src/agent_eval/core/path_resolver.py
@@ -32,7 +32,6 @@ without forcing migration.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Optional
 
 _CANONICAL_EVAL = Path("tests") / "eval"
 _LEGACY_EVAL_FLAT = Path("eval")
@@ -98,7 +97,7 @@ def find_eval_dir(agent_dir: Path | str) -> Path:
     return project_root / _CANONICAL_EVAL
 
 
-def find_metrics_path(agent_dir: Path | str) -> Optional[Path]:
+def find_metrics_path(agent_dir: Path | str) -> Path | None:
     """Return the active ``metric_definitions.json`` path or ``None`` if missing.
 
     Searches in canonical-first, then legacy-fallback order. Includes the
@@ -119,7 +118,7 @@ def find_metrics_path(agent_dir: Path | str) -> Optional[Path]:
     return None
 
 
-def find_dataset_path(agent_dir: Path | str) -> Optional[Path]:
+def find_dataset_path(agent_dir: Path | str) -> Path | None:
     """Return the active ``dataset.jsonl`` path or ``None`` if missing.
 
     Searches canonical (project-root ``tests/eval/``), then the F3 legacy
@@ -147,7 +146,7 @@ def find_dataset_path(agent_dir: Path | str) -> Optional[Path]:
 _PROJECT_ROOT_MARKERS = ("pyproject.toml", "setup.py", "setup.cfg")
 
 
-def find_project_root(start: Path | None = None, max_depth: int = 6) -> Optional[Path]:
+def find_project_root(start: Path | None = None, max_depth: int = 6) -> Path | None:
     """Walk up from ``start`` (default cwd) looking for a project-root marker.
 
     Returns the directory containing the marker, or None if nothing matches
@@ -166,10 +165,10 @@ def find_project_root(start: Path | None = None, max_depth: int = 6) -> Optional
 
 def resolve_relative_to_project(
     relpath: Path | str,
-    explicit: Optional[Path | str] = None,
+    explicit: Path | str | None = None,
     *,
     start: Path | None = None,
-) -> Optional[Path]:
+) -> Path | None:
     """Resolve ``relpath`` (e.g. ``tests/eval/dataset.jsonl``) against the
     nearest project root walking up from ``start`` (default cwd).
 

--- a/tools/agent-eval/src/agent_eval/core/processor.py
+++ b/tools/agent-eval/src/agent_eval/core/processor.py
@@ -14,7 +14,7 @@
 import asyncio
 import json
 import logging
-from typing import Any, Dict, Optional
+from typing import Any
 
 import pandas as pd
 
@@ -24,7 +24,7 @@ logger = logging.getLogger("agent_eval.processor")
 
 
 async def enrich_single_interaction(
-    row: pd.Series, results_dir: Optional[str] = None, skip_traces: bool = False
+    row: pd.Series, results_dir: str | None = None, skip_traces: bool = False
 ) -> pd.Series:
     """
     Enriches a single interaction row with session state and trace data.
@@ -209,7 +209,7 @@ class InteractionProcessor:
     Orchestrates the enrichment of interaction logs with traces and state.
     """
 
-    def __init__(self, config: Dict[str, Any]):
+    def __init__(self, config: dict[str, Any]):
         self.config = config
         self.results_dir = config.get("results_dir")
         self.skip_traces = config.get("skip_traces", False)

--- a/tools/agent-eval/src/agent_eval/core/simulation.py
+++ b/tools/agent-eval/src/agent_eval/core/simulation.py
@@ -19,7 +19,7 @@ import os
 import tempfile
 import uuid
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from google.adk.agents.base_agent import BaseAgent
 from google.adk.cli.utils.agent_loader import AgentLoader
@@ -203,8 +203,8 @@ async def run_simulation_in_process(
     dataset_path: Path,
     parallelism: int = 4,
     run_mode: str = "all",
-    case_id: Optional[str] = None,
-) -> List[Dict[str, Any]]:
+    case_id: str | None = None,
+) -> list[dict[str, Any]]:
     """Runs the simulation in-process using ADK Python APIs and returns converted records."""
 
     # Ensure project root is in sys.path so the agent can import shared modules

--- a/tools/agent-eval/src/agent_eval/core/utils.py
+++ b/tools/agent-eval/src/agent_eval/core/utils.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Dict, Optional
 
 logger = logging.getLogger("agent_eval.utils")
 
@@ -33,8 +32,8 @@ _EXCLUDE_PATTERNS = [
 
 
 def discover_agent_context(
-    agent_dir: Optional[Path], quiet: bool = False
-) -> Dict[str, str]:
+    agent_dir: Path | None, quiet: bool = False
+) -> dict[str, str]:
     """Discover and load agent source code and ADK context from an agent directory.
 
     Scans for agent.py, tools.py, and GEMINI.md files while skipping
@@ -47,7 +46,7 @@ def discover_agent_context(
     Returns:
         Dict mapping file paths (or labels) to their contents.
     """
-    context: Dict[str, str] = {}
+    context: dict[str, str] = {}
     if not agent_dir or not agent_dir.exists():
         return context
 

--- a/tools/agent-eval/tests/cli/test_init.py
+++ b/tools/agent-eval/tests/cli/test_init.py
@@ -134,7 +134,7 @@ class TestInitAutoApprove(unittest.TestCase):
     correct surfaces are scaffolded based on what we seeded into the tmp dir.
     """
 
-    def _invoke(self, target_dir: Path) -> "object":
+    def _invoke(self, target_dir: Path) -> object:
         """Invoke init -y with env stubbed and the gcloud check no-oped."""
         runner = CliRunner()
         with mock.patch(


### PR DESCRIPTION
## Summary

This PR enables the **`UP` (pyupgrade)** linter rule in Ruff to modernize Python syntax codebase-wide to match our target Python version (**3.10+**). It automatically upgrades **627 syntax and type-hint patterns** across the repository, aligning the codebase with modern Python best practices, and cleans up legacy circular-import linter bypasses.
Enforcing these modern syntax rules now ensures that all future code contributions remain clean, readable, and consistent with Python 3.10+ standards.

---

## Key Changes

1. **Linter Configuration (`pyproject.toml`)**:
   * Appended `"UP"` to `tool.ruff.lint.select` to activate the `pyupgrade` rule. Syntax modernization will now be automatically checked and enforced by Ruff in all future commits and CI checks.
2. **Modernized Type Annotations (PEP 585 & PEP 604)**:
   * Converted all deprecated `typing` generics (`List`, `Dict`, `Tuple`) to native built-in types (`list`, `dict`, `tuple`).
   * Converted all `Optional[T]` and `Union[A, B]` type declarations to clean, modern native union operators: **`T | None`** and **`A | B`** (e.g., `str | None` instead of `Optional[str]`).
3. **Circular-Import & Late-Import Cleanups (`main.py`)**:
   * Moved all 14 Click command imports from the middle of `src/agent_eval/cli/main.py` to the very top of the file where they belong, and **eliminated 14 legacy `# noqa: E402` linter bypasses**.
   * Verified that because our command modules (like `simulate.py`, `evaluate.py`) already use local runtime imports to load the welcome banner, there are **absolutely no circular dependencies at startup** when importing them at the top of `main.py`!
4. **Automated Codebase-Wide Upgrade**:
   * Executed `ruff check --fix` and `ruff format` to automatically apply the syntax upgrades across all source and test files, leaving **zero remaining lint errors**!