### PR TITLE
feat(agent-eval): implement end-to-end evaluation on Vertex AI Pipelines (KFP) & fix SDK instantiation

### DIFF
--- a/tools/agent-eval/pyproject.toml
+++ b/tools/agent-eval/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "tqdm>=4.66.0",
     "questionary>=2.0.0",
     "pydantic-settings>=2.12.0",
+    "kfp>=2.7.0",
 ]
 
 [project.optional-dependencies]

--- a/tools/agent-eval/src/agent_eval/core/evaluator.py
+++ b/tools/agent-eval/src/agent_eval/core/evaluator.py
@@ -906,7 +906,7 @@ class Evaluator:
     def __init__(self, config: dict[str, Any]):
         self.config = config
         self.project_id = get_project_id()
-        self.location = config.get("location") or CONFIG.GOOGLE_CLOUD_LOCATION
+        self.location = config.get("location", CONFIG.GOOGLE_CLOUD_LOCATION)
 
         if not self.project_id:
             raise ValueError("GOOGLE_CLOUD_PROJECT environment variable is not set.")

--- a/tools/agent-eval/src/agent_eval/core/evaluator.py
+++ b/tools/agent-eval/src/agent_eval/core/evaluator.py
@@ -906,7 +906,7 @@ class Evaluator:
     def __init__(self, config: dict[str, Any]):
         self.config = config
         self.project_id = get_project_id()
-        self.location = CONFIG.GOOGLE_CLOUD_LOCATION
+        self.location = config.get("location") or CONFIG.GOOGLE_CLOUD_LOCATION
 
         if not self.project_id:
             raise ValueError("GOOGLE_CLOUD_PROJECT environment variable is not set.")

