### PR TITLE
fix( agent-eval cli): restrict load_dotenv to local .env to prevent parent folder…

### DIFF
--- a/tools/agent-eval/src/agent_eval/cli/commands/init.py
+++ b/tools/agent-eval/src/agent_eval/cli/commands/init.py
@@ -811,7 +811,7 @@ def _verify_environment(auto_approve: bool = False) -> None:
         _check_api_enabled as _setup_check_api,
     )
 
-    load_dotenv(override=True)
+    load_dotenv(dotenv_path=".env", override=True)
 
     console.print()
     console.print(

--- a/tools/agent-eval/src/agent_eval/cli/commands/setup.py
+++ b/tools/agent-eval/src/agent_eval/cli/commands/setup.py
@@ -573,7 +573,7 @@ def _step_2_project(auto_approve: bool) -> tuple[str | None, str | None]:
     """
     from dotenv import load_dotenv
 
-    load_dotenv(override=True)
+    load_dotenv(dotenv_path=".env", override=True)
 
     _step(
         2,

--- a/tools/agent-eval/tests/core/test_config.py
+++ b/tools/agent-eval/tests/core/test_config.py
@@ -16,7 +16,16 @@
 import os
 from unittest import mock
 
+import pytest
+
 from agent_eval.core.config import EvalConfig, get_location, get_project_id
+
+
+@pytest.fixture(autouse=True)
+def isolate_from_env_file():
+    """Prevent tests from loading local .env file."""
+    with mock.patch.dict(EvalConfig.model_config, {"env_file": None}):
+        yield
 
 
 def test_eval_config_defaults():

--- a/tools/agent-eval/tests/test_sdk.py
+++ b/tools/agent-eval/tests/test_sdk.py
@@ -678,6 +678,8 @@ async def test_sdk_run_evaluation_local_with_agent_instance(
             project_root=mock.ANY,
             dataset_path=mock.ANY,
             agent_instance=mock_agent_instance,  # 👈 Assert passed down!
+            case_id=None,
+            replications=1,
         )
 
 


### PR DESCRIPTION
## Description
This PR resolves an issue in `agent-eval setup` and `agent-eval init` where the active Google Cloud project ID was silently overridden by a parent directory's `.env` file.

### Root Cause
By default, calling `dotenv.load_dotenv(override=True)` without an explicit path searches recursively upwards
  through parent directories. If any parent directory contains a `.env` file (e.g., in nested developer workspace
  structures), those variables are loaded and silently override shell environment variables or local `gcloud`
  configuration defaults.

### Changes
- **CLI Fix**: Updated `load_dotenv` calls in `src/agent_eval/cli/commands/setup.py` and
  `src/agent_eval/cli/commands/init.py` to specify `dotenv_path=".env"`. This restricts the search scope strictly to
  the local directory's `.env` file.
- **Test Isolation**: Added an autouse pytest fixture to `tests/core/test_config.py` to patch `EvalConfig.
  model_config` with `env_file=None` so unit tests are completely isolated from local `.env` files.
- **SDK Test Alignment**: Updated `tests/test_sdk.py` mock assertions to include default parameters
  `case_id=None` and `replications=1`.