### PR TITLE
feat(agent-eval): add native ADK2 Workflow execution and case-level granular filtering

### DIFF
--- a/tools/agent-eval/src/agent_eval/core/agent_client.py
+++ b/tools/agent-eval/src/agent_eval/core/agent_client.py
@@ -19,13 +19,14 @@ import subprocess
 import time
 import uuid
 from abc import ABC, abstractmethod
-from datetime import datetime
 from typing import Any
 
 import requests
 from google.adk.agents.invocation_context import InvocationContext
+from google.adk.events.event import Event as AdkEvent
 from google.adk.sessions.in_memory_session_service import InMemorySessionService
-from google.adk.sessions.session import Session as AdkSession
+from google.genai.types import Content as AdkContent
+from google.genai.types import Part as AdkPart
 
 logger = logging.getLogger("agent_eval.agent_client")
 
@@ -647,15 +648,18 @@ class LocalAgentClient(BaseAgentClient):
         if not session:
             raise ValueError(f"Session {session_id} not found.")
 
-        # 1. Rebuild ADK session and context
-        adk_session = AdkSession(
-            id=session_id,
-            user_id=self.user_id,
+        # 1. Rebuild ADK session using the session service
+        session_service = InMemorySessionService()
+        adk_session = await session_service.create_session(
             app_name=self.app_name,
+            user_id=self.user_id,
+            session_id=session_id,
             state=session["state"],
         )
 
-        session_service = InMemorySessionService()
+        # Seed the session events history
+        adk_session.events = [AdkEvent.model_validate(e) for e in session["events"]]
+
         inv_context = InvocationContext(
             session_service=session_service,
             invocation_id=f"inv_{uuid.uuid4()}",
@@ -679,19 +683,44 @@ class LocalAgentClient(BaseAgentClient):
             res = self.agent_instance(inv_context)
             response_text = res.output or "" if hasattr(res, "output") else str(res)
 
-        # 3. Update session state and mock events
-        user_event = {
-            "author": "user",
-            "content": {"parts": [{"text": question}]},
-            "timestamp": datetime.now().isoformat(),
-        }
-        model_event = {
-            "author": self.app_name,
-            "content": {"parts": [{"text": response_text}]},
-            "timestamp": datetime.now().isoformat(),
-        }
+        # 3. Update session state and events, ensuring no duplicates
+        user_msg_appended = any(
+            getattr(event, "author", None) == "user"
+            and any(
+                getattr(part, "text", "") == question
+                for part in getattr(getattr(event, "content", None), "parts", [])
+                if hasattr(part, "text")
+            )
+            for event in adk_session.events
+        )
+        if not user_msg_appended:
+            user_event = AdkEvent(
+                author="user",
+                content=AdkContent(parts=[AdkPart(text=question)]),
+                timestamp=time.time(),
+            )
+            adk_session.events.append(user_event)
 
-        session["events"].extend([user_event, model_event])
+        model_res_appended = any(
+            getattr(event, "author", None) == self.app_name
+            and any(
+                getattr(part, "text", "") == response_text
+                for part in getattr(getattr(event, "content", None), "parts", [])
+                if hasattr(part, "text")
+            )
+            for event in adk_session.events
+        )
+        if not model_res_appended:
+            model_event = AdkEvent(
+                author=self.app_name,
+                content=AdkContent(parts=[AdkPart(text=response_text)]),
+                timestamp=time.time(),
+            )
+            adk_session.events.append(model_event)
+
+        session["events"] = [
+            event.model_dump(mode="json") for event in adk_session.events
+        ]
         session["state"] = adk_session.state
 
         return {

--- a/tools/agent-eval/src/agent_eval/core/agent_client.py
+++ b/tools/agent-eval/src/agent_eval/core/agent_client.py
@@ -23,6 +23,9 @@ from datetime import datetime
 from typing import Any
 
 import requests
+from google.adk.agents.invocation_context import InvocationContext
+from google.adk.sessions.in_memory_session_service import InMemorySessionService
+from google.adk.sessions.session import Session as AdkSession
 
 logger = logging.getLogger("agent_eval.agent_client")
 
@@ -644,9 +647,6 @@ class LocalAgentClient(BaseAgentClient):
         if not session:
             raise ValueError(f"Session {session_id} not found.")
 
-        from google.adk.agents.invocation_context import InvocationContext
-        from google.adk.sessions.session import Session as AdkSession
-
         # 1. Rebuild ADK session and context
         adk_session = AdkSession(
             id=session_id,
@@ -654,8 +654,6 @@ class LocalAgentClient(BaseAgentClient):
             app_name=self.app_name,
             state=session["state"],
         )
-
-        from google.adk.sessions.in_memory_session_service import InMemorySessionService
 
         session_service = InMemorySessionService()
         inv_context = InvocationContext(

--- a/tools/agent-eval/src/agent_eval/core/agent_client.py
+++ b/tools/agent-eval/src/agent_eval/core/agent_client.py
@@ -655,13 +655,11 @@ class LocalAgentClient(BaseAgentClient):
             state=session["state"],
         )
 
-        from unittest.mock import MagicMock
+        from google.adk.sessions.in_memory_session_service import InMemorySessionService
 
-        from google.adk.sessions.base_session_service import BaseSessionService
-
-        mock_session_service = MagicMock(spec=BaseSessionService)
+        session_service = InMemorySessionService()
         inv_context = InvocationContext(
-            session_service=mock_session_service,
+            session_service=session_service,
             invocation_id=f"inv_{uuid.uuid4()}",
             session=adk_session,
         )

--- a/tools/agent-eval/src/agent_eval/core/agent_client.py
+++ b/tools/agent-eval/src/agent_eval/core/agent_client.py
@@ -43,7 +43,7 @@ class BaseAgentClient(ABC):
         """Creates a new session for the agent."""
 
     @abstractmethod
-    def run_interaction(self, session_id: str, question: str) -> dict[str, Any]:
+    async def run_interaction(self, session_id: str, question: str) -> dict[str, Any]:
         """Sends a prompt turn to the agent and returns the response payload."""
 
     @abstractmethod
@@ -155,7 +155,7 @@ class AgentClient(BaseAgentClient):
         logger.debug("Session created successfully.")
         return session_id
 
-    def run_interaction(
+    async def run_interaction(
         self, session_id: str, question: str, streaming: bool = False
     ) -> dict[str, Any]:
         """
@@ -641,7 +641,7 @@ class LocalAgentClient(BaseAgentClient):
         }
         return session_id
 
-    async def _run_interaction_async(
+    async def run_interaction(
         self, session_id: str, question: str
     ) -> dict[str, Any]:
         session = self.sessions.get(session_id)
@@ -728,23 +728,6 @@ class LocalAgentClient(BaseAgentClient):
             "session_id": session_id,
             "state": adk_session.state,
         }
-
-    def run_interaction(self, session_id: str, question: str) -> dict[str, Any]:
-        """Synchronous wrapper around async interaction execution."""
-        import asyncio
-
-        try:
-            loop = asyncio.get_running_loop()
-        except RuntimeError:
-            loop = None
-
-        if loop and loop.is_running():
-            future = asyncio.run_coroutine_threadsafe(
-                self._run_interaction_async(session_id, question), loop
-            )
-            return future.result()
-        else:
-            return asyncio.run(self._run_interaction_async(session_id, question))
 
     def get_session_state(self, session_id: str) -> dict[str, Any]:
         session = self.sessions.get(session_id)

--- a/tools/agent-eval/src/agent_eval/core/agent_client.py
+++ b/tools/agent-eval/src/agent_eval/core/agent_client.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import asyncio
 import contextlib
 import json
 import logging
@@ -22,9 +23,12 @@ from abc import ABC, abstractmethod
 from typing import Any
 
 import requests
+from google.adk.agents.context import Context as AdkContext
 from google.adk.agents.invocation_context import InvocationContext
 from google.adk.events.event import Event as AdkEvent
 from google.adk.sessions.in_memory_session_service import InMemorySessionService
+from google.adk.workflow import BaseNode
+from google.adk.workflow._node_runner import NodeRunner
 from google.genai.types import Content as AdkContent
 from google.genai.types import Part as AdkPart
 
@@ -665,11 +669,19 @@ class LocalAgentClient(BaseAgentClient):
             invocation_id=f"inv_{uuid.uuid4()}",
             session=adk_session,
         )
+        inv_context._event_queue = asyncio.Queue()
 
         # 2. Run the agent in-process!
         response_text = ""
 
-        if hasattr(self.agent_instance, "run_async"):
+        if isinstance(self.agent_instance, BaseNode):
+            root_ctx = AdkContext(inv_context)
+            node_runner = NodeRunner(node=self.agent_instance, parent_ctx=root_ctx)
+            result_ctx = await node_runner.run(node_input=question)
+            if result_ctx.error:
+                raise result_ctx.error
+            response_text = result_ctx.output or ""
+        elif hasattr(self.agent_instance, "run_async"):
             async for event in self.agent_instance.run_async(inv_context):
                 if hasattr(event, "is_final_response") and event.is_final_response():
                     response_text = event.output or ""

--- a/tools/agent-eval/src/agent_eval/core/agent_client.py
+++ b/tools/agent-eval/src/agent_eval/core/agent_client.py
@@ -18,6 +18,8 @@ import re
 import subprocess
 import time
 import uuid
+from abc import ABC, abstractmethod
+from datetime import datetime
 from typing import Any
 
 import requests
@@ -25,7 +27,50 @@ import requests
 logger = logging.getLogger("agent_eval.agent_client")
 
 
-class AgentClient:
+class BaseAgentClient(ABC):
+    """Abstract Base Class defining the contract for Agent Clients."""
+
+    def __init__(self, app_name: str, user_id: str = "eval_user"):
+        self.app_name = app_name
+        self.user_id = user_id
+
+    @abstractmethod
+    def create_session(self, **session_data) -> str:
+        """Creates a new session for the agent."""
+
+    @abstractmethod
+    def run_interaction(self, session_id: str, question: str) -> dict[str, Any]:
+        """Sends a prompt turn to the agent and returns the response payload."""
+
+    @abstractmethod
+    def get_session_state(self, session_id: str) -> dict[str, Any]:
+        """Retrieves the final state of the session."""
+
+    @abstractmethod
+    def get_session_trace(self, session_id: str) -> dict[str, Any]:
+        """Retrieves the execution trace/telemetry of the session."""
+
+    @staticmethod
+    def get_final_payload_field(session_data: dict, field_name: str) -> Any:
+        """Extracts a field from the final JSON payload event."""
+        events = session_data.get("events", [])
+        for event in reversed(events):
+            content = event.get("content")
+            if not content or not isinstance(content, dict):
+                continue
+            parts = content.get("parts", [])
+            for part in parts:
+                text = part.get("text", "")
+                if text and "natural_language_response" in text:
+                    try:
+                        payload = json.loads(text)
+                        return payload.get(field_name)
+                    except (json.JSONDecodeError, TypeError):
+                        continue
+        return None
+
+
+class AgentClient(BaseAgentClient):
     """
     A client for interacting with the Agent service.
     Encapsulates session creation, message sending, state retrieval, and trace analysis.
@@ -47,9 +92,8 @@ class AgentClient:
             user_id: The user ID to associate with sessions.
             token: Optional gcloud identity token. If not provided, it will be fetched using gcloud.
         """
+        super().__init__(app_name, user_id)
         self.base_url = base_url.rstrip("/")
-        self.app_name = app_name
-        self.user_id = user_id
         self._token = token
 
     @property
@@ -572,21 +616,116 @@ class AgentClient:
 
         return trace
 
-    @staticmethod
-    def get_final_payload_field(session_data: dict, field_name: str) -> Any:
-        """Extracts a field from the final JSON payload event."""
-        events = session_data.get("events", [])
-        for event in reversed(events):
-            content = event.get("content")
-            if not content or not isinstance(content, dict):
-                continue
-            parts = content.get("parts", [])
-            for part in parts:
-                text = part.get("text", "")
-                if text and "natural_language_response" in text:
-                    try:
-                        payload = json.loads(text)
-                        return payload.get(field_name)
-                    except (json.JSONDecodeError, TypeError):
-                        continue
-        return None
+
+class LocalAgentClient(BaseAgentClient):
+    """An in-process, local client for interacting with an ADK agent/workflow instance.
+
+    Shares the same interface as AgentClient but executes calls in-process.
+    """
+
+    def __init__(self, agent_instance: Any, app_name: str, user_id: str = "eval_user"):
+        super().__init__(app_name, user_id)
+        self.agent_instance = agent_instance
+        self.base_url = "local://in-process"
+        self.sessions = {}
+
+    def create_session(self, **session_data) -> str:
+        session_id = f"local_session_{uuid.uuid4()}"
+        self.sessions[session_id] = {
+            "state": session_data.get("state") or {},
+            "events": [],
+        }
+        return session_id
+
+    async def _run_interaction_async(
+        self, session_id: str, question: str
+    ) -> dict[str, Any]:
+        session = self.sessions.get(session_id)
+        if not session:
+            raise ValueError(f"Session {session_id} not found.")
+
+        from google.adk.agents.invocation_context import InvocationContext
+        from google.adk.sessions.session import Session as AdkSession
+
+        # 1. Rebuild ADK session and context
+        adk_session = AdkSession(
+            id=session_id,
+            user_id=self.user_id,
+            app_name=self.app_name,
+            state=session["state"],
+        )
+
+        from unittest.mock import MagicMock
+
+        from google.adk.sessions.base_session_service import BaseSessionService
+
+        mock_session_service = MagicMock(spec=BaseSessionService)
+        inv_context = InvocationContext(
+            session_service=mock_session_service,
+            invocation_id=f"inv_{uuid.uuid4()}",
+            session=adk_session,
+        )
+
+        # 2. Run the agent in-process!
+        response_text = ""
+
+        if hasattr(self.agent_instance, "run_async"):
+            async for event in self.agent_instance.run_async(inv_context):
+                if hasattr(event, "is_final_response") and event.is_final_response():
+                    response_text = event.output or ""
+                    if not response_text and event.content:
+                        response_text = "".join(
+                            part.text
+                            for part in event.content.parts
+                            if hasattr(part, "text")
+                        )
+        else:
+            res = self.agent_instance(inv_context)
+            response_text = res.output or "" if hasattr(res, "output") else str(res)
+
+        # 3. Update session state and mock events
+        user_event = {
+            "author": "user",
+            "content": {"parts": [{"text": question}]},
+            "timestamp": datetime.now().isoformat(),
+        }
+        model_event = {
+            "author": self.app_name,
+            "content": {"parts": [{"text": response_text}]},
+            "timestamp": datetime.now().isoformat(),
+        }
+
+        session["events"].extend([user_event, model_event])
+        session["state"] = adk_session.state
+
+        return {
+            "response": response_text,
+            "session_id": session_id,
+            "state": adk_session.state,
+        }
+
+    def run_interaction(self, session_id: str, question: str) -> dict[str, Any]:
+        """Synchronous wrapper around async interaction execution."""
+        import asyncio
+
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+
+        if loop and loop.is_running():
+            future = asyncio.run_coroutine_threadsafe(
+                self._run_interaction_async(session_id, question), loop
+            )
+            return future.result()
+        else:
+            return asyncio.run(self._run_interaction_async(session_id, question))
+
+    def get_session_state(self, session_id: str) -> dict[str, Any]:
+        session = self.sessions.get(session_id)
+        if not session:
+            raise ValueError(f"Session {session_id} not found.")
+        return {"events": session["events"], "state": session["state"]}
+
+    def get_session_trace(self, session_id: str) -> dict[str, Any]:
+        return {"spans": []}

--- a/tools/agent-eval/src/agent_eval/core/interactions.py
+++ b/tools/agent-eval/src/agent_eval/core/interactions.py
@@ -21,7 +21,7 @@ from typing import Any
 
 import pandas as pd
 
-from agent_eval.core.agent_client import AgentClient
+from agent_eval.core.agent_client import AgentClient, LocalAgentClient
 
 logger = logging.getLogger("agent_eval.interactions")
 
@@ -256,8 +256,6 @@ class InteractionRunner:
         self.config = config
         self.user_ldap = config.get("user") or os.environ.get("USER") or "unknown"
         if agent_instance is not None:
-            from agent_eval.core.agent_client import LocalAgentClient
-
             self.agent_client = LocalAgentClient(
                 agent_instance=agent_instance,
                 app_name=config["app_name"],

--- a/tools/agent-eval/src/agent_eval/core/interactions.py
+++ b/tools/agent-eval/src/agent_eval/core/interactions.py
@@ -252,14 +252,23 @@ class InteractionRunner:
     Orchestrates the running of interactions for a set of questions.
     """
 
-    def __init__(self, config: dict[str, Any]):
+    def __init__(self, config: dict[str, Any], agent_instance: Any = None):
         self.config = config
         self.user_ldap = config.get("user") or os.environ.get("USER") or "unknown"
-        self.agent_client = AgentClient(
-            base_url=config["base_url"],
-            app_name=config["app_name"],
-            user_id=config.get("user_id", "eval_user"),
-        )
+        if agent_instance is not None:
+            from agent_eval.core.agent_client import LocalAgentClient
+
+            self.agent_client = LocalAgentClient(
+                agent_instance=agent_instance,
+                app_name=config["app_name"],
+                user_id=config.get("user_id", "eval_user"),
+            )
+        else:
+            self.agent_client = AgentClient(
+                base_url=config["base_url"],
+                app_name=config["app_name"],
+                user_id=config.get("user_id", "eval_user"),
+            )
 
     async def run(self) -> pd.DataFrame:
         questions_file = self.config["questions_file"]

--- a/tools/agent-eval/src/agent_eval/core/interactions.py
+++ b/tools/agent-eval/src/agent_eval/core/interactions.py
@@ -207,7 +207,7 @@ async def process_single_question(
 
         # Send all turns
         for turn in user_inputs:
-            await asyncio.to_thread(agent_client.run_interaction, session_id, turn)
+            await agent_client.run_interaction(session_id, turn)
 
         return {
             "status": json.dumps({"boolean": "success"}),

--- a/tools/agent-eval/src/agent_eval/core/simulation.py
+++ b/tools/agent-eval/src/agent_eval/core/simulation.py
@@ -203,6 +203,7 @@ async def run_simulation_in_process(
     parallelism: int = 4,
     run_mode: str = "all",
     case_id: str | None = None,
+    agent_instance: Any = None,
 ) -> list[dict[str, Any]]:
     """Runs the simulation in-process using ADK Python APIs and returns converted records."""
 
@@ -218,9 +219,12 @@ async def run_simulation_in_process(
     agents_dir = str(agent_dir.parent)
     agent_name = agent_dir.name
 
-    logger.info("Loading agent %s from %s", agent_name, agents_dir)
-    loader = AgentLoader(agents_dir=agents_dir)
-    agent_or_app = loader.load_agent(agent_name)
+    if agent_instance is not None:
+        agent_or_app = agent_instance
+    else:
+        logger.info("Loading agent %s from %s", agent_name, agents_dir)
+        loader = AgentLoader(agents_dir=agents_dir)
+        agent_or_app = loader.load_agent(agent_name)
 
     # Extract root agent
     from google.adk.apps.app import App
@@ -230,7 +234,7 @@ async def run_simulation_in_process(
         app_name = agent_or_app.name
     else:
         root_agent = agent_or_app
-        app_name = agent_name
+        app_name = agent_name or agent_or_app.__class__.__name__
 
     # 2. Load dataset
     rows = read_dataset(dataset_path)

--- a/tools/agent-eval/src/agent_eval/sdk.py
+++ b/tools/agent-eval/src/agent_eval/sdk.py
@@ -65,6 +65,7 @@ async def run_evaluation(
     runner_image: str | None = None,
     agent_url: str | None = None,
     agent_name: str | None = None,
+    agent_instance: Any = None,
 ) -> EvaluationResult:
     """Run an evaluation (either locally in-process or on Vertex AI Pipelines).
 
@@ -81,9 +82,7 @@ async def run_evaluation(
         runner_image: Docker image containing agent-eval for the KFP steps.
         agent_url: The remote agent endpoint URL (required if pipeline=True).
         agent_name: The name of the agent application (required if pipeline=True).
-
-    Returns:
-        EvaluationResult containing the metrics and pass/fail status.
+        agent_instance: Optional pre-instantiated, mocked agent instance to use in simulation.
     """
     agent_dir = Path(agent_dir).resolve()
     eval_dir = Path(eval_dir).resolve() if eval_dir else find_eval_dir(agent_dir)
@@ -204,6 +203,7 @@ async def run_evaluation(
                 agent_dir=agent_dir,
                 project_root=project_root,
                 dataset_path=dataset_path,
+                agent_instance=agent_instance,
             )
         except Exception:
             logger.exception("Simulation failed")

--- a/tools/agent-eval/src/agent_eval/sdk.py
+++ b/tools/agent-eval/src/agent_eval/sdk.py
@@ -67,6 +67,7 @@ async def run_evaluation(
     agent_name: str | None = None,
     agent_instance: Any = None,
     mode: str = "simulate",
+    case_id: str | None = None,
 ) -> EvaluationResult:
     """Run an evaluation (either locally in-process or on Vertex AI Pipelines).
 
@@ -234,6 +235,7 @@ async def run_evaluation(
                     project_root=project_root,
                     dataset_path=dataset_path,
                     agent_instance=agent_instance,
+                    case_id=case_id,
                 )
             except Exception:
                 logger.exception("Simulation failed")

--- a/tools/agent-eval/src/agent_eval/sdk.py
+++ b/tools/agent-eval/src/agent_eval/sdk.py
@@ -66,6 +66,7 @@ async def run_evaluation(
     agent_url: str | None = None,
     agent_name: str | None = None,
     agent_instance: Any = None,
+    mode: str = "simulate",
 ) -> EvaluationResult:
     """Run an evaluation (either locally in-process or on Vertex AI Pipelines).
 
@@ -83,6 +84,7 @@ async def run_evaluation(
         agent_url: The remote agent endpoint URL (required if pipeline=True).
         agent_name: The name of the agent application (required if pipeline=True).
         agent_instance: Optional pre-instantiated, mocked agent instance to use in simulation.
+        mode: The evaluation mode, either 'simulate' (default) or 'interact' (direct inference).
     """
     agent_dir = Path(agent_dir).resolve()
     eval_dir = Path(eval_dir).resolve() if eval_dir else find_eval_dir(agent_dir)
@@ -194,34 +196,62 @@ async def run_evaluation(
                 logger.info(f"Downloaded raw CSV to {local_csv_path}")
 
     else:
-        # 2. Run simulation in process
-        logger.info("Starting simulation...")
-        project_root = agent_project_root(agent_dir)
-        dataset_path = eval_dir / "dataset.jsonl"
-        try:
-            records = await run_simulation_in_process(
-                agent_dir=agent_dir,
-                project_root=project_root,
-                dataset_path=dataset_path,
-                agent_instance=agent_instance,
-            )
-        except Exception:
-            logger.exception("Simulation failed")
-            raise
+        # 2. Run simulation or interaction in process
+        if mode == "interact":
+            logger.info("Starting interaction (direct inference)...")
+            from agent_eval.core.interactions import InteractionRunner
 
-        if not records:
-            logger.warning("No interactions collected.")
-            return EvaluationResult(
-                success=True,
-                failed_metrics=[],
-                metrics={},
-                summary={},
-                raw_results=pd.DataFrame(),
-            )
+            runner_config = {
+                "questions_file": str(eval_dir / "dataset.jsonl"),
+                "app_name": agent_name or agent_dir.name,
+                "user_id": "eval_user",
+                "runs": 1,
+                "base_url": "local://in-process",
+            }
+            runner = InteractionRunner(runner_config, agent_instance=agent_instance)
+            results_df = await runner.run()
 
-        sim_output = raw_dir / "processed_interaction_sim.jsonl"
-        write_jsonl(records, str(sim_output))
-        interaction_files = [sim_output]
+            if results_df.empty:
+                logger.warning("No interactions collected.")
+                return EvaluationResult(
+                    success=True,
+                    failed_metrics=[],
+                    metrics={},
+                    summary={},
+                    raw_results=pd.DataFrame(),
+                )
+
+            interaction_output = raw_dir / f"evaluation_results_{run_id}.csv"
+            results_df.to_csv(interaction_output, index=False)
+            interaction_files = [interaction_output]
+        else:
+            logger.info("Starting simulation...")
+            project_root = agent_project_root(agent_dir)
+            dataset_path = eval_dir / "dataset.jsonl"
+            try:
+                records = await run_simulation_in_process(
+                    agent_dir=agent_dir,
+                    project_root=project_root,
+                    dataset_path=dataset_path,
+                    agent_instance=agent_instance,
+                )
+            except Exception:
+                logger.exception("Simulation failed")
+                raise
+
+            if not records:
+                logger.warning("No interactions collected.")
+                return EvaluationResult(
+                    success=True,
+                    failed_metrics=[],
+                    metrics={},
+                    summary={},
+                    raw_results=pd.DataFrame(),
+                )
+
+            sim_output = raw_dir / "processed_interaction_sim.jsonl"
+            write_jsonl(records, str(sim_output))
+            interaction_files = [sim_output]
 
         # 3. Verify metric definitions exist
         metrics_path = eval_dir / "metrics" / "metric_definitions.json"

--- a/tools/agent-eval/tests/cli/test_cli_integration.py
+++ b/tools/agent-eval/tests/cli/test_cli_integration.py
@@ -234,7 +234,7 @@ def test_run_pipeline_success(
             ],
             "final_session_state": {"events": []},
         }
-        with open(sim_output, "w") as f:
+        with sim_output.open("w") as f:
             f.write(json.dumps(mock_record) + "\n")
         return True
 
@@ -276,7 +276,7 @@ def test_run_pipeline_success(
                 "expected_concise": "hi",
             },
         }
-        with open(dataset_path, "w") as f:
+        with dataset_path.open("w") as f:
             f.write(json.dumps(dataset_row) + "\n")
 
         # Seed metric_definitions.json
@@ -305,7 +305,7 @@ def test_run_pipeline_success(
                 },
             }
         }
-        with open(metrics_path, "w") as f:
+        with metrics_path.open("w") as f:
             f.write(json.dumps(metrics_content, indent=2))
 
         # Mock env check to skip gcloud checks

--- a/tools/agent-eval/tests/core/test_interactions.py
+++ b/tools/agent-eval/tests/core/test_interactions.py
@@ -33,6 +33,7 @@ from agent_eval.core.interactions import (
 
 # ── 1. Helper Parsing Tests ──────────────────────────────────────────────────
 
+
 def test_parse_metadata_filters():
     assert parse_metadata_filters(None) == {}
     assert parse_metadata_filters([]) == {}
@@ -71,6 +72,7 @@ def test_parse_state_variables():
 
 
 # ── 2. Row Adapter Tests ─────────────────────────────────────────────────────
+
 
 def test_unified_row_to_question():
     # Case A: Nested reference data (canonical)
@@ -121,6 +123,7 @@ def test_unified_row_to_question():
 
 
 # ── 3. Golden Questions Loading Tests ────────────────────────────────────────
+
 
 def test_get_golden_questions_jsonl():
     # Seed a temp dataset.jsonl containing both single-turn and multi-turn rows
@@ -174,6 +177,7 @@ def test_get_golden_questions_file_not_found():
 
 # ── 4. Metadata Filtering Tests ──────────────────────────────────────────────
 
+
 def test_filter_questions_by_metadata():
     questions = [
         {"id": "q1", "metadata": {"category": "travel", "difficulty": "easy"}},
@@ -203,6 +207,7 @@ def test_filter_questions_by_metadata():
 
 
 # ── 5. Single Question Execution Tests ───────────────────────────────────────
+
 
 @pytest.mark.anyio
 async def test_process_single_question_success():
@@ -247,10 +252,12 @@ async def test_process_single_question_success():
     # Verify mock interactions were called
     mock_client.create_session.assert_called_once_with(debug="true")
     assert mock_client.run_interaction.call_count == 2
-    mock_client.run_interaction.assert_has_calls([
-        mock.call("session_abc", "hello turn 1"),
-        mock.call("session_abc", "hello turn 2"),
-    ])
+    mock_client.run_interaction.assert_has_calls(
+        [
+            mock.call("session_abc", "hello turn 1"),
+            mock.call("session_abc", "hello turn 2"),
+        ]
+    )
 
 
 @pytest.mark.anyio
@@ -284,6 +291,7 @@ async def test_process_single_question_failure():
 
 
 # ── 6. InteractionRunner Orchestrator Tests ──────────────────────────────────
+
 
 @pytest.mark.anyio
 @mock.patch("agent_eval.core.interactions.AgentClient")
@@ -327,13 +335,87 @@ async def test_interaction_runner_full_orchestration(mock_agent_client_class):
         assert list(df["session_id"]) == ["session_1", "session_1"]
 
         # Verify state variables were parsed and passed to session creation
-        mock_client.create_session.assert_has_calls([
-            mock.call(debug="true"),
-            mock.call(debug="true"),
-        ])
+        mock_client.create_session.assert_has_calls(
+            [
+                mock.call(debug="true"),
+                mock.call(debug="true"),
+            ]
+        )
 
         # Verify run_interaction was called for prompt 1 in both runs
-        mock_client.run_interaction.assert_has_calls([
-            mock.call("session_1", "prompt 1"),
-            mock.call("session_1", "prompt 1"),
-        ])
+        mock_client.run_interaction.assert_has_calls(
+            [
+                mock.call("session_1", "prompt 1"),
+                mock.call("session_1", "prompt 1"),
+            ]
+        )
+
+
+@pytest.mark.anyio
+async def test_interaction_runner_local_with_agent_instance():
+    # 1. Setup mock agent_instance with async run_async generator
+    mock_agent_instance = mock.MagicMock()
+
+    async def mock_run_async(inv_context):
+        # Yield a telemetry event and a final response event
+        mock_event_1 = mock.MagicMock()
+        mock_event_1.is_final_response.return_value = False
+        yield mock_event_1
+
+        mock_event_2 = mock.MagicMock()
+        mock_event_2.is_final_response.return_value = True
+        mock_event_2.output = "Hello, local user!"
+        yield mock_event_2
+
+    mock_agent_instance.run_async.side_effect = mock_run_async
+
+    # 2. Seed a temporary dataset file
+    dataset_row = {
+        "id": "q1",
+        "prompt": "prompt 1",
+        "kind": "single_turn",
+        "reference_data": {"expected_response": "Hello, local user!"},
+    }
+    with tempfile.TemporaryDirectory() as td:
+        dataset_path = Path(td) / "dataset.jsonl"
+        with dataset_path.open("w") as f:
+            f.write(json.dumps(dataset_row) + "\n")
+
+        config = {
+            "app_name": "my-agent",
+            "questions_file": str(dataset_path),
+            "base_url": "local://in-process",
+            "runs": 1,
+            "user": "sergiovidiella",
+        }
+
+        # 3. Instantiate InteractionRunner passing the agent_instance!
+        runner = InteractionRunner(config, agent_instance=mock_agent_instance)
+
+        # Verify it instantiated LocalAgentClient!
+        from agent_eval.core.agent_client import LocalAgentClient
+
+        assert isinstance(runner.agent_client, LocalAgentClient)
+
+        # 4. Run!
+        df = await runner.run()
+
+        # 5. Assertions
+        assert isinstance(df, pd.DataFrame)
+        assert len(df) == 1
+        assert df.iloc[0]["question_id"] == "q1"
+        assert df.iloc[0]["app_name"] == "my-agent"
+
+        session_id = df.iloc[0]["session_id"]
+        assert "local_session_" in session_id
+
+        # Verify response was stored in the session state events!
+        session_state = runner.agent_client.get_session_state(session_id)
+        assert len(session_state["events"]) == 2
+        assert (
+            session_state["events"][1]["content"]["parts"][0]["text"]
+            == "Hello, local user!"
+        )
+
+        # Verify run_async was called on our mock_agent_instance
+        mock_agent_instance.run_async.assert_called_once()

--- a/tools/agent-eval/tests/core/test_interactions.py
+++ b/tools/agent-eval/tests/core/test_interactions.py
@@ -224,6 +224,7 @@ async def test_process_single_question_success():
     mock_client.app_name = "my-agent"
     mock_client.user_id = "eval_user"
     mock_client.create_session.return_value = "session_abc"
+    mock_client.run_interaction = mock.AsyncMock()
 
     state_vars = {"debug": "true"}
 
@@ -299,6 +300,7 @@ async def test_interaction_runner_full_orchestration(mock_agent_client_class):
     mock_client = mock.MagicMock()
     mock_client.app_name = "my-agent"
     mock_client.create_session.return_value = "session_1"
+    mock_client.run_interaction = mock.AsyncMock()
     mock_agent_client_class.return_value = mock_client
 
     # Seed questions dataset

--- a/tools/agent-eval/tests/core/test_simulation.py
+++ b/tools/agent-eval/tests/core/test_simulation.py
@@ -331,6 +331,59 @@ class TestSimulationFlow(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(eval_cases), 1)
         self.assertEqual(eval_cases[0].eval_id, "case_1")
 
+    @patch("agent_eval.core.simulation.read_dataset")
+    @patch("agent_eval.core.simulation.AgentLoader")
+    @patch("agent_eval.core.simulation.PrePopulatingEvalService")
+    @patch("agent_eval.core.simulation.AdkHistoryConverter")
+    async def test_run_simulation_in_process_with_agent_instance(
+        self, mock_converter_cls, mock_service_cls, mock_loader_cls, mock_read_dataset
+    ):
+        # 1. Setup mocks
+        mock_read_dataset.return_value = [
+            {"id": "case_1", "prompt": "Hello", "kind": "single_turn"}
+        ]
+
+        mock_service = MagicMock()
+        async def mock_perform_inference(*args, **kwargs):
+            yield InferenceResult(
+                app_name="my_agent",
+                eval_set_id="eval_set",
+                eval_case_id="single_turn_case_1",
+                session_id="dummy_session",
+            )
+        async def mock_evaluate(*args, **kwargs):
+            yield MagicMock()
+        mock_service.perform_inference.side_effect = mock_perform_inference
+        mock_service.evaluate.side_effect = mock_evaluate
+        mock_service_cls.return_value = mock_service
+
+        mock_converter = MagicMock()
+        mock_converter.run.return_value = [{"converted": "record"}]
+        mock_converter_cls.return_value = mock_converter
+
+        # 2. Instantiate a mock agent instance
+        mock_agent_instance = MagicMock()
+
+        # 3. Run passing the agent_instance
+        records = await run_simulation_in_process(
+            agent_dir=self.agent_dir,
+            project_root=self.project_root,
+            dataset_path=self.dataset_path,
+            parallelism=2,
+            agent_instance=mock_agent_instance,
+        )
+
+        # 4. Assertions
+        # Verify AgentLoader was NEVER instantiated/called because agent_instance was passed!
+        mock_loader_cls.assert_not_called()
+
+        # Verify PrePopulatingEvalService was called with our mock_agent_instance directly as root_agent!
+        mock_service_cls.assert_called_once()
+        called_root_agent = mock_service_cls.call_args[1]["root_agent"]
+        self.assertEqual(called_root_agent, mock_agent_instance)
+
+        self.assertEqual(records, [{"converted": "record"}])
+
 
 class TestPrePopulatingSessionService(unittest.IsolatedAsyncioTestCase):
     async def test_pre_population(self):

--- a/tools/agent-eval/tests/core/test_simulation.py
+++ b/tools/agent-eval/tests/core/test_simulation.py
@@ -344,6 +344,7 @@ class TestSimulationFlow(unittest.IsolatedAsyncioTestCase):
         ]
 
         mock_service = MagicMock()
+
         async def mock_perform_inference(*args, **kwargs):
             yield InferenceResult(
                 app_name="my_agent",
@@ -351,8 +352,10 @@ class TestSimulationFlow(unittest.IsolatedAsyncioTestCase):
                 eval_case_id="single_turn_case_1",
                 session_id="dummy_session",
             )
+
         async def mock_evaluate(*args, **kwargs):
             yield MagicMock()
+
         mock_service.perform_inference.side_effect = mock_perform_inference
         mock_service.evaluate.side_effect = mock_evaluate
         mock_service_cls.return_value = mock_service

--- a/tools/agent-eval/tests/test_sdk.py
+++ b/tools/agent-eval/tests/test_sdk.py
@@ -680,3 +680,70 @@ async def test_sdk_run_evaluation_local_with_agent_instance(
             agent_instance=mock_agent_instance,  # 👈 Assert passed down!
         )
 
+
+@pytest.mark.anyio
+@mock.patch("agent_eval.sdk.Evaluator")
+@mock.patch("agent_eval.core.interactions.InteractionRunner")
+async def test_sdk_run_evaluation_local_interact_with_agent_instance(
+    mock_runner_class, mock_evaluator_class
+):
+    # Setup mocks
+    mock_runner = mock.MagicMock()
+    mock_runner.run = mock.AsyncMock()
+    # Return a dummy dataframe containing the interaction results
+    mock_runner.run.return_value = pd.DataFrame(
+        [{"status": "success", "question_id": "q1", "response": "hello"}]
+    )
+    mock_runner_class.return_value = mock_runner
+
+    mock_evaluator = mock.MagicMock()
+    mock_evaluator.evaluate = mock.AsyncMock()
+    mock_evaluator_class.return_value = mock_evaluator
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        agent_dir = tmp_path / "my_agent"
+        agent_dir.mkdir()
+        (agent_dir / "agent.py").touch()
+
+        eval_dir = tmp_path / "tests" / "eval"
+        eval_dir.mkdir(parents=True)
+        (eval_dir / "dataset.jsonl").write_text("{}")
+        metrics_dir = eval_dir / "metrics"
+        metrics_dir.mkdir()
+        (metrics_dir / "metric_definitions.json").write_text("{}")
+
+        # Seed a dummy eval_summary.json to satisfy SDK loading
+        results_dir = eval_dir / "results" / "test_run"
+        results_dir.mkdir(parents=True)
+        (results_dir / "eval_summary.json").write_text(
+            '{"overall_summary": {"llm_based_metrics": {}, "failed_metrics": []}}'
+        )
+
+        mock_agent_instance = mock.MagicMock()
+
+        # Run SDK evaluation in local mode, passing the agent_instance and mode="interact"!
+        await run_evaluation(
+            agent_dir=agent_dir,
+            eval_dir=eval_dir,
+            run_id="test_run",
+            pipeline=False,
+            agent_instance=mock_agent_instance,
+            mode="interact",  # 👈 Pass mode!
+        )
+
+        # Verify that InteractionRunner was instantiated with the agent_instance!
+        mock_runner_class.assert_called_once_with(
+            mock.ANY,
+            agent_instance=mock_agent_instance,  # 👈 Assert passed down!
+        )
+
+        # Verify that InteractionRunner.run was awaited!
+        mock_runner.run.assert_called_once()
+
+        # Verify that the returned DataFrame was saved as a CSV in raw_dir!
+        expected_csv_path = results_dir / "raw" / "evaluation_results_test_run.csv"
+        assert expected_csv_path.exists()
+        saved_df = pd.read_csv(expected_csv_path)
+        assert len(saved_df) == 1
+        assert saved_df.iloc[0]["question_id"] == "q1"

--- a/tools/agent-eval/tests/test_sdk.py
+++ b/tools/agent-eval/tests/test_sdk.py
@@ -626,3 +626,57 @@ async def test_sdk_run_evaluation_pipeline_downloads_csv_files(
         mock_csv_blob_2.download_to_filename.assert_called_once_with(
             str(expected_local_csv_2)
         )
+
+
+@pytest.mark.anyio
+@mock.patch("agent_eval.sdk.Evaluator")
+@mock.patch("agent_eval.sdk.run_simulation_in_process")
+async def test_sdk_run_evaluation_local_with_agent_instance(
+    mock_run_sim, mock_evaluator_class
+):
+    # Setup mocks
+    mock_run_sim.return_value = [{"converted": "record"}]
+
+    mock_evaluator = mock.MagicMock()
+    mock_evaluator.evaluate = mock.AsyncMock()
+    mock_evaluator_class.return_value = mock_evaluator
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        agent_dir = tmp_path / "my_agent"
+        agent_dir.mkdir()
+        (agent_dir / "agent.py").touch()
+
+        eval_dir = tmp_path / "tests" / "eval"
+        eval_dir.mkdir(parents=True)
+        (eval_dir / "dataset.jsonl").write_text("{}")
+        metrics_dir = eval_dir / "metrics"
+        metrics_dir.mkdir()
+        (metrics_dir / "metric_definitions.json").write_text("{}")
+
+        # Seed a dummy eval_summary.json to satisfy SDK loading
+        results_dir = eval_dir / "results" / "test_run"
+        results_dir.mkdir(parents=True)
+        (results_dir / "eval_summary.json").write_text(
+            '{"overall_summary": {"llm_based_metrics": {}, "failed_metrics": []}}'
+        )
+
+        mock_agent_instance = mock.MagicMock()
+
+        # Run SDK evaluation in local mode, passing the agent_instance
+        await run_evaluation(
+            agent_dir=agent_dir,
+            eval_dir=eval_dir,
+            run_id="test_run",
+            pipeline=False,
+            agent_instance=mock_agent_instance,  # 👈 Pass the agent_instance!
+        )
+
+        # Verify that run_simulation_in_process was called with the agent_instance!
+        mock_run_sim.assert_called_once_with(
+            agent_dir=mock.ANY,
+            project_root=mock.ANY,
+            dataset_path=mock.ANY,
+            agent_instance=mock_agent_instance,  # 👈 Assert passed down!
+        )
+


### PR DESCRIPTION
### 🚀 Summary
This PR upgrades the core `agent-eval` tool to natively support modern ADK2 `BaseNode` / `Workflow` agent instances and introduces granular `case_id` filtering for running specific simulation scenarios in isolation.

These features make `agent-eval` significantly more flexible, allowing it to evaluate complex multi-agent graphs and workflows while enabling high-performance parallelized test execution.

---

### 🛠️ Key Changes

1. **Native ADK2 BaseNode/Workflow Support** (`tools/agent-eval/src/agent_eval/core/agent_client.py`):
   * Enhanced `LocalAgentClient` to detect if the provided `agent_instance` is a `BaseNode` (ADK2 root workflow node).
   * Implemented in-process execution driving using ADK's `NodeRunner`, recursively driving the node and capturing its output. This bypasses the old requirement to implement a custom ADK1 `run_async` wrapper, enabling direct pair-programming and evaluation on modern graphs.

2. **Isolated Case Filtering (`case_id`)** (`tools/agent-eval/src/agent_eval/sdk.py`):
   * Added an optional `case_id` parameter to the main `run_evaluation` entry point.
   * Passed `case_id` down to `run_simulation_in_process` to filter the simulation dataset down to a single scenario.
   * *Impact*: This allows developers to run specific evaluation scenarios in isolation (crucial for local debugging) and enables parallel test running (e.g., using `pytest -n X` where each worker runs a single scenario) without state collision or double runs.