--- a/tools/agent-eval/src/agent_eval/core/kfp_pipeline.py
+++ b/tools/agent-eval/src/agent_eval/core/kfp_pipeline.py
@@ -1,0 +1,384 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Kubeflow Pipeline (KFP) definition for end-to-end agent-eval."""
+
+import logging
+from pathlib import Path
+from typing import Any
+
+from kfp import compiler, dsl
+
+logger = logging.getLogger("agent_eval.kfp_pipeline")
+
+
+# ── KFP Component Definitions ────────────────────────────────────────────────
+
+
+@dsl.component(
+    base_image="{runner_image}",
+    packages_to_install=["google-cloud-storage", "pandas", "pydantic"],
+)
+def simulate_component(
+    dataset_gcs_path: str,
+    prompts_gcs_output: dsl.OutputPath(str),
+) -> None:
+    """KFP component to run the User Simulator and generate prompts."""
+    import tempfile
+    from pathlib import Path
+
+    from google.cloud import storage
+
+    # 1. Download dataset from GCS
+    storage_client = storage.Client()
+    local_dataset = Path(tempfile.mktemp(suffix="_dataset.jsonl"))
+
+    # Parse GCS URI
+    bucket_name, blob_name = dataset_gcs_path.replace("gs://", "").split("/", 1)
+    bucket = storage_client.bucket(bucket_name)
+    blob = bucket.blob(blob_name)
+    blob.download_to_filename(local_dataset)
+
+    # 2. Run Simulation
+    # For simulation, we need a dummy agent_dir to satisfy resolvers
+    temp_agent_dir = Path(tempfile.mkdtemp())
+    (temp_agent_dir / "agent.py").touch()
+
+    # We run the simulation in-process to generate prompts
+    # Since we are just generating prompts, we don't run the actual agent interactions yet
+    # (that happens in the interact step)
+    #
+    # Let's run the CLI command via subprocess inside the container.
+    local_output = Path(tempfile.mktemp(suffix="_prompts.jsonl"))
+
+    import subprocess
+
+    cmd = [
+        "agent-eval",
+        "simulate",
+        "--dataset-path",
+        str(local_dataset),
+        "--output-path",
+        str(local_output),
+    ]
+
+    print(f"Running command: {' '.join(cmd)}")
+    subprocess.run(cmd, check=True)
+
+    # 3. Upload prompts to the KFP-managed output GCS path
+    out_bucket_name, out_blob_name = prompts_gcs_output.replace("gs://", "").split(
+        "/", 1
+    )
+    out_bucket = storage_client.bucket(out_bucket_name)
+    out_blob = out_bucket.blob(out_blob_name)
+    out_blob.upload_from_filename(local_output)
+
+    # Cleanup
+    local_dataset.unlink(missing_ok=True)
+    local_output.unlink(missing_ok=True)
+
+
+@dsl.component(
+    base_image="{runner_image}",
+    packages_to_install=["google-cloud-storage", "requests"],
+)
+def interact_component(
+    prompts_gcs_path: str,
+    agent_url: str,
+    agent_name: str,
+    interactions_gcs_output: dsl.OutputPath(str),
+) -> None:
+    """KFP component to drive the remote agent and record interactions."""
+    import subprocess
+    import tempfile
+    from pathlib import Path
+
+    from google.cloud import storage
+
+    storage_client = storage.Client()
+
+    # 1. Download prompts from GCS
+    local_prompts = Path(tempfile.mktemp(suffix="_prompts.jsonl"))
+    bucket_name, blob_name = prompts_gcs_path.replace("gs://", "").split("/", 1)
+    bucket = storage_client.bucket(bucket_name)
+    blob = bucket.blob(blob_name)
+    blob.download_to_filename(local_prompts)
+
+    # 2. Run Interact CLI
+    local_output = Path(tempfile.mktemp(suffix="_interactions.jsonl"))
+
+    cmd = [
+        "agent-eval",
+        "interact",
+        "--prompts-file",
+        str(local_prompts),
+        "--output-file",
+        str(local_output),
+        "--agent-url",
+        agent_url,
+        "--agent-name",
+        agent_name,
+    ]
+
+    print(f"Running command: {' '.join(cmd)}")
+    subprocess.run(cmd, check=True)
+
+    # 3. Upload interactions to GCS
+    out_bucket_name, out_blob_name = interactions_gcs_output.replace("gs://", "").split(
+        "/", 1
+    )
+    out_bucket = storage_client.bucket(out_bucket_name)
+    out_blob = out_bucket.blob(out_blob_name)
+    out_blob.upload_from_filename(local_output)
+
+    # Cleanup
+    local_prompts.unlink(missing_ok=True)
+    local_output.unlink(missing_ok=True)
+
+
+@dsl.component(
+    base_image="{runner_image}",
+    packages_to_install=["google-cloud-storage", "google-cloud-aiplatform"],
+)
+def evaluate_component(
+    interactions_gcs_path: str,
+    metrics_gcs_path: str,
+    explicit_gcs_dest: str,
+    results_gcs_output: dsl.OutputPath(str),
+    location: str = "us-central1",
+) -> None:
+    """KFP component to run evaluation metrics on the interactions."""
+    import os
+    import shutil
+    import subprocess
+    import tempfile
+    from pathlib import Path
+
+    from google.cloud import storage
+
+    storage_client = storage.Client()
+
+    # 1. Download inputs from GCS
+    local_interactions = Path(tempfile.mktemp(suffix="_interactions.jsonl"))
+    bucket_name, blob_name = interactions_gcs_path.replace("gs://", "").split("/", 1)
+    bucket = storage_client.bucket(bucket_name)
+    blob = bucket.blob(blob_name)
+    blob.download_to_filename(local_interactions)
+
+    local_metrics = Path(tempfile.mktemp(suffix="_metrics.json"))
+    m_bucket_name, m_blob_name = metrics_gcs_path.replace("gs://", "").split("/", 1)
+    m_bucket = storage_client.bucket(m_bucket_name)
+    m_blob = m_bucket.blob(m_blob_name)
+    m_blob.download_to_filename(local_metrics)
+
+    # 2. Run Evaluate CLI
+    local_results_dir = Path(tempfile.mkdtemp())
+
+    cmd = [
+        "agent-eval",
+        "evaluate",
+        "--interaction-file",
+        str(local_interactions),
+        "--metrics-files",
+        str(local_metrics),
+        "--results-dir",
+        str(local_results_dir),
+        "--gcs-dest",
+        explicit_gcs_dest,
+        "--location",
+        location,
+    ]
+
+    print(f"Running command: {' '.join(cmd)}")
+    subprocess.run(cmd, check=True)
+
+    # 3. Upload summary and details to GCS
+    local_summary = local_results_dir / "eval_summary.json"
+    if local_summary.exists():
+        # A. Upload to KFP managed output path
+        out_bucket_name, out_blob_name = results_gcs_output.replace("gs://", "").split(
+            "/", 1
+        )
+        out_bucket = storage_client.bucket(out_bucket_name)
+        out_blob = out_bucket.blob(out_blob_name)
+        out_blob.upload_from_filename(local_summary)
+
+        # B. Upload directly to explicit_gcs_dest/eval_summary.json (for easy SDK access)
+        exp_bucket_name, exp_blob_name = explicit_gcs_dest.replace("gs://", "").split(
+            "/", 1
+        )
+        exp_bucket = storage_client.bucket(exp_bucket_name)
+        exp_blob_path = f"{exp_blob_name.rstrip('/')}/eval_summary.json"
+        exp_blob = exp_bucket.blob(exp_blob_path)
+        exp_blob.upload_from_filename(local_summary)
+
+        # Also upload everything else to the sibling directory for archiving
+        parent_blob_dir = os.path.dirname(out_blob_name)
+        for root, _, files in os.walk(local_results_dir):
+            for file in files:
+                local_file_path = Path(root) / file
+                rel_path = local_file_path.relative_to(local_results_dir)
+                dest_blob_name = f"{parent_blob_dir}/details/{rel_path}"
+                sibling_blob = out_bucket.blob(dest_blob_name)
+                sibling_blob.upload_from_filename(local_file_path)
+
+    # Cleanup
+    local_interactions.unlink(missing_ok=True)
+    local_metrics.unlink(missing_ok=True)
+    shutil.rmtree(local_results_dir, ignore_errors=True)
+
+
+# ── Pipeline Definition ──────────────────────────────────────────────────────
+
+
+def create_evaluation_pipeline(runner_image: str):
+    """Dynamically compiles KFP component definitions with the correct runner image."""
+
+    @dsl.pipeline(
+        name="agent-eval-end-to-end",
+        description="End-to-end serverless agent evaluation pipeline: Simulate, Interact, and Evaluate.",
+    )
+    def agent_eval_pipeline(
+        dataset_gcs_path: str,
+        metrics_gcs_path: str,
+        agent_url: str,
+        agent_name: str,
+        gcs_dest: str,
+        location: str = "us-central1",
+    ):
+        # 1. Run Simulation
+        sim_task = simulate_component(
+            dataset_gcs_path=dataset_gcs_path,
+        )
+
+        # 2. Run Interaction (depends on Simulation prompts)
+        interact_task = interact_component(
+            prompts_gcs_path=sim_task.outputs["prompts_gcs_output"],
+            agent_url=agent_url,
+            agent_name=agent_name,
+        )
+
+        # 3. Run Evaluation (depends on Interaction history)
+        eval_task = evaluate_component(
+            interactions_gcs_path=interact_task.outputs["interactions_gcs_output"],
+            metrics_gcs_path=metrics_gcs_path,
+            explicit_gcs_dest=gcs_dest,
+            location=location,
+        )
+
+        # Disable caching to ensure evals always run fresh when triggered
+        sim_task.set_caching_options(False)
+        interact_task.set_caching_options(False)
+        eval_task.set_caching_options(False)
+
+    return agent_eval_pipeline
+
+
+# ── Pipeline Compiler Helper ────────────────────────────────────────────────
+
+
+def compile_pipeline(
+    output_path: Path | str,
+    runner_image: str,
+) -> None:
+    """Compile the KFP pipeline to a YAML definition file.
+
+    Args:
+        output_path: Local file path to write the compiled pipeline YAML to.
+        runner_image: The Docker image containing agent-eval to run the steps.
+    """
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    simulate_component.component_spec.implementation.container.image = runner_image
+    interact_component.component_spec.implementation.container.image = runner_image
+    evaluate_component.component_spec.implementation.container.image = runner_image
+
+    pipeline_func = create_evaluation_pipeline(runner_image)
+
+    logger.info(f"Compiling agent-eval pipeline using runner image: {runner_image}...")
+    compiler.Compiler().compile(
+        pipeline_func=pipeline_func,
+        package_path=str(output_path),
+    )
+    logger.info(f"Pipeline compiled successfully to {output_path}")
+
+
+# ── Pipeline Job Submission Helper ──────────────────────────────────────────
+
+
+def submit_pipeline_job(
+    project_id: str,
+    location: str,
+    pipeline_yaml_path: Path | str,
+    gcs_dest: str,
+    dataset_gcs_path: str,
+    metrics_gcs_path: str,
+    agent_url: str,
+    agent_name: str,
+    wait: bool = True,
+) -> Any:
+    """Submit the compiled KFP pipeline job to Vertex AI Pipelines.
+
+    Args:
+        project_id: The Google Cloud project ID.
+        location: The Vertex AI region (e.g. us-central1).
+        pipeline_yaml_path: Local path to the compiled pipeline.yaml file.
+        gcs_dest: GCS destination URI (gs://...) for final evaluation summaries.
+        dataset_gcs_path: GCS path to the input dataset.jsonl.
+        metrics_gcs_path: GCS path to the input metric_definitions.json.
+        agent_url: The remote agent endpoint URL.
+        agent_name: The name of the agent application.
+        wait: Whether to block and wait for pipeline completion.
+
+    Returns:
+        The Vertex AI PipelineJob resource object.
+    """
+    from google.cloud import aiplatform
+
+    aiplatform.init(project=project_id, location=location)
+
+    # Staging area for KFP intermediate artifacts
+    pipeline_root = f"{gcs_dest.rstrip('/')}/pipeline_root"
+
+    parameter_values = {
+        "dataset_gcs_path": dataset_gcs_path,
+        "metrics_gcs_path": metrics_gcs_path,
+        "agent_url": agent_url,
+        "agent_name": agent_name,
+        "gcs_dest": gcs_dest,
+        "location": location,
+    }
+
+    job = aiplatform.PipelineJob(
+        display_name="agent-eval-end-to-end-run",
+        template_path=str(pipeline_yaml_path),
+        pipeline_root=pipeline_root,
+        parameter_values=parameter_values,
+        enable_caching=False,
+    )
+
+    logger.info("Submitting PipelineJob to Vertex AI Pipelines...")
+    job.submit()
+    logger.info(f"PipelineJob submitted successfully! Job ID: {job.resource_name}")
+    logger.info(
+        f"Monitor the job at: https://console.cloud.google.com/vertex-ai/pipelines/locations/"
+        f"{location}/runs/{job.name}?project={project_id}"
+    )
+
+    if wait:
+        logger.info("Waiting for pipeline job completion...")
+        job.wait()
+        logger.info("Pipeline job execution complete!")
+
+    return job

--- a/tools/agent-eval/src/agent_eval/core/kfp_pipeline.py
+++ b/tools/agent-eval/src/agent_eval/core/kfp_pipeline.py
@@ -54,7 +54,13 @@ def simulate_component(
     blob.download_to_filename(local_dataset)
 
     # 2. Run Simulation
-    # For simulation, we need a dummy agent_dir to satisfy resolvers
+    # The 'agent-eval simulate' CLI command performs validation checks (see
+    # agent_eval/cli/commands/simulate.py) and strictly requires 'agent.py'
+    # to exist in the agent directory to verify a valid ADK agent context.
+    # Since we are running in an isolated container and only using the CLI
+    # to project/convert the dataset (not running the actual agent code yet),
+    # we create a temporary folder and touch a dummy 'agent.py' to satisfy
+    # this CLI validation check.
     temp_agent_dir = Path(tempfile.mkdtemp())
     (temp_agent_dir / "agent.py").touch()
 

--- a/tools/agent-eval/src/agent_eval/core/kfp_pipeline.py
+++ b/tools/agent-eval/src/agent_eval/core/kfp_pipeline.py
@@ -34,10 +34,14 @@ def simulate_component(
     prompts_gcs_output: dsl.OutputPath(str),
 ) -> None:
     """KFP component to run the User Simulator and generate prompts."""
+    import logging
     import tempfile
     from pathlib import Path
 
     from google.cloud import storage
+
+    logging.basicConfig(level=logging.INFO)
+    logger = logging.getLogger("simulate_component")
 
     # 1. Download dataset from GCS
     storage_client = storage.Client()
@@ -72,7 +76,7 @@ def simulate_component(
         str(local_output),
     ]
 
-    print(f"Running command: {' '.join(cmd)}")
+    logger.info(f"Running command: {' '.join(cmd)}")
     subprocess.run(cmd, check=True)
 
     # 3. Upload prompts to the KFP-managed output GCS path
@@ -99,11 +103,15 @@ def interact_component(
     interactions_gcs_output: dsl.OutputPath(str),
 ) -> None:
     """KFP component to drive the remote agent and record interactions."""
+    import logging
     import subprocess
     import tempfile
     from pathlib import Path
 
     from google.cloud import storage
+
+    logging.basicConfig(level=logging.INFO)
+    logger = logging.getLogger("interact_component")
 
     storage_client = storage.Client()
 
@@ -130,7 +138,7 @@ def interact_component(
         agent_name,
     ]
 
-    print(f"Running command: {' '.join(cmd)}")
+    logger.info(f"Running command: {' '.join(cmd)}")
     subprocess.run(cmd, check=True)
 
     # 3. Upload interactions to GCS
@@ -158,6 +166,7 @@ def evaluate_component(
     location: str = "us-central1",
 ) -> None:
     """KFP component to run evaluation metrics on the interactions."""
+    import logging
     import os
     import shutil
     import subprocess
@@ -165,6 +174,9 @@ def evaluate_component(
     from pathlib import Path
 
     from google.cloud import storage
+
+    logging.basicConfig(level=logging.INFO)
+    logger = logging.getLogger("evaluate_component")
 
     storage_client = storage.Client()
 
@@ -199,7 +211,7 @@ def evaluate_component(
         location,
     ]
 
-    print(f"Running command: {' '.join(cmd)}")
+    logger.info(f"Running command: {' '.join(cmd)}")
     subprocess.run(cmd, check=True)
 
     # 3. Upload summary and details to GCS

--- a/tools/agent-eval/src/agent_eval/sdk.py
+++ b/tools/agent-eval/src/agent_eval/sdk.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+import os
+import tempfile
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -97,8 +99,6 @@ async def run_evaluation(
     raw_dir.mkdir(parents=True, exist_ok=True)
 
     if pipeline:
-        import os
-
         if not gcs_dest:
             raise ValueError(
                 "gcs_dest must be provided when running on Vertex AI Pipelines (pipeline=True)."
@@ -146,8 +146,6 @@ async def run_evaluation(
         logger.info(f"Uploaded metrics to {metrics_gcs_path}")
 
         # B. Compile Pipeline locally
-        import tempfile
-
         temp_dir = Path(tempfile.mkdtemp())
         pipeline_yaml_path = temp_dir / "pipeline.yaml"
         compile_pipeline(output_path=pipeline_yaml_path, runner_image=runner_image)

--- a/tools/agent-eval/src/agent_eval/sdk.py
+++ b/tools/agent-eval/src/agent_eval/sdk.py
@@ -57,6 +57,7 @@ async def run_evaluation(
     run_analysis: bool = False,
     generate_html: bool = False,
     model: str = "gemini-3.1-pro-preview",
+    gcs_dest: str | None = None,
 ) -> EvaluationResult:
     """Run an evaluation in-process.
 
@@ -119,7 +120,11 @@ async def run_evaluation(
 
     # 4. Evaluate
     logger.info("Evaluating interactions...")
-    evaluator = Evaluator(location=location)
+    eval_config = {
+        "location": location,
+        "gcs_dest": gcs_dest,
+    }
+    evaluator = Evaluator(eval_config)
     await evaluator.evaluate(
         interaction_files=interaction_files,
         metrics_files=[metrics_path],
@@ -214,6 +219,7 @@ def run_evaluation_sync(
     run_analysis: bool = False,
     generate_html: bool = False,
     model: str = "gemini-3.1-pro-preview",
+    gcs_dest: str | None = None,
 ) -> EvaluationResult:
     """Synchronous wrapper for run_evaluation.
 
@@ -225,6 +231,7 @@ def run_evaluation_sync(
         run_analysis: Whether to run Gemini-based analysis on the results.
         generate_html: Whether to generate the HTML report.
         model: Model to use for analysis.
+        gcs_dest: Optional GCS destination URI for managed Vertex AI pipelines.
 
     Returns:
         EvaluationResult containing the metrics and pass/fail status.
@@ -238,5 +245,6 @@ def run_evaluation_sync(
             run_analysis=run_analysis,
             generate_html=generate_html,
             model=model,
+            gcs_dest=gcs_dest,
         )
     )

--- a/tools/agent-eval/src/agent_eval/sdk.py
+++ b/tools/agent-eval/src/agent_eval/sdk.py
@@ -23,12 +23,14 @@ from pathlib import Path
 from typing import Any
 
 import pandas as pd
+from google.cloud import storage
 from pydantic import BaseModel, ConfigDict, Field
 
 from agent_eval.core.analyzer import Analyzer
 from agent_eval.core.converters import write_jsonl
-from agent_eval.core.evaluator import Evaluator
+from agent_eval.core.evaluator import Evaluator, get_project_id
 from agent_eval.core.html_report import generate_html_report
+from agent_eval.core.kfp_pipeline import compile_pipeline, submit_pipeline_job
 from agent_eval.core.path_resolver import agent_project_root, find_eval_dir
 from agent_eval.core.schema import EvaluationSummary
 from agent_eval.core.simulation import run_simulation_in_process
@@ -58,8 +60,12 @@ async def run_evaluation(
     generate_html: bool = False,
     model: str = "gemini-3.1-pro-preview",
     gcs_dest: str | None = None,
+    pipeline: bool = False,
+    runner_image: str | None = None,
+    agent_url: str | None = None,
+    agent_name: str | None = None,
 ) -> EvaluationResult:
-    """Run an evaluation in-process.
+    """Run an evaluation (either locally in-process or on Vertex AI Pipelines).
 
     Args:
         agent_dir: Path to the agent project directory.
@@ -69,6 +75,11 @@ async def run_evaluation(
         run_analysis: Whether to run Gemini-based analysis on the results.
         generate_html: Whether to generate the HTML report.
         model: Model to use for analysis.
+        gcs_dest: Optional GCS destination URI for managed Vertex AI pipelines.
+        pipeline: Whether to orchestrate the entire flow on Vertex AI Pipelines.
+        runner_image: Docker image containing agent-eval for the KFP steps.
+        agent_url: The remote agent endpoint URL (required if pipeline=True).
+        agent_name: The name of the agent application (required if pipeline=True).
 
     Returns:
         EvaluationResult containing the metrics and pass/fail status.
@@ -85,51 +96,151 @@ async def run_evaluation(
     raw_dir = results_dir / "raw"
     raw_dir.mkdir(parents=True, exist_ok=True)
 
-    # 2. Run simulation in process
-    logger.info("Starting simulation...")
-    project_root = agent_project_root(agent_dir)
-    dataset_path = eval_dir / "dataset.jsonl"
-    try:
-        records = await run_simulation_in_process(
-            agent_dir=agent_dir,
-            project_root=project_root,
-            dataset_path=dataset_path,
+    if pipeline:
+        import os
+
+        if not gcs_dest:
+            raise ValueError(
+                "gcs_dest must be provided when running on Vertex AI Pipelines (pipeline=True)."
+            )
+        if not agent_url:
+            raise ValueError(
+                "agent_url must be provided when running on Vertex AI Pipelines (pipeline=True)."
+            )
+        if not agent_name:
+            raise ValueError(
+                "agent_name must be provided when running on Vertex AI Pipelines (pipeline=True)."
+            )
+        if not runner_image:
+            raise ValueError(
+                "runner_image must be provided when running on Vertex AI Pipelines (pipeline=True)."
+            )
+
+        # A. Staging local files to GCS
+        logger.info(
+            f"Staging evaluation dataset and metrics to GCS bucket: {gcs_dest}..."
         )
-    except Exception:
-        logger.exception("Simulation failed")
-        raise
+        storage_client = storage.Client()
 
-    if not records:
-        logger.warning("No interactions collected.")
-        return EvaluationResult(
-            passed=True,
-            failed_metrics=[],
-            metrics={},
-            summary={},
-            raw_results=pd.DataFrame(),
+        # Parse GCS destination
+        gcs_dest_clean = gcs_dest.rstrip("/")
+        bucket_name, blob_prefix = gcs_dest_clean.replace("gs://", "").split("/", 1)
+        bucket = storage_client.bucket(bucket_name)
+
+        # Upload dataset.jsonl
+        dataset_path = eval_dir / "dataset.jsonl"
+        if not dataset_path.exists():
+            raise FileNotFoundError(f"Evaluation dataset not found at {dataset_path}")
+        dataset_gcs_blob = f"{blob_prefix}/staging/dataset.jsonl"
+        dataset_gcs_path = f"gs://{bucket_name}/{dataset_gcs_blob}"
+        bucket.blob(dataset_gcs_blob).upload_from_filename(str(dataset_path))
+        logger.info(f"Uploaded dataset to {dataset_gcs_path}")
+
+        # Upload metric_definitions.json
+        metrics_path = eval_dir / "metrics" / "metric_definitions.json"
+        if not metrics_path.exists():
+            raise FileNotFoundError(f"Metric definitions not found at {metrics_path}")
+        metrics_gcs_blob = f"{blob_prefix}/staging/metric_definitions.json"
+        metrics_gcs_path = f"gs://{bucket_name}/{metrics_gcs_blob}"
+        bucket.blob(metrics_gcs_blob).upload_from_filename(str(metrics_path))
+        logger.info(f"Uploaded metrics to {metrics_gcs_path}")
+
+        # B. Compile Pipeline locally
+        import tempfile
+
+        temp_dir = Path(tempfile.mkdtemp())
+        pipeline_yaml_path = temp_dir / "pipeline.yaml"
+        compile_pipeline(output_path=pipeline_yaml_path, runner_image=runner_image)
+
+        # C. Submit and execute pipeline job on Vertex AI
+        project_id = get_project_id()
+        if not project_id:
+            raise ValueError("GOOGLE_CLOUD_PROJECT environment variable is not set.")
+
+        loc = location or "us-central1"
+
+        logger.info("Submitting pipeline run to Vertex AI...")
+        await asyncio.to_thread(
+            submit_pipeline_job,
+            project_id=project_id,
+            location=loc,
+            pipeline_yaml_path=pipeline_yaml_path,
+            gcs_dest=gcs_dest_clean,
+            dataset_gcs_path=dataset_gcs_path,
+            metrics_gcs_path=metrics_gcs_path,
+            agent_url=agent_url,
+            agent_name=agent_name,
+            wait=True,
         )
 
-    sim_output = raw_dir / "processed_interaction_sim.jsonl"
-    write_jsonl(records, str(sim_output))
-    interaction_files = [sim_output]
+        # Cleanup temp pipeline file
+        pipeline_yaml_path.unlink(missing_ok=True)
+        temp_dir.rmdir()
 
-    # 3. Verify metric definitions exist
-    metrics_path = eval_dir / "metrics" / "metric_definitions.json"
-    if not metrics_path.exists():
-        raise FileNotFoundError(f"Metric definitions not found at {metrics_path}")
+        # D. Download final results from GCS to local results_dir
+        logger.info("Pipeline run finished. Downloading evaluation summary...")
+        eval_summary_path = results_dir / "eval_summary.json"
 
-    # 4. Evaluate
-    logger.info("Evaluating interactions...")
-    eval_config = {
-        "location": location,
-        "gcs_dest": gcs_dest,
-    }
-    evaluator = Evaluator(eval_config)
-    await evaluator.evaluate(
-        interaction_files=interaction_files,
-        metrics_files=[metrics_path],
-        results_dir=results_dir,
-    )
+        summary_gcs_blob = f"{blob_prefix}/eval_summary.json"
+        bucket.blob(summary_gcs_blob).download_to_filename(str(eval_summary_path))
+        logger.info(f"Downloaded evaluation summary to {eval_summary_path}")
+
+        # Download raw CSV to local raw_dir so downstream code can load it
+        logger.info("Downloading raw evaluation CSV records...")
+        blobs = storage_client.list_blobs(bucket_name, prefix=f"{blob_prefix}/details/")
+        for blob in blobs:
+            if blob.name.endswith(".csv"):
+                local_csv_name = os.path.basename(blob.name)
+                local_csv_path = raw_dir / local_csv_name
+                blob.download_to_filename(str(local_csv_path))
+                logger.info(f"Downloaded raw CSV to {local_csv_path}")
+
+    else:
+        # 2. Run simulation in process
+        logger.info("Starting simulation...")
+        project_root = agent_project_root(agent_dir)
+        dataset_path = eval_dir / "dataset.jsonl"
+        try:
+            records = await run_simulation_in_process(
+                agent_dir=agent_dir,
+                project_root=project_root,
+                dataset_path=dataset_path,
+            )
+        except Exception:
+            logger.exception("Simulation failed")
+            raise
+
+        if not records:
+            logger.warning("No interactions collected.")
+            return EvaluationResult(
+                success=True,
+                failed_metrics=[],
+                metrics={},
+                summary={},
+                raw_results=pd.DataFrame(),
+            )
+
+        sim_output = raw_dir / "processed_interaction_sim.jsonl"
+        write_jsonl(records, str(sim_output))
+        interaction_files = [sim_output]
+
+        # 3. Verify metric definitions exist
+        metrics_path = eval_dir / "metrics" / "metric_definitions.json"
+        if not metrics_path.exists():
+            raise FileNotFoundError(f"Metric definitions not found at {metrics_path}")
+
+        # 4. Evaluate
+        logger.info("Evaluating interactions...")
+        eval_config = {
+            "location": location,
+            "gcs_dest": gcs_dest,
+        }
+        evaluator = Evaluator(eval_config)
+        await evaluator.evaluate(
+            interaction_files=interaction_files,
+            metrics_files=[metrics_path],
+            results_dir=results_dir,
+        )
 
     # Read the summary to get failed metrics from evaluator runtime
     eval_summary_path = results_dir / "eval_summary.json"
@@ -220,6 +331,10 @@ def run_evaluation_sync(
     generate_html: bool = False,
     model: str = "gemini-3.1-pro-preview",
     gcs_dest: str | None = None,
+    pipeline: bool = False,
+    runner_image: str | None = None,
+    agent_url: str | None = None,
+    agent_name: str | None = None,
 ) -> EvaluationResult:
     """Synchronous wrapper for run_evaluation.
 
@@ -232,6 +347,10 @@ def run_evaluation_sync(
         generate_html: Whether to generate the HTML report.
         model: Model to use for analysis.
         gcs_dest: Optional GCS destination URI for managed Vertex AI pipelines.
+        pipeline: Whether to orchestrate the entire flow on Vertex AI Pipelines.
+        runner_image: Docker image containing agent-eval for the KFP steps.
+        agent_url: The remote agent endpoint URL (required if pipeline=True).
+        agent_name: The name of the agent application (required if pipeline=True).
 
     Returns:
         EvaluationResult containing the metrics and pass/fail status.
@@ -246,5 +365,9 @@ def run_evaluation_sync(
             generate_html=generate_html,
             model=model,
             gcs_dest=gcs_dest,
+            pipeline=pipeline,
+            runner_image=runner_image,
+            agent_url=agent_url,
+            agent_name=agent_name,
         )
     )

--- a/tools/agent-eval/tests/core/test_kfp_pipeline.py
+++ b/tools/agent-eval/tests/core/test_kfp_pipeline.py
@@ -1,0 +1,61 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for KFP pipeline compilation."""
+
+import tempfile
+from pathlib import Path
+
+from agent_eval.core.kfp_pipeline import compile_pipeline
+
+
+def test_compile_pipeline_success():
+    """Verify that the KFP pipeline compiles successfully to a valid JSON file."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_file = Path(tmpdir) / "pipeline.yaml"
+        runner_image = "gcr.io/my-project/agent-eval:latest"
+
+        # Compile the pipeline
+        compile_pipeline(output_path=output_file, runner_image=runner_image)
+
+        # Assert file exists
+        assert output_file.exists()
+
+        # Load and verify YAML contents
+        import yaml
+
+        with output_file.open("r", encoding="utf-8") as f:
+            pipeline_spec = yaml.safe_load(f)
+
+        # Verify KFP pipeline schema version and name
+        assert "pipelineInfo" in pipeline_spec
+        assert pipeline_spec["pipelineInfo"]["name"] == "agent-eval-end-to-end"
+
+        # Verify components are defined in the schema
+        assert "deploymentSpec" in pipeline_spec
+        executors = pipeline_spec["deploymentSpec"]["executors"]
+
+        # We expect 3 executors (simulate, interact, evaluate)
+        assert len(executors) >= 3
+
+        # Verify that our runner_image was correctly baked into the container specs
+        # Executors in KFP v2 have container configurations
+        found_images = []
+        for exec_name, exec_val in executors.items():
+            container = exec_val.get("container", {})
+            if container:
+                found_images.append(container.get("image"))
+
+        assert len(found_images) == 3
+        for image in found_images:
+            assert image == runner_image

--- a/tools/agent-eval/tests/test_sdk.py
+++ b/tools/agent-eval/tests/test_sdk.py
@@ -87,6 +87,7 @@ async def test_sdk_run_evaluation_success(
             run_id="test_run",
         )
 
+        mock_evaluator.assert_called_once_with({"location": None, "gcs_dest": None})
         assert result.success is True
         assert result.failed_metrics == []
         assert result.metrics == {
@@ -149,6 +150,7 @@ async def test_sdk_run_evaluation_error_metric(
             run_id="test_run",
         )
 
+        mock_evaluator.assert_called_once_with({"location": None, "gcs_dest": None})
         assert result.success is False
         assert "broken_metric" in result.failed_metrics
 
@@ -171,6 +173,7 @@ def test_sdk_run_evaluation_sync(mock_run_eval):
         run_analysis=False,
         generate_html=False,
         model="gemini-3.1-pro-preview",
+        gcs_dest=None,
     )
     assert result == mock_result
 
@@ -233,6 +236,7 @@ async def test_sdk_run_evaluation_threshold_success(
             run_id="test_run",
         )
 
+        mock_evaluator.assert_called_once_with({"location": None, "gcs_dest": None})
         assert result.success is True
         assert result.failed_metrics == []
         assert result.threshold_failures == []
@@ -296,6 +300,7 @@ async def test_sdk_run_evaluation_threshold_failure(
             run_id="test_run",
         )
 
+        mock_evaluator.assert_called_once_with({"location": None, "gcs_dest": None})
         assert result.success is False
         assert result.failed_metrics == []
         assert result.threshold_failures == [

--- a/tools/agent-eval/tests/test_sdk.py
+++ b/tools/agent-eval/tests/test_sdk.py
@@ -174,6 +174,10 @@ def test_sdk_run_evaluation_sync(mock_run_eval):
         generate_html=False,
         model="gemini-3.1-pro-preview",
         gcs_dest=None,
+        pipeline=False,
+        runner_image=None,
+        agent_url=None,
+        agent_name=None,
     )
     assert result == mock_result
 
@@ -310,3 +314,98 @@ async def test_sdk_run_evaluation_threshold_failure(
                 "threshold": 0.8,
             }
         ]
+
+
+@pytest.mark.anyio
+@mock.patch("agent_eval.sdk.generate_html_report")
+@mock.patch("agent_eval.sdk.get_project_id")
+@mock.patch("agent_eval.sdk.submit_pipeline_job")
+@mock.patch("agent_eval.sdk.compile_pipeline")
+@mock.patch("agent_eval.sdk.storage.Client")
+async def test_sdk_run_evaluation_pipeline_success(
+    mock_storage_client,
+    mock_compile,
+    mock_submit,
+    mock_get_project_id,
+    mock_generate_html_report,
+):
+    # Setup mocks
+    mock_get_project_id.return_value = "test-project"
+
+    # Mock storage client structure
+    mock_client_inst = mock.MagicMock()
+    mock_storage_client.return_value = mock_client_inst
+    mock_bucket = mock.MagicMock()
+    mock_client_inst.bucket.return_value = mock_bucket
+    mock_blob = mock.MagicMock()
+    mock_bucket.blob.return_value = mock_blob
+
+    # Sinks a fake summary JSON on GCS download
+    def fake_download_to_filename(dest_path):
+        Path(dest_path).write_text(
+            json.dumps(
+                {
+                    "experiment_id": "test_run",
+                    "overall_summary": {
+                        "failed_metrics": [],
+                        "llm_based_metrics": {
+                            "trajectory_accuracy": {
+                                "average": 0.85,
+                                "threshold": 0.7,
+                            }
+                        },
+                    },
+                }
+            )
+        )
+
+    mock_blob.download_to_filename.side_effect = fake_download_to_filename
+
+    # Mock list_blobs to return no raw CSVs (empty details)
+    mock_client_inst.list_blobs.return_value = []
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        agent_dir = tmp_path / "my_agent"
+        agent_dir.mkdir()
+        (agent_dir / "agent.py").touch()
+
+        eval_dir = tmp_path / "tests" / "eval"
+        eval_dir.mkdir(parents=True)
+        (eval_dir / "dataset.jsonl").write_text("{}")
+
+        metrics_dir = eval_dir / "metrics"
+        metrics_dir.mkdir()
+        (metrics_dir / "metric_definitions.json").write_text("{}")
+
+        # Run SDK evaluation on pipeline
+        result = await run_evaluation(
+            agent_dir=agent_dir,
+            eval_dir=eval_dir,
+            run_id="test_run",
+            gcs_dest="gs://my-bucket/runs/run_01",
+            pipeline=True,
+            runner_image="gcr.io/my-project/agent-eval:latest",
+            agent_url="http://my-agent/run",
+            agent_name="my_agent_app",
+        )
+
+        # Assertions
+        assert result.success is True
+        assert result.failed_metrics == []
+        assert result.metrics == {"trajectory_accuracy": 0.85}
+        assert result.threshold_failures == []
+
+        # Verify pipeline helpers were called correctly
+        mock_compile.assert_called_once()
+        mock_submit.assert_called_once_with(
+            project_id="test-project",
+            location="us-central1",
+            pipeline_yaml_path=mock.ANY,
+            gcs_dest="gs://my-bucket/runs/run_01",
+            dataset_gcs_path="gs://my-bucket/runs/run_01/staging/dataset.jsonl",
+            metrics_gcs_path="gs://my-bucket/runs/run_01/staging/metric_definitions.json",
+            agent_url="http://my-agent/run",
+            agent_name="my_agent_app",
+            wait=True,
+        )

--- a/tools/agent-eval/uv.lock
+++ b/tools/agent-eval/uv.lock
@@ -28,6 +28,7 @@ dependencies = [
     { name = "google-adk", extra = ["eval"] },
     { name = "google-cloud-aiplatform", extra = ["agent-engines", "evaluation"] },
     { name = "google-cloud-bigquery" },
+    { name = "kfp" },
     { name = "pandas" },
     { name = "pydantic-settings" },
     { name = "questionary" },
@@ -57,6 +58,7 @@ requires-dist = [
     { name = "google-cloud-aiplatform", extras = ["evaluation", "agent-engines"], specifier = ">=1.132.0,<2.0.0" },
     { name = "google-cloud-bigquery", specifier = ">=3.25.0" },
     { name = "gradio", marker = "extra == 'dashboard'", specifier = ">=6.3.0" },
+    { name = "kfp", specifier = ">=2.7.0" },
     { name = "pandas", specifier = ">=2.0.0" },
     { name = "plotly", marker = "extra == 'dashboard'", specifier = ">=6.5.2" },
     { name = "pydantic-settings", specifier = ">=2.12.0" },
@@ -608,6 +610,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593, upload-time = "2024-12-21T18:38:44.339Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188, upload-time = "2024-12-21T18:38:41.666Z" },
+]
+
+[[package]]
+name = "click-option-group"
+version = "0.5.7"
+source = { registry = "https://pypi.org/simple/" }
+dependencies = [
+    { name = "click" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/9f/1f917934da4e07ae7715a982347e3c2179556d8a58d1108c5da3e8f09c76/click_option_group-0.5.7.tar.gz", hash = "sha256:8dc780be038712fc12c9fecb3db4fe49e0d0723f9c171d7cda85c20369be693c", size = 22110, upload-time = "2025-03-24T13:24:55.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/27/bf74dc1494625c3b14dbcdb93740defd7b8c58dae3736be8d264f2a643fb/click_option_group-0.5.7-py3-none-any.whl", hash = "sha256:96b9f52f397ef4d916f81929bd6c1f85e89046c7a401a64e72a61ae74ad35c24", size = 11483, upload-time = "2025-03-24T13:24:54.611Z" },
 ]
 
 [[package]]
@@ -1900,6 +1914,77 @@ wheels = [
 ]
 
 [[package]]
+name = "kfp"
+version = "2.16.1"
+source = { registry = "https://pypi.org/simple/" }
+dependencies = [
+    { name = "click" },
+    { name = "click-option-group" },
+    { name = "docstring-parser" },
+    { name = "google-api-core" },
+    { name = "google-auth" },
+    { name = "google-cloud-storage", version = "3.7.0", source = { registry = "https://pypi.org/simple/" }, marker = "python_full_version < '3.13'" },
+    { name = "google-cloud-storage", version = "3.11.0", source = { registry = "https://pypi.org/simple/" }, marker = "python_full_version >= '3.13'" },
+    { name = "kfp-pipeline-spec" },
+    { name = "kfp-server-api" },
+    { name = "kubernetes" },
+    { name = "protobuf" },
+    { name = "pyyaml" },
+    { name = "requests-toolbelt" },
+    { name = "tabulate" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/24/d8/4b72f7ffaf8918f629873766db81d444c7dd65a2c7342829b7b9df3d0cc3/kfp-2.16.1.tar.gz", hash = "sha256:67fffff19960bb4624836d1ee0a4449e6e326092646883f7d57e9d1cc402bce2", size = 317570, upload-time = "2026-05-05T13:47:52.389Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/64/c2393ab7410017cefd5fd5693811a77d7d55d5b02faf09a9e6402c4d187c/kfp-2.16.1-py3-none-any.whl", hash = "sha256:d90742de35d1fee871240ddf619b29f5c25103f522eddaf97d2b24cb2483d3ba", size = 421579, upload-time = "2026-05-05T13:47:50.588Z" },
+]
+
+[[package]]
+name = "kfp-pipeline-spec"
+version = "2.16.1"
+source = { registry = "https://pypi.org/simple/" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4f/8e/1844e0a11fefe77c86f6fc0d0ea463b338111d914515b930ff86be65a281/kfp_pipeline_spec-2.16.1.tar.gz", hash = "sha256:0b0719a828a48c2ff081e6cf6517531907231afadcfbbee0e6b2ea419bcbe634", size = 10573, upload-time = "2026-05-05T13:46:36.558Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/ca/7aab754c26e3cdb6dedc718bbb0d9d76600229bbc1cd008143db6fd62ec1/kfp_pipeline_spec-2.16.1-py3-none-any.whl", hash = "sha256:c6873c4362e8d227cd900e7e186ac9d2cdd2d492e9baa905d52d78452b7c2b65", size = 9866, upload-time = "2026-05-05T13:46:35.055Z" },
+]
+
+[[package]]
+name = "kfp-server-api"
+version = "2.16.1"
+source = { registry = "https://pypi.org/simple/" }
+dependencies = [
+    { name = "certifi" },
+    { name = "python-dateutil" },
+    { name = "six" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0c/c8/f96575c59dbbd5524f08b474f346b25390b18e56f94d3fee8ead90cbe817/kfp_server_api-2.16.1.tar.gz", hash = "sha256:19a80adcfe2d3666522ed164baeafe86a48ce25ee7fce9d93bb6457339120abd", size = 63847, upload-time = "2026-05-05T13:46:06.739Z" }
+
+[[package]]
+name = "kubernetes"
+version = "30.1.0"
+source = { registry = "https://pypi.org/simple/" }
+dependencies = [
+    { name = "certifi" },
+    { name = "google-auth" },
+    { name = "oauthlib" },
+    { name = "python-dateutil" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "requests-oauthlib" },
+    { name = "six" },
+    { name = "urllib3" },
+    { name = "websocket-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/82/3c/9f29f6cab7f35df8e54f019e5719465fa97b877be2454e99f989270b4f34/kubernetes-30.1.0.tar.gz", hash = "sha256:41e4c77af9f28e7a6c314e3bd06a8c6229ddd787cad684e0ab9f69b498e98ebc", size = 887810, upload-time = "2024-06-06T15:58:30.031Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/2027ddede72d33be2effc087580aeba07e733a7360780ae87226f1f91bd8/kubernetes-30.1.0-py2.py3-none-any.whl", hash = "sha256:e212e8b7579031dd2e512168b617373bc1e03888d41ac4e04039240a292d478d", size = 1706042, upload-time = "2024-06-06T15:58:27.13Z" },
+]
+
+[[package]]
 name = "litellm"
 version = "1.85.4"
 source = { registry = "https://pypi.org/simple/" }
@@ -2250,6 +2335,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/17/f4/09b2fa1b58f0fb4f7c7963a1649c64c4d315752240377ed74d9cd878f7b5/numpy-2.2.6-pp310-pypy310_pp73-macosx_14_0_x86_64.whl", hash = "sha256:7befc596a7dc9da8a337f79802ee8adb30a552a94f792b9c9d18c840055907db", size = 6786754, upload-time = "2025-05-17T21:44:47.446Z" },
     { url = "https://files.pythonhosted.org/packages/af/30/feba75f143bdc868a1cc3f44ccfa6c4b9ec522b36458e738cd00f67b573f/numpy-2.2.6-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ce47521a4754c8f4593837384bd3424880629f718d87c5d44f8ed763edd63543", size = 16643476, upload-time = "2025-05-17T21:45:11.871Z" },
     { url = "https://files.pythonhosted.org/packages/37/48/ac2a9584402fb6c0cd5b5d1a91dcf176b15760130dd386bbafdbfe3640bf/numpy-2.2.6-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:d042d24c90c41b54fd506da306759e06e568864df8ec17ccc17e9e884634fd00", size = 12812666, upload-time = "2025-05-17T21:45:31.426Z" },
+]
+
+[[package]]
+name = "oauthlib"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple/" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
 ]
 
 [[package]]
@@ -3371,6 +3465,31 @@ wheels = [
 ]
 
 [[package]]
+name = "requests-oauthlib"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple/" }
+dependencies = [
+    { name = "oauthlib" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
+]
+
+[[package]]
+name = "requests-toolbelt"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple/" }
+dependencies = [
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6", size = 206888, upload-time = "2023-05-01T04:11:33.229Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl", hash = "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06", size = 54481, upload-time = "2023-05-01T04:11:28.427Z" },
+]
+
+[[package]]
 name = "rich"
 version = "14.3.3"
 source = { registry = "https://pypi.org/simple/" }
@@ -4023,6 +4142,15 @@ source = { registry = "https://pypi.org/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/35/a2/8e3becb46433538a38726c948d3399905a4c7cabd0df578ede5dc51f0ec2/wcwidth-0.6.0.tar.gz", hash = "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159", size = 159684, upload-time = "2026-02-06T19:19:40.919Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl", hash = "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad", size = 94189, upload-time = "2026-02-06T19:19:39.646Z" },
+]
+
+[[package]]
+name = "websocket-client"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple/" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576, upload-time = "2025-10-07T21:16:36.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616, upload-time = "2025-10-07T21:16:34.951Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### **Summary**

This Pull Request introduces full end-to-end orchestration support for running `agent-eval` workflows (Simulation, Interaction, and Evaluation) as a serverless, managed **Vertex AI Pipeline (Kubeflow Pipelines / KFP)** on Google Cloud. 
Additionally, it patches a critical latent `TypeError` bug in the Python SDK's evaluator instantiation and makes the GCP region/location parameter fully configurable.

---

### **Key Changes**

#### **1. End-to-End Vertex AI Pipelines Orchestration (KFP)**

- **Pipeline Compiler (`kfp_pipeline.py`)**: Implemented a custom KFP compiler module that builds the evaluation DAG and compiles it into a modern, future-proof `.yaml` pipeline specification.
- **Robust GCS Staging Components**: Implemented three container-based KFP python components that transparently stage inputs/outputs to GCS, allowing the core `agent-eval` CLI to remain simple and local-path-based:
  - **`simulate_component`**: Downloads the evaluation dataset from GCS, runs `agent-eval simulate` inside the container, and uploads the prompts.
  - **`interact_component`**: Downloads prompts, drives your remote agent HTTP endpoint via `agent-eval interact`, and records traces.
  - **`evaluate_component`**: Downloads traces/metrics, triggers the managed Vertex GenAI Rapid Evaluation service (passing the predictable GCS destination), and uploads the final summaries.
- **Predictable Output Paths**: Added support for an `explicit_gcs_dest` parameter, ensuring the final `eval_summary.json` is written to a predictable GCS path, allowing the SDK to easily download and parse scores.
#### **2. Python SDK Enhancements & Critical Bugfix (`sdk.py`)**
- **Fixed Evaluator Instantiation Crash**: Resolved a severe latent bug where the SDK was instantiating the evaluator incorrectly (`Evaluator(location=location)` instead of passing a config dictionary), which would cause a runtime `TypeError` for real users.
- **Enabled Location Configuration**: Updated the `Evaluator` constructor in `evaluator.py` to dynamically read the GCP location from the config dictionary instead of ignoring it.
- **SDK Pipeline Orchestrator**: Added `pipeline`, `runner_image`, `agent_url`, and `agent_name` to the SDK signatures. When `pipeline=True`, the SDK stages files to GCS, compiles the KFP pipeline, submits the `PipelineJob` to Vertex AI, waits for completion, and downloads the results back locally.

---

### **Architectural Design (Remote Agent Staging)**

To avoid the heavy overhead of containerizing and uploading your local agent's code/databases to the cloud on every run, the pipeline uses a **Remote Agent Endpoint (Mode A)** architecture:
1. Your agent is deployed as an HTTP service (e.g., Cloud Run, Vertex Agent Engine).
2. The pipeline runs using a **generic, pre-built `agent-eval` runner container**.
3. During the interaction step, the pipeline container drives your agent by making standard HTTP requests to the provided `--agent-url`.
4. This ensures a **zero-setup execution**—no custom docker images need to be built by the user!

---

### **Usage Examples**

#### **Python SDK**

```python
from agent_eval.sdk import run_evaluation_sync
result = run_evaluation_sync(
    agent_dir=".",
    pipeline=True,  # <--- Triggers serverless KFP pipeline on GCP
    runner_image="gcr.io/your-project/agent-eval:latest",
    agent_url="https://my-deployed-agent.run.app",
    agent_name="my_agent_app",
    gcs_dest="gs://my-eval-bucket/runs/run_01",
    location="us-central1",
)
print(f"Success: {result.success}")
print(f"Metrics: {result.metrics}")
```
---

### **Verification & Testing**

- **New Compiler Unit Tests (`test_kfp_pipeline.py`)**: Added tests to verify the pipeline compiles successfully to KFP YAML with the correct component definitions and runner images.
- **New SDK Pipeline Unit Tests (`test_sdk.py`)**: Added tests to mock-verify the GCS staging, pipeline compilation, job submission, and result downloading.
- **Result**: **All 7 unit tests pass successfully (100% green).**